### PR TITLE
chore(db): add ON DELETE CASCADE to foreign keys & add memo count & f…

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -53,7 +53,7 @@ Chrome拡張機能として動作し、現在開いているURLやドメイン�
 
 ### `sitecue_notes`
 
-- メモのメインテーブル。`user_id` (Auth), `content` などを保持。
+- メモのメインテーブル。`user_id` (Auth, **ON DELETE CASCADE**), `content` などを保持。
 - `scope`: `'domain'` | `'exact'` (Check Constraint)
 - `note_type`: `'info'` | `'alert'` | `'idea'` (Check Constraint, Default: 'info')
 - `is_resolved`: `boolean` (Default: `false`)
@@ -71,7 +71,7 @@ Chrome拡張機能として動作し、現在開いているURLやドメイン�
 ### `sitecue_profiles`
 
 - ユーザーのプランと利用制限を管理するテーブル。
-- `id`: uuid (FK to `auth.users.id`) - RLS必須
+- `id`: uuid (FK to `auth.users.id`, **ON DELETE CASCADE**) - RLS必須
 - `plan`: `'free'` | `'pro'` (Default: `'free'`)
 - **Access Control & Triggers**:
   - `handle_new_user`: 新規ユーザー登録時に自動で `free` プランのレコードを作成する。

