### PR TITLE
feat(basecamp): establish foundation and launchpad UI for base camp c…

### DIFF
--- a/apps/app/src/app/basecamp/page.tsx
+++ b/apps/app/src/app/basecamp/page.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+
+export default function BaseCampPage() {
+	return (
+		<div className="min-h-screen bg-neutral-50 text-neutral-950 font-sans">
+			<header className="border-b border-neutral-200 bg-white">
+				<div className="mx-auto max-w-5xl px-6 py-8">
+					<h1 className="text-3xl font-bold tracking-tight">
+						SiteCue Base Camp
+					</h1>
+					<p className="mt-2 text-neutral-500">
+						あなたの情報の種を、ここから育てましょう。
+					</p>
+				</div>
+			</header>
+
+			<main className="mx-auto max-w-5xl px-6 py-12">
+				{/* Launchpad Section */}
+				<section className="mb-16">
+					<div className="mb-8 flex items-center gap-2">
+						<span className="text-xl">🚀</span>
+						<h2 className="text-lg font-semibold text-neutral-800">
+							クイックスタート
+						</h2>
+					</div>
+					<div className="grid gap-6 sm:grid-cols-3">
+						<Link
+							href="/basecamp/draft/new?target=x"
+							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-8 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900"
+						>
+							<div className="mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-50 text-2xl transition-colors group-hover:bg-neutral-100">
+								🐦
+							</div>
+							<h3 className="mb-2 font-bold text-neutral-900">X (Twitter)</h3>
+							<p className="text-sm text-neutral-500">
+								思いついたアイデアをドラフトとして保存します。
+							</p>
+							<div className="mt-6 flex items-center text-xs font-semibold text-neutral-400 group-hover:text-neutral-900">
+								作成を開始する{" "}
+								<span className="ml-1 transition-transform group-hover:translate-x-1">
+									→
+								</span>
+							</div>
+						</Link>
+
+						<Link
+							href="/basecamp/draft/new?target=zenn"
+							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-8 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900"
+						>
+							<div className="mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-50 text-2xl transition-colors group-hover:bg-neutral-100">
+								📘
+							</div>
+							<h3 className="mb-2 font-bold text-neutral-900">Zenn</h3>
+							<p className="text-sm text-neutral-500">
+								技術記事の構成案やメモを執筆します。
+							</p>
+							<div className="mt-6 flex items-center text-xs font-semibold text-neutral-400 group-hover:text-neutral-900">
+								執筆をはじめる{" "}
+								<span className="ml-1 transition-transform group-hover:translate-x-1">
+									→
+								</span>
+							</div>
+						</Link>
+
+						<Link
+							href="/basecamp/draft/new?target=generic"
+							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-8 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900"
+						>
+							<div className="mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-50 text-2xl transition-colors group-hover:bg-neutral-100">
+								📝
+							</div>
+							<h3 className="mb-2 font-bold text-neutral-900">汎用ノート</h3>
+							<p className="text-sm text-neutral-500">
+								プラットフォームを限定しない自由なメモです。
+							</p>
+							<div className="mt-6 flex items-center text-xs font-semibold text-neutral-400 group-hover:text-neutral-900">
+								ノートを作る{" "}
+								<span className="ml-1 transition-transform group-hover:translate-x-1">
+									→
+								</span>
+							</div>
+						</Link>
+					</div>
+				</section>
+
+				{/* Stats section (Placeholder) */}
+				<section>
+					<div className="mb-8 flex items-center gap-2">
+						<span className="text-xl">📊</span>
+						<h2 className="text-lg font-semibold text-neutral-800">活動状況</h2>
+					</div>
+					<div className="grid gap-6 rounded-2xl border border-neutral-200 bg-white p-10 sm:grid-cols-3">
+						<div className="flex flex-col">
+							<span className="mb-1 text-sm font-medium text-neutral-400 uppercase tracking-tight">
+								総ノート数
+							</span>
+							<span className="text-4xl font-bold text-neutral-900">--</span>
+						</div>
+						<div className="flex flex-col">
+							<span className="mb-1 text-sm font-medium text-neutral-400 uppercase tracking-tight">
+								今週のドラフト
+							</span>
+							<span className="text-4xl font-bold text-neutral-900">--</span>
+						</div>
+						<div className="flex flex-col">
+							<span className="mb-1 text-sm font-medium text-neutral-400 uppercase tracking-tight">
+								公開済みアイテム
+							</span>
+							<span className="text-4xl font-bold text-neutral-900">--</span>
+						</div>
+					</div>
+					<div className="mt-8 flex items-center justify-center rounded-2xl border-2 border-dashed border-neutral-100 py-12">
+						<p className="text-sm text-neutral-400 italic">
+							活動データが集まると、ここに統計が表示されます。
+						</p>
+					</div>
+				</section>
+			</main>
+		</div>
+	);
+}

