### PR TITLE
fix: resolve URL overwrite bug and optimize Favorites UI layout

### DIFF
--- a/extension/src/components/NoteItem.tsx
+++ b/extension/src/components/NoteItem.tsx
@@ -77,11 +77,12 @@ export default function NoteItem({
 
 	const contentRef = useRef<HTMLDivElement>(null);
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: Needed to recalculate height on content change
 	useLayoutEffect(() => {
 		if (contentRef.current) {
 			setIsOverflowing(contentRef.current.scrollHeight > COLLAPSE_THRESHOLD);
 		}
-	}, []);
+	}, [note.content]);
 
 	const startEditing = () => {
 		setIsEditing(true);
@@ -358,6 +359,31 @@ export default function NoteItem({
 						)}
 					</div>
 
+					{/* Favoriteリスト時のみのメタデータ（必要なら引き続き表示） */}
+					{isFavoriteList && note.scope !== "inbox" && (
+						<div className="text-[10px] text-neutral-400 flex items-center gap-2 mt-1">
+							<span
+								className={`px-1 rounded border ${note.scope === "exact" ? "bg-white border-neutral-200 text-neutral-500" : "bg-neutral-50 border-neutral-200 text-neutral-400"}`}
+							>
+								{note.scope === "exact" ? "Page" : "Domain"}
+							</span>
+							{note.url_pattern !==
+								(note.scope === "domain"
+									? getScopeUrls(currentFullUrl).domain
+									: getScopeUrls(currentFullUrl).exact) && (
+								<a
+									href={`https://${note.url_pattern}`}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center gap-1 hover:text-blue-400 hover:underline transition-colors max-w-48 truncate"
+									title={`Open ${note.url_pattern}`}
+								>
+									<span className="truncate">{note.url_pattern}</span>
+								</a>
+							)}
+						</div>
+					)}
+
 					{/* 3層目：フッター（操作ボタン、ホバー時のみ出現） */}
 					<div className="mt-1 pt-1 border-t border-transparent group-hover:border-gray-100 flex items-center justify-between opacity-0 group-hover:opacity-100 transition-all duration-200">
 						{/* 左側：並び替え（Pinがない時のみ表示） */}
@@ -422,31 +448,6 @@ export default function NoteItem({
 							</button>
 						</div>
 					</div>
-
-					{/* Favoriteリスト時のみのメタデータ（必要なら引き続き表示） */}
-					{isFavoriteList && note.scope !== "inbox" && (
-						<div className="text-[10px] text-neutral-400 flex items-center gap-2 mt-1">
-							<span
-								className={`px-1 rounded border ${note.scope === "exact" ? "bg-white border-neutral-200 text-neutral-500" : "bg-neutral-50 border-neutral-200 text-neutral-400"}`}
-							>
-								{note.scope === "exact" ? "Page" : "Domain"}
-							</span>
-							{note.url_pattern !==
-								(note.scope === "domain"
-									? getScopeUrls(currentFullUrl).domain
-									: getScopeUrls(currentFullUrl).exact) && (
-								<a
-									href={`https://${note.url_pattern}`}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="flex items-center gap-1 hover:text-blue-400 hover:underline transition-colors max-w-48 truncate"
-									title={`Open ${note.url_pattern}`}
-								>
-									<span className="truncate">{note.url_pattern}</span>
-								</a>
-							)}
-						</div>
-					)}
 				</div>
 			)}
 		</div>

--- a/extension/src/components/NoteList.tsx
+++ b/extension/src/components/NoteList.tsx
@@ -1,4 +1,4 @@
-import { Ghost, Loader2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Ghost, Loader2 } from "lucide-react";
 import { useState } from "react";
 import type { Note, NoteScope, NoteType } from "../hooks/useNotes";
 import { getScopeUrls } from "../utils/url";
@@ -44,6 +44,7 @@ export default function NoteList({
 	onToggleExpansion,
 }: NoteListProps) {
 	const [isSorting, setIsSorting] = useState(false);
+	const [isFavoritesOpen, setIsFavoritesOpen] = useState(false);
 
 	const filteredNotes = notes.filter((note) => {
 		if (filterType !== "all") {
@@ -187,12 +188,23 @@ export default function NoteList({
 		<>
 			{favoriteNotes.length > 0 && (
 				<div className="space-y-3">
-					<div className="flex items-center gap-2 text-xs font-semibold text-neutral-500 uppercase tracking-wider px-1">
-						<span>Favorites</span>
-					</div>
-					<div className="space-y-3">
-						{favoriteNotes.map((note) => renderItem(note, true))}
-					</div>
+					<button
+						type="button"
+						onClick={() => setIsFavoritesOpen(!isFavoritesOpen)}
+						className="flex items-center gap-1 text-xs font-semibold text-neutral-500 uppercase tracking-wider px-1 hover:text-neutral-800 transition-colors cursor-pointer"
+					>
+						{isFavoritesOpen ? (
+							<ChevronDown className="w-3 h-3" />
+						) : (
+							<ChevronRight className="w-3 h-3" />
+						)}
+						<span>FAVORITES ({favoriteNotes.length})</span>
+					</button>
+					{isFavoritesOpen && (
+						<div className="space-y-3">
+							{favoriteNotes.map((note) => renderItem(note, true))}
+						</div>
+					)}
 					{currentScopeNotes.length > 0 && <hr className="border-gray-200" />}
 				</div>
 			)}

--- a/extension/src/hooks/useNotes.ts
+++ b/extension/src/hooks/useNotes.ts
@@ -133,6 +133,7 @@ export function useNotes(
 	) => {
 		if (!editContent.trim()) return false;
 		try {
+			const currentNote = notes.find((n) => n.id === id);
 			let targetUrlPattern: string | undefined;
 			const updatePayload: {
 				content: string;
@@ -144,7 +145,7 @@ export function useNotes(
 				note_type: editType,
 			};
 
-			if (editScope) {
+			if (editScope && editScope !== currentNote?.scope) {
 				updatePayload.scope = editScope;
 				const scopeUrls = getScopeUrls(currentFullUrl);
 				targetUrlPattern =


### PR DESCRIPTION
Why:
- Editing a Favorite note unintentionally overwrote its original URL pattern with the current tab's URL.
- The "Read more" button did not appear immediately after creating or editing a long note.
- The note's metadata (URL) in the Favorites section was displayed below the action bar, causing an unnatural layout.
- A long list of Favorite notes pushed the primary "CURRENT PAGE" notes out of the initial view.

What:
- Updated `updateNote` in `useNotes.ts` to recalculate `scopeUrls` only when the note's scope is explicitly changed.
- Added `note.content` to the `useLayoutEffect` dependency array in `NoteItem.tsx` to recalculate height dynamically.
- Moved the metadata section above the action bar (footer) in `NoteItem.tsx`.
- Implemented a collapsible accordion for the Favorites section in `NoteList.tsx`, defaulting to a closed state.