### PR TITLE
chore(config): suppress Vite chunk size warning for extension build

### DIFF
--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -35,6 +35,9 @@ export default defineConfig(({ mode, command }) => {
 
 	return {
 		plugins: [react(), tailwindcss(), crx({ manifest: dynamicManifest })],
+		build: {
+			chunkSizeWarningLimit: 1500,
+		},
 		server: {
 			port: 5173,
 			strictPort: true,


### PR DESCRIPTION
Why:
- Vite's default chunk size warning limit (500kB) was being triggered during the extension build.
- Since Chrome extensions run locally, large chunk sizes do not cause network latency issues.
- Implementing code splitting (manualChunks) to fix the warning introduces the risk of runtime errors in the extension environment.

What:
- Increased `chunkSizeWarningLimit` in `vite.config.ts` to prevent unnecessary warnings during `bun run build`.