### PR TITLE
chore(domain): update production URLs to custom domain sitecue.app

### DIFF
--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -1,3 +1,4 @@
 # ローカル開発用の設定 (Supabase Local)
 SUPABASE_URL=http://127.0.0.1:54321
 SUPABASE_ANON_KEY=your_local_anon_key_here
+GEMINI_API_KEY=[GCP_API_KEY]

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,7 +16,15 @@ type Variables = {
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
-app.use("/*", cors());
+app.use(
+	"/*",
+	cors({
+		origin: ["http://127.0.0.1:3000", "https://app.sitecue.app"],
+		allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+		allowHeaders: ["Content-Type", "Authorization"],
+		credentials: true,
+	}),
+);
 
 app.get("/", (c) => {
 	return c.text("SiteCue API is running.");

--- a/apps/app/.env.example
+++ b/apps/app/.env.example
@@ -10,7 +10,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=
 # （注意）必ず127.0.0.1を指定し、localhostは使用しないでください
 # Next.jsでのローカル開発 (bun run dev): http://127.0.0.1:3000
 # Cloudflareローカルプレビュー (bun run preview): http://127.0.0.1:8787
-# 本番環境: https://sitecue-app.taikiwt.workers.dev
+# 本番環境: 
 NEXT_PUBLIC_SITE_URL=http://127.0.0.1:3000
 
 # --- APIへの接続先 ---

--- a/apps/app/wrangler.toml
+++ b/apps/app/wrangler.toml
@@ -11,4 +11,4 @@ binding = "ASSETS"
 
 [vars]
 NEXT_PUBLIC_SUPABASE_URL = "https://jmoqxrsclhhdhswneyga.supabase.co"
-NEXT_PUBLIC_API_URL = "https://sitecue-api.taikiwt.workers.dev"
+NEXT_PUBLIC_API_URL = "https://api.sitecue.app"

--- a/apps/extension/.env.example
+++ b/apps/extension/.env.example
@@ -6,7 +6,7 @@ VITE_WEB_URL=
 
 # APIの接続先
 # 開発中: http://127.0.0.1:8787
-# 本番: https://sitecue-api.[your-subdomain].workers.dev
+# 本番: 
 VITE_API_URL=
 
 # Supabaseの接続先


### PR DESCRIPTION
Why:
- Acquired the new custom domain `sitecue.app`.
- Adopting a best-practice subdomain architecture (`app.sitecue.app` for the web app, `api.sitecue.app` for the API) to ensure long-term scalability, strict CORS management, and readiness for a future landing page on the naked domain.

What:
- Update CORS configuration in `apps/api` to allow traffic from `https://app.sitecue.app` and enforce `http://127.0.0.1:3000` for local development.
- Update `NEXT_PUBLIC_API_URL` in `apps/app/wrangler.toml` and `apps/app/.env.production` to point to `https://api.sitecue.app`.
- Update `VITE_WEB_URL` and `VITE_API_URL` in `apps/extension/.env.production` to the new custom domains.
- Remove outdated `workers.dev` URLs from environment configurations.