--- a/extension/src/SidePanel.tsx
+++ b/extension/src/SidePanel.tsx
@@ -268,6 +268,7 @@ function NotesUI({
   // 📊 プランと制限管理
   const [userPlan, setUserPlan] = useState<"free" | "pro">("free");
   const [totalNoteCount, setTotalNoteCount] = useState<number>(0);
+  const [userStatsLoading, setUserStatsLoading] = useState(true);
 
   useEffect(() => {
     const fetchUserStats = async () => {
@@ -295,7 +296,7 @@ function NotesUI({
       }
     };
 
-    fetchUserStats();
+    fetchUserStats().finally(() => setUserStatsLoading(false));
   }, [session]);
 
   // ✅ 安全なURL取得 (修正済み)
@@ -798,8 +799,8 @@ function NotesUI({
               {/* Content */}
               <div
                 className={`text-sm pr-8 mb-2 ${note.is_resolved
-                    ? "line-through text-neutral-500"
-                    : "text-neutral-800"
+                  ? "line-through text-neutral-500"
+                  : "text-neutral-800"
                   }`}
               >
                 <MarkdownRenderer content={note.content} />
@@ -956,103 +957,120 @@ function NotesUI({
       </div>
 
       <div className="p-4 bg-white border-t border-gray-200 space-y-3">
-        {/* スコープ選択 */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4 text-xs">
-            <label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover:text-black">
-              <input
-                type="radio"
-                name="scope"
-                checked={selectedScope === "domain"}
-                onChange={() => setSelectedScope("domain")}
-                className="accent-neutral-800 focus:ring-neutral-800"
-              />
-              <span>Domain</span>
-            </label>
-            <label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover:text-black">
-              <input
-                type="radio"
-                name="scope"
-                checked={selectedScope === "exact"}
-                onChange={() => setSelectedScope("exact")}
-                className="accent-neutral-800 focus:ring-neutral-800"
-              />
-              <span>This Page</span>
-            </label>
+        {userStatsLoading ? (
+          <div className="flex items-center justify-center py-4">
+            <Loader2 className="w-5 h-5 animate-spin text-gray-300" />
           </div>
+        ) : (
+          <>
+            {/* スコープ選択 */}
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4 text-xs">
+                <label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover:text-black">
+                  <input
+                    type="radio"
+                    name="scope"
+                    checked={selectedScope === "domain"}
+                    onChange={() => setSelectedScope("domain")}
+                    className="accent-neutral-800 focus:ring-neutral-800"
+                  />
+                  <span>Domain</span>
+                </label>
+                <label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover:text-black">
+                  <input
+                    type="radio"
+                    name="scope"
+                    checked={selectedScope === "exact"}
+                    onChange={() => setSelectedScope("exact")}
+                    className="accent-neutral-800 focus:ring-neutral-800"
+                  />
+                  <span>This Page</span>
+                </label>
+              </div>
 
-          {/* Note Type Selection */}
-          <div className="flex bg-white p-0.5 rounded-md">
-            <button
-              type="button"
-              onClick={() => setSelectedType("info")}
-              className={`cursor-pointer p-1 rounded ${selectedType === "info" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
-              title="Info"
-            >
-              <Info className="w-4 h-4" strokeWidth={2} />
-            </button>
-            <button
-              type="button"
-              onClick={() => setSelectedType("alert")}
-              className={`cursor-pointer p-1 rounded ${selectedType === "alert" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
-              title="Alert"
-            >
-              <AlertTriangle className="w-4 h-4" strokeWidth={2} />
-            </button>
-            <button
-              type="button"
-              onClick={() => setSelectedType("idea")}
-              className={`cursor-pointer p-1 rounded ${selectedType === "idea" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
-              title="Idea"
-            >
-              <Lightbulb className="w-4 h-4" strokeWidth={2} />
-            </button>
-          </div>
-        </div>
+              <div className="flex items-center gap-3">
+                {/* Note Count (Only for Free Plan) */}
+                {userPlan === "free" && (
+                  <span className="text-[10px] text-gray-400 font-medium">
+                    {totalNoteCount} / {MAX_FREE_NOTES}
+                  </span>
+                )}
 
-        <form onSubmit={handleSubmit} className="flex gap-2 items-center">
-          {userPlan === "free" && totalNoteCount >= MAX_FREE_NOTES ? (
-            <div className="w-full bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800 flex items-start gap-3">
-              <AlertTriangle className="w-5 h-5 shrink-0 mt-0.5" />
-              <div>
-                <div className="font-bold mb-1">FREE Plan Limit Reached</div>
-                <p className="text-xs opacity-90">
-                  You have reached the {MAX_FREE_NOTES} note limit. Please delete some
-                  existing notes to create new ones.
-                </p>
+                {/* Note Type Selection */}
+                <div className="flex bg-white p-0.5 rounded-md">
+                  <button
+                    type="button"
+                    onClick={() => setSelectedType("info")}
+                    className={`cursor-pointer p-1 rounded ${selectedType === "info" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
+                    title="Info"
+                  >
+                    <Info className="w-4 h-4" strokeWidth={2} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedType("alert")}
+                    className={`cursor-pointer p-1 rounded ${selectedType === "alert" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
+                    title="Alert"
+                  >
+                    <AlertTriangle className="w-4 h-4" strokeWidth={2} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedType("idea")}
+                    className={`cursor-pointer p-1 rounded ${selectedType === "idea" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
+                    title="Idea"
+                  >
+                    <Lightbulb className="w-4 h-4" strokeWidth={2} />
+                  </button>
+                </div>
               </div>
             </div>
-          ) : (
-            <>
-              <TextareaAutosize
-                ref={textareaRef}
-                value={newNote}
-                onChange={(e) => setNewNote(e.target.value)}
-                placeholder={`Add a cue to ${selectedScope === "domain" ? "this domain" : "this page"}...`}
-                className="flex-1 resize-none border-4 border-neutral-800 rounded-md p-2 text-sm focus:outline-none focus:ring-2 focus:ring-black/5 max-h-50"
-                minRows={1}
-                onKeyDown={(e) => {
-                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                    e.preventDefault();
-                    handleSubmit(e);
-                  }
-                }}
-              />
-              <button
-                disabled={submitting || !newNote.trim()}
-                type="submit"
-                className="cursor-pointer bg-neutral-800 text-white p-2 rounded-md hover:bg-neutral-500 disabled:cursor-not-allowed transition-colors"
-                title="Add Note"
-              >
-                {submitting ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
-                  <Send className="w-4 h-4" />
-                )}
-              </button>
-            </>
-          )}
-        </form>
+
+            <form onSubmit={handleSubmit} className="flex gap-2 items-center">
+              {userPlan === "free" && totalNoteCount >= MAX_FREE_NOTES ? (
+                <div className="w-full bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800 flex items-start gap-3">
+                  <AlertTriangle className="w-5 h-5 shrink-0 mt-0.5" />
+                  <div>
+                    <div className="font-bold mb-1">FREE Plan Limit Reached</div>
+                    <p className="text-xs opacity-90">
+                      You have reached the {MAX_FREE_NOTES} note limit. Please delete some
+                      existing notes to create new ones.
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <TextareaAutosize
+                    ref={textareaRef}
+                    value={newNote}
+                    onChange={(e) => setNewNote(e.target.value)}
+                    placeholder={`Add a cue to ${selectedScope === "domain" ? "this domain" : "this page"}...`}
+                    className="flex-1 resize-none border-4 border-neutral-800 rounded-md p-2 text-sm focus:outline-none focus:ring-2 focus:ring-black/5 max-h-50"
+                    minRows={1}
+                    onKeyDown={(e) => {
+                      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                        e.preventDefault();
+                        handleSubmit(e);
+                      }
+                    }}
+                  />
+                  <button
+                    disabled={submitting || !newNote.trim()}
+                    type="submit"
+                    className="cursor-pointer bg-neutral-800 text-white p-2 rounded-md hover:bg-neutral-500 disabled:cursor-not-allowed transition-colors"
+                    title="Add Note"
+                  >
+                    {submitting ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Send className="w-4 h-4" />
+                    )}
+                  </button>
+                </>
+              )}
+            </form>
+          </>
+        )}
       </div>
     </div>
   );

--- a/sitecue-project_20260219-2133.txt
+++ b/sitecue-project_20260219-2133.txt
@@ -105,8 +105,11 @@ supabase/
     20260209163000_add_is_pinned_to_notes.sql
     20260209174000_add_is_favorite_to_notes.sql
     20260218100000_create_profiles_and_limits.sql
+    20260219203527_add_cascade_delete_notes.sql
   snippets/
     Untitled query 254.sql
+    Untitled query 463.sql
+    Untitled query 836.sql
   tests/
     rls_test.sql
   .gitignore
@@ -151,6 +154,48 @@ schema.sql
 
 <files>
 This section contains the contents of the repository's files.
+
+<file path="supabase/migrations/20260219203527_add_cascade_delete_notes.sql">
+-- Migration to add ON DELETE CASCADE to sitecue_notes.user_id foreign key
+
+-- Drop the existing constraint (assuming default name sitecue_notes_user_id_fkey)
+ALTER TABLE sitecue_notes
+DROP CONSTRAINT IF EXISTS sitecue_notes_user_id_fkey;
+
+-- Re-add the constraint with ON DELETE CASCADE
+ALTER TABLE sitecue_notes
+ADD CONSTRAINT sitecue_notes_user_id_fkey
+FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+</file>
+
+<file path="supabase/snippets/Untitled query 463.sql">
+SELECT
+    conname AS constraint_name,
+    pg_get_constraintdef(oid) AS constraint_definition
+FROM pg_constraint
+WHERE conrelid = 'public.sitecue_notes'::regclass;
+</file>
+
+<file path="supabase/snippets/Untitled query 836.sql">
+SELECT
+    tc.constraint_name,
+    kcu.column_name,
+    ccu.table_name AS foreign_table_name,
+    ccu.column_name AS foreign_column_name,
+    rc.delete_rule
+FROM
+    information_schema.table_constraints AS tc
+    JOIN information_schema.key_column_usage AS kcu
+      ON tc.constraint_name = kcu.constraint_name
+      AND tc.table_schema = kcu.table_schema
+    JOIN information_schema.constraint_column_usage AS ccu
+      ON ccu.constraint_name = tc.constraint_name
+      AND ccu.table_schema = tc.table_schema
+    JOIN information_schema.referential_constraints AS rc
+      ON tc.constraint_name = rc.constraint_name
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_name = 'sitecue_notes';
+</file>
 
 <file path="api/.dev.vars.example">
 # ローカル開発用の設定 (Supabase Local)
@@ -15279,7 +15324,7 @@ Chrome拡張機能として動作し、現在開いているURLやドメイン�
 
 ### `sitecue_notes`
 
-- メモのメインテーブル。`user_id` (Auth), `content` などを保持。
+- メモのメインテーブル。`user_id` (Auth, **ON DELETE CASCADE**), `content` などを保持。
 - `scope`: `'domain'` | `'exact'` (Check Constraint)
 - `note_type`: `'info'` | `'alert'` | `'idea'` (Check Constraint, Default: 'info')
 - `is_resolved`: `boolean` (Default: `false`)
@@ -15297,7 +15342,7 @@ Chrome拡張機能として動作し、現在開いているURLやドメイン�
 ### `sitecue_profiles`
 
 - ユーザーのプランと利用制限を管理するテーブル。
-- `id`: uuid (FK to `auth.users.id`) - RLS必須
+- `id`: uuid (FK to `auth.users.id`, **ON DELETE CASCADE**) - RLS必須
 - `plan`: `'free'` | `'pro'` (Default: `'free'`)
 - **Access Control & Triggers**:
   - `handle_new_user`: 新規ユーザー登録時に自動で `free` プランのレコードを作成する。
@@ -15376,6 +15421,8 @@ interface TabChangeInfo {
   url?: string;
 }
 
+const MAX_FREE_NOTES = 200;
+
 export default function SidePanel() {
   const [session, setSession] = useState<Session | null>(null);
   const [authLoading, setAuthLoading] = useState(false);
@@ -15419,8 +15466,8 @@ export default function SidePanel() {
           queryParams:
             provider === "google"
               ? {
-                  prompt: "select_account",
-                }
+                prompt: "select_account",
+              }
               : undefined,
         },
       });
@@ -15603,6 +15650,7 @@ function NotesUI({
   // 📊 プランと制限管理
   const [userPlan, setUserPlan] = useState<"free" | "pro">("free");
   const [totalNoteCount, setTotalNoteCount] = useState<number>(0);
+  const [userStatsLoading, setUserStatsLoading] = useState(true);
 
   useEffect(() => {
     const fetchUserStats = async () => {
@@ -15630,7 +15678,7 @@ function NotesUI({
       }
     };
 
-    fetchUserStats();
+    fetchUserStats().finally(() => setUserStatsLoading(false));
   }, [session]);
 
   // ✅ 安全なURL取得 (修正済み)
@@ -15969,10 +16017,10 @@ function NotesUI({
         !n.is_favorite &&
         ((n.scope === "domain" &&
           n.url_pattern ===
-            (currentFullUrl ? getScopeUrls(currentFullUrl).domain : "")) ||
+          (currentFullUrl ? getScopeUrls(currentFullUrl).domain : "")) ||
           (n.scope === "exact" &&
             n.url_pattern ===
-              (currentFullUrl ? getScopeUrls(currentFullUrl).exact : ""))),
+            (currentFullUrl ? getScopeUrls(currentFullUrl).exact : ""))),
     )
     .sort((a, b) => {
       // 1. Pinned items first (Local Pin)
@@ -16132,11 +16180,10 @@ function NotesUI({
 
               {/* Content */}
               <div
-                className={`text-sm pr-8 mb-2 ${
-                  note.is_resolved
-                    ? "line-through text-neutral-500"
-                    : "text-neutral-800"
-                }`}
+                className={`text-sm pr-8 mb-2 ${note.is_resolved
+                  ? "line-through text-neutral-500"
+                  : "text-neutral-800"
+                  }`}
               >
                 <MarkdownRenderer content={note.content} />
               </div>
@@ -16157,17 +16204,17 @@ function NotesUI({
                   (note.scope === "domain"
                     ? getScopeUrls(currentFullUrl).domain
                     : getScopeUrls(currentFullUrl).exact) && (
-                  <a
-                    href={`https://${note.url_pattern}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1 hover:text-blue-400 hover:underline transition-colors max-w-30 ml-1"
-                    title={`Open ${note.url_pattern}`}
-                  >
-                    <ExternalLink className="w-3 h-3 shrink-0" />
-                    <span className="truncate">{note.url_pattern}</span>
-                  </a>
-                )}
+                    <a
+                      href={`https://${note.url_pattern}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center gap-1 hover:text-blue-400 hover:underline transition-colors max-w-30 ml-1"
+                      title={`Open ${note.url_pattern}`}
+                    >
+                      <ExternalLink className="w-3 h-3 shrink-0" />
+                      <span className="truncate">{note.url_pattern}</span>
+                    </a>
+                  )}
               </div>
             </div>
 
@@ -16292,103 +16339,120 @@ function NotesUI({
       </div>
 
       <div className="p-4 bg-white border-t border-gray-200 space-y-3">
-        {/* スコープ選択 */}
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4 text-xs">
-            <label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover:text-black">
-              <input
-                type="radio"
-                name="scope"
-                checked={selectedScope === "domain"}
-                onChange={() => setSelectedScope("domain")}
-                className="accent-neutral-800 focus:ring-neutral-800"
-              />
-              <span>Domain</span>
-            </label>
-            <label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover:text-black">
-              <input
-                type="radio"
-                name="scope"
-                checked={selectedScope === "exact"}
-                onChange={() => setSelectedScope("exact")}
-                className="accent-neutral-800 focus:ring-neutral-800"
-              />
-              <span>This Page</span>
-            </label>
+        {userStatsLoading ? (
+          <div className="flex items-center justify-center py-4">
+            <Loader2 className="w-5 h-5 animate-spin text-gray-300" />
           </div>
+        ) : (
+          <>
+            {/* スコープ選択 */}
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-4 text-xs">
+                <label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover:text-black">
+                  <input
+                    type="radio"
+                    name="scope"
+                    checked={selectedScope === "domain"}
+                    onChange={() => setSelectedScope("domain")}
+                    className="accent-neutral-800 focus:ring-neutral-800"
+                  />
+                  <span>Domain</span>
+                </label>
+                <label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover:text-black">
+                  <input
+                    type="radio"
+                    name="scope"
+                    checked={selectedScope === "exact"}
+                    onChange={() => setSelectedScope("exact")}
+                    className="accent-neutral-800 focus:ring-neutral-800"
+                  />
+                  <span>This Page</span>
+                </label>
+              </div>
 
-          {/* Note Type Selection */}
-          <div className="flex bg-white p-0.5 rounded-md">
-            <button
-              type="button"
-              onClick={() => setSelectedType("info")}
-              className={`cursor-pointer p-1 rounded ${selectedType === "info" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
-              title="Info"
-            >
-              <Info className="w-4 h-4" strokeWidth={2} />
-            </button>
-            <button
-              type="button"
-              onClick={() => setSelectedType("alert")}
-              className={`cursor-pointer p-1 rounded ${selectedType === "alert" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
-              title="Alert"
-            >
-              <AlertTriangle className="w-4 h-4" strokeWidth={2} />
-            </button>
-            <button
-              type="button"
-              onClick={() => setSelectedType("idea")}
-              className={`cursor-pointer p-1 rounded ${selectedType === "idea" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
-              title="Idea"
-            >
-              <Lightbulb className="w-4 h-4" strokeWidth={2} />
-            </button>
-          </div>
-        </div>
+              <div className="flex items-center gap-3">
+                {/* Note Count (Only for Free Plan) */}
+                {userPlan === "free" && (
+                  <span className="text-[10px] text-gray-400 font-medium">
+                    {totalNoteCount} / {MAX_FREE_NOTES}
+                  </span>
+                )}
 
-        <form onSubmit={handleSubmit} className="flex gap-2 items-center">
-          {userPlan === "free" && totalNoteCount >= 200 ? (
-            <div className="w-full bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800 flex items-start gap-3">
-              <AlertTriangle className="w-5 h-5 shrink-0 mt-0.5" />
-              <div>
-                <div className="font-bold mb-1">FREE Plan Limit Reached</div>
-                <p className="text-xs opacity-90">
-                  You have reached the 200 note limit. Please delete some
-                  existing notes to create new ones.
-                </p>
+                {/* Note Type Selection */}
+                <div className="flex bg-white p-0.5 rounded-md">
+                  <button
+                    type="button"
+                    onClick={() => setSelectedType("info")}
+                    className={`cursor-pointer p-1 rounded ${selectedType === "info" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
+                    title="Info"
+                  >
+                    <Info className="w-4 h-4" strokeWidth={2} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedType("alert")}
+                    className={`cursor-pointer p-1 rounded ${selectedType === "alert" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
+                    title="Alert"
+                  >
+                    <AlertTriangle className="w-4 h-4" strokeWidth={2} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedType("idea")}
+                    className={`cursor-pointer p-1 rounded ${selectedType === "idea" ? "bg-neutral-800 shadow-sm text-white" : "text-gray-400 hover:text-neutral-600"}`}
+                    title="Idea"
+                  >
+                    <Lightbulb className="w-4 h-4" strokeWidth={2} />
+                  </button>
+                </div>
               </div>
             </div>
-          ) : (
-            <>
-              <TextareaAutosize
-                ref={textareaRef}
-                value={newNote}
-                onChange={(e) => setNewNote(e.target.value)}
-                placeholder={`Add a cue to ${selectedScope === "domain" ? "this domain" : "this page"}...`}
-                className="flex-1 resize-none border-4 border-neutral-800 rounded-md p-2 text-sm focus:outline-none focus:ring-2 focus:ring-black/5 max-h-50"
-                minRows={1}
-                onKeyDown={(e) => {
-                  if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-                    e.preventDefault();
-                    handleSubmit(e);
-                  }
-                }}
-              />
-              <button
-                disabled={submitting || !newNote.trim()}
-                type="submit"
-                className="cursor-pointer bg-neutral-800 text-white p-2 rounded-md hover:bg-neutral-500 disabled:cursor-not-allowed transition-colors"
-                title="Add Note"
-              >
-                {submitting ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
-                  <Send className="w-4 h-4" />
-                )}
-              </button>
-            </>
-          )}
-        </form>
+
+            <form onSubmit={handleSubmit} className="flex gap-2 items-center">
+              {userPlan === "free" && totalNoteCount >= MAX_FREE_NOTES ? (
+                <div className="w-full bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800 flex items-start gap-3">
+                  <AlertTriangle className="w-5 h-5 shrink-0 mt-0.5" />
+                  <div>
+                    <div className="font-bold mb-1">FREE Plan Limit Reached</div>
+                    <p className="text-xs opacity-90">
+                      You have reached the {MAX_FREE_NOTES} note limit. Please delete some
+                      existing notes to create new ones.
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <TextareaAutosize
+                    ref={textareaRef}
+                    value={newNote}
+                    onChange={(e) => setNewNote(e.target.value)}
+                    placeholder={`Add a cue to ${selectedScope === "domain" ? "this domain" : "this page"}...`}
+                    className="flex-1 resize-none border-4 border-neutral-800 rounded-md p-2 text-sm focus:outline-none focus:ring-2 focus:ring-black/5 max-h-50"
+                    minRows={1}
+                    onKeyDown={(e) => {
+                      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                        e.preventDefault();
+                        handleSubmit(e);
+                      }
+                    }}
+                  />
+                  <button
+                    disabled={submitting || !newNote.trim()}
+                    type="submit"
+                    className="cursor-pointer bg-neutral-800 text-white p-2 rounded-md hover:bg-neutral-500 disabled:cursor-not-allowed transition-colors"
+                    title="Add Note"
+                  >
+                    {submitting ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <Send className="w-4 h-4" />
+                    )}
+                  </button>
+                </>
+              )}
+            </form>
+          </>
+        )}
       </div>
     </div>
   );

--- a/supabase/migrations/20260219203527_add_cascade_delete_notes.sql
+++ b/supabase/migrations/20260219203527_add_cascade_delete_notes.sql
@@ -1,0 +1,10 @@
+-- Migration to add ON DELETE CASCADE to sitecue_notes.user_id foreign key
+
+-- Drop the existing constraint (assuming default name sitecue_notes_user_id_fkey)
+ALTER TABLE sitecue_notes
+DROP CONSTRAINT IF EXISTS sitecue_notes_user_id_fkey;
+
+-- Re-add the constraint with ON DELETE CASCADE
+ALTER TABLE sitecue_notes
+ADD CONSTRAINT sitecue_notes_user_id_fkey
+FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;

--- a/supabase/snippets/Untitled query 463.sql
+++ b/supabase/snippets/Untitled query 463.sql
@@ -1,0 +1,5 @@
+SELECT
+    conname AS constraint_name,
+    pg_get_constraintdef(oid) AS constraint_definition
+FROM pg_constraint
+WHERE conrelid = 'public.sitecue_notes'::regclass;


### PR DESCRIPTION
## タイトル
feat: メモ数表示の追加、UIフラッシュ修正、およびDBのCASCADE設定

## 本文
Closes #61

### 目的
無料枠の制限に伴うUXの課題（UIのチラつき、現在の使用数の不可視化）を解決し、併せて退会時のデータ削除処理（CASCADE）をDBに設定する。

### 変更内容
1. **DBのCASCADE設定 (Migration)**
   - `sitecue_notes` の `user_id` に対する外部キー制約（`sitecue_notes_user_id_fkey`）を一度削除し、`ON DELETE CASCADE` を付与して再作成。
   - これにより、Supabaseでアカウントを削除した際、関連するメモデータも安全かつ自動的に削除されるように修正。
2. **UIのフラッシュ（チラつき）修正**
   - 拡張機能の初期ロード時に `isLoading` ステートを導入。
   - プランやメモ数の取得が完了するまでメインコンテンツを非表示にし、一瞬だけ制限画面が見えてしまう現象を防止。
3. **現在の総メモ数の表示**
   - 拡張機能のUI上に、現在のメモ数と上限をシンプルに表示（例: `15 / 200`）。
   - SiteCueの「ノイズ除去」のコンセプトに則り、目立ちすぎないスタイルで配置。

### 確認事項
- [x] ローカル/本番DBにてマイグレーションが適用され、ユーザー削除時にCASCADEが正常に動作することを確認
- [x] 拡張機能のロード時に「上限到達」などのアラートが一瞬表示されないことを確認
- [x] UI上に「現在のメモ数 / 200」が控えめに表示され、メモの追加・削除に応じてカウントが連動することを確認