### PR TITLE
feat: update code block styling to light theme and enable line wrapping

### DIFF
--- a/extension/src/components/MarkdownRenderer.tsx
+++ b/extension/src/components/MarkdownRenderer.tsx
@@ -17,7 +17,7 @@ import toml from "react-syntax-highlighter/dist/esm/languages/prism/toml";
 import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
 import typescript from "react-syntax-highlighter/dist/esm/languages/prism/typescript";
 import yaml from "react-syntax-highlighter/dist/esm/languages/prism/yaml";
-import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
@@ -195,17 +195,18 @@ export default function MarkdownRenderer({
 								<div className="rounded-lg overflow-hidden text-xs font-mono leading-relaxed relative">
 									<SyntaxHighlighter
 										{...rest}
-										style={vscDarkPlus}
+										style={oneLight}
 										language={language}
 										PreTag="div"
 										customStyle={{
 											margin: 0,
 											padding: "0.75rem",
-											backgroundColor: "#1e1e1e", // Match vscDarkPlus bg
+											// backgroundColor: "#1e1e1e", // Match vscDarkPlus bg
 										}}
 										codeTagProps={{
 											style: { fontFamily: "inherit" },
 										}}
+										wrapLongLines={true}
 									>
 										{codeString}
 									</SyntaxHighlighter>


### PR DESCRIPTION
Why:
- The dark theme for code blocks was too visually prominent and clashed with the minimal white/gray design.
- Horizontal scrolling for long lines of code was inconvenient and reduced readability in the narrow extension side panel.

What:
- Change syntax highlighter to a light theme.
- Add `wrapLongLines={true}` to automatically wrap long lines of code.
- Remove hardcoded `#1e1e1e` background color to apply the new theme correctly.