### PR TITLE
feat(ext): add auto-indent functionality to textarea

### DIFF
--- a/extension/src/components/NoteInput.tsx
+++ b/extension/src/components/NoteInput.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, Info, Lightbulb, Send } from "lucide-react";
 import { useRef, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
+import { useAutoIndent } from "../hooks/useAutoIndent";
 import type { NoteScope, NoteType } from "../hooks/useNotes";
 
 interface NoteInputProps {
@@ -24,6 +25,7 @@ export default function NoteInput({
 	const [selectedType, setSelectedType] = useState<NoteType>("info");
 	const [newNote, setNewNote] = useState("");
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const handleAutoIndent = useAutoIndent();
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
@@ -137,6 +139,8 @@ export default function NoteInput({
 								if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
 									e.preventDefault();
 									handleSubmit(e);
+								} else {
+									handleAutoIndent(e);
 								}
 							}}
 						/>

--- a/extension/src/components/NoteItem.tsx
+++ b/extension/src/components/NoteItem.tsx
@@ -17,6 +17,7 @@ import {
 import { useLayoutEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import TextareaAutosize from "react-textarea-autosize";
+import { useAutoIndent } from "../hooks/useAutoIndent";
 import type { Note, NoteScope, NoteType } from "../hooks/useNotes";
 import { getScopeUrls } from "../utils/url";
 import MarkdownRenderer from "./MarkdownRenderer";
@@ -72,6 +73,7 @@ export default function NoteItem({
 	const [copiedNoteId, setCopiedNoteId] = useState<string | null>(null);
 	const [isOverflowing, setIsOverflowing] = useState(false);
 	const [isSwapping, setIsSwapping] = useState(false);
+	const handleAutoIndent = useAutoIndent();
 
 	const contentRef = useRef<HTMLDivElement>(null);
 
@@ -216,6 +218,8 @@ export default function NoteItem({
 							if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
 								e.preventDefault();
 								handleUpdate();
+							} else {
+								handleAutoIndent(e);
 							}
 						}}
 					/>

--- a/extension/src/hooks/useAutoIndent.ts
+++ b/extension/src/hooks/useAutoIndent.ts
@@ -1,0 +1,93 @@
+import type React from "react";
+
+/**
+ * Hook to provide auto-indent functionality for a textarea.
+ * It preserves the indentation from the previous line when Enter is pressed.
+ * It also clears the indentation if Enter is pressed on a line containing only indentation.
+ */
+export function useAutoIndent() {
+	const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		// Only handle Enter key without any modifiers
+		if (e.key !== "Enter" || e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) {
+			return;
+		}
+
+		const textarea = e.currentTarget;
+		const { value, selectionStart, selectionEnd } = textarea;
+
+		// If there is a selection, we let the default behavior take over
+		if (selectionStart !== selectionEnd) {
+			return;
+		}
+
+		// Find the start of the current line
+		const currentLineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
+		const currentLine = value.slice(currentLineStart, selectionStart);
+
+		// Extract leading whitespace (indentation)
+		const indentMatch = currentLine.match(/^[ \t]+/);
+		if (!indentMatch) {
+			return;
+		}
+
+		const indent = indentMatch[0];
+
+		/**
+		 * Helper to insert text while preserving undo history if possible.
+		 * Uses document.execCommand("insertText") as a preferred method.
+		 */
+		const insertText = (
+			text: string,
+			selectionOverrideStart?: number,
+			selectionOverrideEnd?: number,
+		) => {
+			let success = false;
+
+			if (
+				selectionOverrideStart !== undefined &&
+				selectionOverrideEnd !== undefined
+			) {
+				textarea.setSelectionRange(
+					selectionOverrideStart,
+					selectionOverrideEnd,
+				);
+			}
+
+			// 空文字の場合はネイティブの削除コマンドを使用する
+			const command = text === "" ? "delete" : "insertText";
+
+			// Try document.execCommand first to preserve undo history
+			if (document.queryCommandSupported(command)) {
+				success = document.execCommand(
+					command,
+					false,
+					text === "" ? undefined : text,
+				);
+			}
+
+			// Fallback to manual manipulation if execCommand failed or is not supported
+			if (!success) {
+				// setRangeTextで selectionMode を "end" に強制する
+				const start = selectionOverrideStart ?? textarea.selectionStart;
+				const end = selectionOverrideEnd ?? textarea.selectionEnd;
+				textarea.setRangeText(text, start, end, "end");
+
+				// Manually trigger 'input' event so React updates its state
+				textarea.dispatchEvent(new Event("input", { bubbles: true }));
+			}
+		};
+
+		// Case 1: If the line has ONLY indentation and user presses Enter, clear the indentation
+		if (indent === currentLine) {
+			e.preventDefault();
+			insertText("", currentLineStart, selectionStart);
+			return;
+		}
+
+		// Case 2: Indentation exists, insert a newline and the same indentation
+		e.preventDefault();
+		insertText(`\n${indent}`);
+	};
+
+	return onKeyDown;
+}


### PR DESCRIPTION
Why:
- To improve the Markdown writing experience (UX) by automatically maintaining the indentation context.
- To eliminate the manual effort of typing spaces or tabs when writing nested lists or code blocks.

What:
- Implement `useAutoIndent` hook to carry over the previous line's indentation when pressing Enter.
- Add a feature to clear the indentation and keep the cursor on the same line when Enter is pressed on an empty indented line.
- Use a hybrid approach prioritizing `document.execCommand` over `setRangeText` to preserve the browser's native Undo (Ctrl+Z) history.
- Utilize the native `delete` command for clearing indents and force `selectionMode: "end"` on fallback to prevent visual cursor jumping bugs.