### PR TITLE
fix(ext): prevent long URLs from overflowing note container

### DIFF
--- a/extension/src/components/MarkdownRenderer.tsx
+++ b/extension/src/components/MarkdownRenderer.tsx
@@ -146,10 +146,10 @@ export default function MarkdownRenderer({
 							href={href}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="text-blue-500 hover:text-blue-600 hover:underline inline-flex items-center gap-0.5"
+							className="text-blue-500 hover:text-blue-600 hover:underline break-all"
 						>
 							{children}
-							<ExternalLink className="w-3 h-3 inline-block" />
+							<ExternalLink className="w-3 h-3 inline-block ml-1 align-text-bottom" />
 						</a>
 					),
 


### PR DESCRIPTION
Why:
- Long URLs inside Markdown notes were causing the parent container to overflow because `inline-flex` prevents natural text wrapping.

What:
- Change the link (`<a>`) styling from `inline-flex` to standard `inline` with `break-all` to force wrapping.
- Adjust the `<ExternalLink>` icon to use `inline-block` with `align-text-bottom` for natural inline alignment.