--- a/apps/app/src/app/weave/WeaveUI.test.tsx
+++ b/apps/app/src/app/weave/WeaveUI.test.tsx
@@ -28,7 +28,7 @@ describe("WeaveUI Component (Context Relay)", () => {
 
 		// メモを選択
 		const checkbox = screen.getByRole("checkbox");
-		if (!checkbox.checked) {
+		if (!(checkbox as HTMLInputElement).checked) {
 			await user.click(checkbox);
 		}
 

--- a/apps/extension/src/components/NoteInput.test.tsx
+++ b/apps/extension/src/components/NoteInput.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import NoteInput from "./NoteInput";
 
 describe("NoteInput Component", () => {

--- a/supabase/migrations/20260406070059_add_drafts_table.sql
+++ b/supabase/migrations/20260406070059_add_drafts_table.sql
@@ -1,0 +1,27 @@
+create table "public"."sitecue_drafts" (
+    "id" uuid not null default gen_random_uuid(),
+    "user_id" uuid not null default auth.uid(),
+    "title" text,
+    "content" text,
+    "target_platform" text not null,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now()
+);
+
+alter table "public"."sitecue_drafts" enable row level security;
+
+CREATE UNIQUE INDEX sitecue_drafts_pkey ON public.sitecue_drafts USING btree (id);
+
+alter table "public"."sitecue_drafts" add constraint "sitecue_drafts_pkey" PRIMARY KEY using index "sitecue_drafts_pkey";
+
+alter table "public"."sitecue_drafts" add constraint "sitecue_drafts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+alter table "public"."sitecue_drafts" add constraint "sitecue_drafts_platform_check" CHECK (target_platform IN ('x', 'zenn', 'generic'));
+
+create policy "Users can perform all actions on their own drafts"
+on "public"."sitecue_drafts"
+as permissive
+for all
+to authenticated
+using ((auth.uid() = user_id))
+with check ((auth.uid() = user_id));

--- a/types/app.ts
+++ b/types/app.ts
@@ -8,3 +8,12 @@ export type Note = Omit<
 > & {
 	scope: NoteScope;
 };
+
+export type DraftPlatform = "x" | "zenn" | "generic";
+
+export type Draft = Omit<
+	Database["public"]["Tables"]["sitecue_drafts"]["Row"],
+	"target_platform"
+> & {
+	target_platform: DraftPlatform;
+};

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -64,6 +64,36 @@ export type Database = {
 				};
 				Relationships: [];
 			};
+			sitecue_drafts: {
+				Row: {
+					content: string | null;
+					created_at: string;
+					id: string;
+					target_platform: string;
+					title: string | null;
+					updated_at: string;
+					user_id: string;
+				};
+				Insert: {
+					content?: string | null;
+					created_at?: string;
+					id?: string;
+					target_platform: string;
+					title?: string | null;
+					updated_at?: string;
+					user_id?: string;
+				};
+				Update: {
+					content?: string | null;
+					created_at?: string;
+					id?: string;
+					target_platform?: string;
+					title?: string | null;
+					updated_at?: string;
+					user_id?: string;
+				};
+				Relationships: [];
+			};
 			sitecue_links: {
 				Row: {
 					created_at: string;
@@ -169,18 +199,21 @@ export type Database = {
 			sitecue_profiles: {
 				Row: {
 					ai_usage_count: number;
+					ai_usage_reset_at: string | null;
 					created_at: string;
 					id: string;
 					plan: string;
 				};
 				Insert: {
 					ai_usage_count?: number;
+					ai_usage_reset_at?: string | null;
 					created_at?: string;
 					id: string;
 					plan?: string;
 				};
 				Update: {
 					ai_usage_count?: number;
+					ai_usage_reset_at?: string | null;
 					created_at?: string;
 					id?: string;
 					plan?: string;


### PR DESCRIPTION
…oncept

Why:
- To evolve SiteCue from a simple note manager into an "activity hub" (Base Camp) where users can compile notes into drafts.
- We need a dedicated dashboard to initiate drafting for specific target platforms (e.g., X, Zenn) and a database schema to persist these drafts.

What:
- Add Supabase migration for `sitecue_drafts` table with RLS and CHECK constraints for `target_platform`.
- Update TypeScript definitions (`supabase.ts`) and wrap them with frontend types in `types/app.ts`.
- Create the initial Launchpad UI at `/app/basecamp/page.tsx` with quick start links.
- Fix existing type assertion error for `HTMLInputElement.checked` in `WeaveUI.test.tsx`.