### PR TITLE
feat(notes): implement inline note editing and unify neutral design

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -17,7 +17,8 @@
 		"@supabase/supabase-js": "^2.93.1",
 		"next": "^16.1.6",
 		"react": "^19.2.0",
-		"react-dom": "^19.2.0"
+		"react-dom": "^19.2.0",
+		"react-textarea-autosize": "^8.5.9"
 	},
 	"devDependencies": {
 		"@opennextjs/cloudflare": "^1.18.0",

--- a/apps/app/src/app/notes/_components/LeftPaneNavigation.tsx
+++ b/apps/app/src/app/notes/_components/LeftPaneNavigation.tsx
@@ -50,7 +50,7 @@ export function LeftPaneNavigation({
 					href="/"
 					className="text-xl font-bold flex items-center gap-2 mb-4"
 				>
-					<span className="text-indigo-600">SiteCue</span>
+					<span className="text-neutral-900">SiteCue</span>
 				</Link>
 
 				{/* Search Area */}
@@ -62,7 +62,7 @@ export function LeftPaneNavigation({
 						type="search"
 						id="nav-search"
 						placeholder="URLやドメインを検索..."
-						className="w-full pl-8 pr-3 py-2 bg-gray-100 border-transparent focus:bg-white focus:border-indigo-300 focus:ring-2 focus:ring-indigo-100 rounded-lg text-sm transition-all outline-none"
+						className="w-full pl-8 pr-3 py-2 bg-gray-100 border-transparent focus:bg-white focus:border-neutral-400 focus:ring-2 focus:ring-neutral-200 rounded-lg text-sm transition-all outline-none"
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}
 					/>
@@ -76,7 +76,7 @@ export function LeftPaneNavigation({
 						href="/notes?domain=inbox"
 						className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
 							isInboxActive
-								? "bg-indigo-50 text-indigo-700"
+								? "bg-neutral-100 text-neutral-900"
 								: "text-gray-600 hover:bg-gray-200 hover:text-gray-900"
 						}`}
 					>
@@ -96,7 +96,7 @@ export function LeftPaneNavigation({
 						href="/notes?view=drafts"
 						className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
 							isDraftsActive
-								? "bg-indigo-50 text-indigo-700"
+								? "bg-neutral-100 text-neutral-900"
 								: "text-gray-600 hover:bg-gray-200 hover:text-gray-900"
 						}`}
 					>
@@ -132,7 +132,7 @@ export function LeftPaneNavigation({
 			<div className="p-4 border-t border-gray-200 bg-white">
 				<Link
 					href="/studio"
-					className="flex items-center justify-center gap-2 w-full px-4 py-2 bg-indigo-600 text-white rounded-md text-sm font-medium hover:bg-indigo-700 transition-colors"
+					className="flex items-center justify-center gap-2 w-full px-4 py-2 bg-neutral-900 text-white rounded-md text-sm font-medium hover:bg-neutral-800 transition-colors"
 				>
 					<span>Studio</span>
 				</Link>
@@ -180,7 +180,7 @@ function DomainAccordionItem({
 				aria-expanded={effectiveIsOpen}
 				className={`w-full flex items-center gap-1 group px-2 py-1.5 rounded-md text-sm transition-colors ${
 					isUnderThisDomain && !currentExact
-						? "bg-indigo-50 text-indigo-700 font-medium"
+						? "bg-neutral-100 text-neutral-900 font-medium"
 						: "text-gray-600 hover:bg-gray-200 hover:text-gray-900"
 				}`}
 			>
@@ -220,7 +220,7 @@ function DomainAccordionItem({
 						href={`/notes?domain=${encodeURIComponent(domainName)}`}
 						className={`block px-2 py-1 text-xs rounded transition-colors truncate ${
 							isUnderThisDomain && !currentExact
-								? "bg-white text-indigo-600 font-medium shadow-sm"
+								? "bg-white text-neutral-900 font-medium shadow-sm"
 								: "text-gray-500 hover:bg-gray-200 hover:text-gray-900"
 						}`}
 					>
@@ -254,7 +254,7 @@ function DomainAccordionItem({
 								)}&exact=${encodeURIComponent(url)}`}
 								className={`block px-2 py-1 text-xs rounded transition-colors truncate ${
 									isActive
-										? "bg-white text-indigo-600 font-medium shadow-sm"
+										? "bg-white text-neutral-900 font-medium shadow-sm"
 										: "text-gray-500 hover:bg-gray-200 hover:text-gray-900"
 								}`}
 								title={url}

--- a/apps/app/src/app/notes/_components/MiddlePaneList.tsx
+++ b/apps/app/src/app/notes/_components/MiddlePaneList.tsx
@@ -112,7 +112,7 @@ export function MiddlePaneList({
 									key={item.id}
 									href={`/notes?${params.toString()}`}
 									className={`block p-4 transition-colors ${
-										isActive ? "bg-indigo-50" : "hover:bg-gray-50"
+										isActive ? "bg-neutral-100" : "hover:bg-gray-50"
 									}`}
 								>
 									<div className="flex justify-between items-start mb-1">

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import type { Draft, Note } from "../types";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import TextareaAutosize from "react-textarea-autosize";
+import { createClient } from "@/utils/supabase/client";
 
 type Props = {
 	note?: Note;
@@ -8,6 +12,19 @@ type Props = {
 };
 
 export function RightPaneDetail({ note, draft }: Props) {
+	const router = useRouter();
+	const [isEditing, setIsEditing] = useState(false);
+	const [editContent, setEditContent] = useState("");
+	const [isSaving, setIsSaving] = useState(false);
+	const [optimisticContent, setOptimisticContent] = useState<string | null>(null);
+
+	// Reset state when note or draft changes
+	useEffect(() => {
+		setIsEditing(false);
+		setOptimisticContent(null);
+		setEditContent(note?.content || "");
+	}, [note?.id, draft?.id, note?.content]);
+
 	if (!note && !draft) {
 		return (
 			<div className="flex-1 flex flex-col items-center justify-center bg-gray-50 text-gray-500 p-8">
@@ -32,10 +49,50 @@ export function RightPaneDetail({ note, draft }: Props) {
 		});
 	};
 
-	const content = note ? note.content : draft?.content || "";
+	const content = optimisticContent !== null ? optimisticContent : (note ? note.content : draft?.content || "");
 	const createdAt = note ? note.created_at : draft?.created_at || "";
 	const updatedAt = note ? note.updated_at : draft?.updated_at || "";
 	const id = note ? note.id : draft?.id || "";
+
+	const handleEdit = () => {
+		setEditContent(note?.content || "");
+		setIsEditing(true);
+	};
+
+	const handleCancel = () => {
+		setIsEditing(false);
+		setEditContent(note?.content || "");
+	};
+
+	const handleSave = async () => {
+		if (!note) return;
+		
+		setIsSaving(true);
+		const newContent = editContent.trim();
+		
+		// Optimistic update
+		setOptimisticContent(newContent);
+		setIsEditing(false);
+
+		try {
+			const supabase = createClient();
+			const { error } = await supabase
+				.from("sitecue_notes")
+				.update({ content: newContent })
+				.eq("id", note.id);
+
+			if (error) throw error;
+
+			router.refresh();
+		} catch (err) {
+			console.error("Failed to update note:", err);
+			alert("ノートの更新に失敗しました。");
+			setOptimisticContent(null);
+			setIsEditing(true);
+		} finally {
+			setIsSaving(false);
+		}
+	};
 
 	return (
 		<div className="flex-1 flex flex-col h-full bg-white overflow-y-auto">
@@ -65,27 +122,61 @@ export function RightPaneDetail({ note, draft }: Props) {
 							</span>
 						</div>
 					</div>
-					<div className="flex gap-2">
-						{note?.is_pinned && (
-							<span
-								role="img"
-								className="text-xl"
-								title="Pinned"
-								aria-label="Pinned"
+					<div className="flex items-center gap-2">
+						{note && !isEditing && (
+							<button
+								type="button"
+								onClick={handleEdit}
+								className="text-xs font-medium px-3 py-1.5 rounded-md bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 hover:text-gray-900 transition-colors flex items-center gap-1.5"
 							>
-								📌
-							</span>
+								<span aria-hidden="true" className="text-sm">
+									✏️
+								</span>
+								Edit
+							</button>
 						)}
-						{note?.is_favorite && (
-							<span
-								role="img"
-								className="text-xl"
-								title="Favorite"
-								aria-label="Favorite"
-							>
-								⭐
-							</span>
+						{isEditing && (
+							<div className="flex items-center gap-2">
+								<button
+									type="button"
+									onClick={handleCancel}
+									className="text-xs font-medium px-3 py-1.5 rounded-md hover:bg-gray-100 text-gray-600 transition-colors"
+									disabled={isSaving}
+								>
+									Cancel
+								</button>
+								<button
+									type="button"
+									onClick={handleSave}
+									className="text-xs font-medium px-4 py-1.5 rounded-md bg-neutral-900 text-white hover:bg-neutral-800 transition-colors disabled:opacity-50"
+									disabled={isSaving}
+								>
+									{isSaving ? "Saving..." : "Save"}
+								</button>
+							</div>
 						)}
+						<div className="flex gap-2 ml-2">
+							{note?.is_pinned && (
+								<span
+									role="img"
+									className="text-xl"
+									title="Pinned"
+									aria-label="Pinned"
+								>
+									📌
+								</span>
+							)}
+							{note?.is_favorite && (
+								<span
+									role="img"
+									className="text-xl"
+									title="Favorite"
+									aria-label="Favorite"
+								>
+									⭐
+								</span>
+							)}
+						</div>
 					</div>
 				</div>
 
@@ -113,20 +204,32 @@ export function RightPaneDetail({ note, draft }: Props) {
 							}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="text-indigo-600 hover:underline break-all text-sm block bg-indigo-50 p-3 rounded-lg border border-indigo-100"
+							className="text-neutral-600 underline hover:text-neutral-900 break-all text-sm block bg-neutral-50 p-3 rounded-lg border border-neutral-200"
 						>
 							{note.url_pattern}
 						</a>
 					</div>
 				)}
 
-				<div className="prose prose-indigo max-w-none">
+				<div className="prose prose-neutral max-w-none">
 					<div className="text-sm text-gray-400 mb-2 uppercase tracking-tight font-medium">
 						{note ? "Note Content" : "Draft Content"}
 					</div>
-					<div className="bg-gray-50 p-6 rounded-xl border border-gray-200 shadow-sm min-h-50 whitespace-pre-wrap text-gray-800 leading-relaxed">
-						{content}
-					</div>
+					{isEditing ? (
+						<div className="relative">
+							<TextareaAutosize
+								autoFocus
+								value={editContent}
+								onChange={(e) => setEditContent(e.target.value)}
+								className="w-full bg-white p-6 rounded-xl border-2 border-neutral-900 shadow-sm min-h-50 whitespace-pre-wrap text-gray-800 leading-relaxed focus:outline-none"
+								placeholder="What's on your mind?"
+							/>
+						</div>
+					) : (
+						<div className="bg-gray-50 p-6 rounded-xl border border-gray-200 shadow-sm min-h-50 whitespace-pre-wrap text-gray-800 leading-relaxed">
+							{content}
+						</div>
+					)}
 				</div>
 
 				<div className="mt-12 pt-8 border-t border-gray-100 text-xs text-gray-400">

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "next": "^16.1.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-textarea-autosize": "^8.5.9",
       },
       "devDependencies": {
         "@opennextjs/cloudflare": "^1.18.0",


### PR DESCRIPTION
Why:
- To allow users to refine and update collected notes directly within the web dashboard.
- To provide a seamless user experience by aligning the web dashboard's visual tone with the Chrome extension's minimalist aesthetic.

What:
- Added an inline explicit edit mode to the `RightPaneDetail` component with "Edit", "Save", and "Cancel" actions.
- Implemented optimistic UI updates for immediate visual feedback when saving a note.
- Replaced legacy `indigo` accent colors with a cohesive `neutral` palette across `LeftPaneNavigation`, `MiddlePaneList`, and `RightPaneDetail`.
- Integrated direct Supabase `UPDATE` queries combined with `router.refresh()` to synchronize the server state.
- Ensured the editing state (e.g., input values and toggles) resets automatically when navigating between different notes or drafts.