### PR TITLE
feat(ui): sync web dashboard styles and icons with extension

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -15,6 +15,7 @@
 	"dependencies": {
 		"@supabase/ssr": "^0.8.0",
 		"@supabase/supabase-js": "^2.93.1",
+		"lucide-react": "^1.7.0",
 		"next": "^16.1.6",
 		"react": "^19.2.0",
 		"react-dom": "^19.2.0",

--- a/apps/app/src/app/notes/_components/LeftPaneNavigation.tsx
+++ b/apps/app/src/app/notes/_components/LeftPaneNavigation.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
+import { Search, Inbox, PenSquare, Globe, FileText } from "lucide-react";
 import { getSafeUrl, normalizeUrlForGrouping } from "@/utils/url";
 import type { DomainGroup, GroupedNotes } from "../types";
 
@@ -55,9 +56,10 @@ export function LeftPaneNavigation({
 
 				{/* Search Area */}
 				<div className="relative">
-					<span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-xs">
-						🔍
-					</span>
+					<Search
+						className="w-4 h-4 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2"
+						aria-hidden="true"
+					/>
 					<input
 						type="search"
 						id="nav-search"
@@ -80,7 +82,7 @@ export function LeftPaneNavigation({
 								: "text-gray-600 hover:bg-gray-200 hover:text-gray-900"
 						}`}
 					>
-						<span aria-hidden="true">📥</span>
+						<Inbox className="w-4 h-4" aria-hidden="true" />
 						<span>Inbox</span>
 						{groupedNotes.inbox.length > 0 && (
 							<span className="ml-auto text-xs bg-gray-200 text-gray-500 px-1.5 py-0.5 rounded-full">
@@ -100,7 +102,7 @@ export function LeftPaneNavigation({
 								: "text-gray-600 hover:bg-gray-200 hover:text-gray-900"
 						}`}
 					>
-						<span aria-hidden="true">📝</span>
+						<PenSquare className="w-4 h-4" aria-hidden="true" />
 						<span>Drafts</span>
 						{groupedNotes.drafts.length > 0 && (
 							<span className="ml-auto text-xs bg-gray-200 text-gray-500 px-1.5 py-0.5 rounded-full">
@@ -224,9 +226,10 @@ function DomainAccordionItem({
 								: "text-gray-500 hover:bg-gray-200 hover:text-gray-900"
 						}`}
 					>
-						<span aria-hidden="true" className="opacity-60 mr-1">
-							🌐
-						</span>
+						<Globe
+							className="w-3.5 h-3.5 opacity-60 mr-1"
+							aria-hidden="true"
+						/>
 						{domainName} 全体のノート
 					</Link>
 
@@ -259,9 +262,10 @@ function DomainAccordionItem({
 								}`}
 								title={url}
 							>
-								<span aria-hidden="true" className="opacity-60 mr-1">
-									📄
-								</span>
+								<FileText
+									className="w-3.5 h-3.5 opacity-60 mr-1"
+									aria-hidden="true"
+								/>
 								{path}
 							</Link>
 						);

--- a/apps/app/src/app/notes/_components/MiddlePaneList.tsx
+++ b/apps/app/src/app/notes/_components/MiddlePaneList.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
+import { ArrowLeft, Inbox, Info, AlertTriangle, Lightbulb, MapPin } from "lucide-react";
 import { getSafeUrl } from "@/utils/url";
 import type { Draft, Note } from "../types";
 
@@ -53,11 +54,20 @@ export function MiddlePaneList({
 	const getNoteTypeStyles = (type: string) => {
 		switch (type) {
 			case "alert":
-				return "bg-red-100 text-red-700";
+				return {
+					className: "bg-rose-50 text-rose-500",
+					Icon: AlertTriangle,
+				};
 			case "idea":
-				return "bg-yellow-100 text-yellow-700";
+				return {
+					className: "bg-amber-50 text-amber-500",
+					Icon: Lightbulb,
+				};
 			default:
-				return "bg-blue-100 text-blue-700";
+				return {
+					className: "bg-blue-50 text-blue-500",
+					Icon: Info,
+				};
 		}
 	};
 
@@ -80,7 +90,7 @@ export function MiddlePaneList({
 			<div className="flex-1 overflow-y-auto">
 				{!isSelected ? (
 					<div className="flex flex-col items-center justify-center h-full p-8 text-center text-gray-400">
-						<div className="text-4xl mb-4">👈</div>
+						<ArrowLeft className="w-10 h-10 mb-4 text-gray-300" aria-hidden="true" />
 						<p className="text-sm font-medium">
 							左のリストからカテゴリを選択してください
 						</p>
@@ -116,17 +126,23 @@ export function MiddlePaneList({
 									}`}
 								>
 									<div className="flex justify-between items-start mb-1">
-										<span
-											className={`text-[10px] uppercase font-bold px-1.5 py-0.5 rounded ${
-												isNote
-													? getNoteTypeStyles(item.note_type)
-													: "bg-purple-100 text-purple-700"
-											}`}
-										>
-											{isNote
-												? item.note_type
-												: item.target_platform || "draft"}
-										</span>
+										{isNote ? (
+											<span
+												className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase ${
+													getNoteTypeStyles(item.note_type).className
+												}`}
+											>
+												{(() => {
+													const { Icon } = getNoteTypeStyles(item.note_type);
+													return <Icon className="w-3.5 h-3.5" aria-hidden="true" />;
+												})()}
+												{item.note_type}
+											</span>
+										) : (
+											<span className="bg-purple-50 text-purple-500 px-2.5 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase">
+												{item.target_platform || "draft"}
+											</span>
+										)}
 										<span className="text-[10px] text-gray-400">
 											{formatDate(isNote ? item.created_at : item.updated_at)}
 										</span>
@@ -138,8 +154,8 @@ export function MiddlePaneList({
 										{isNote ? item.content : item.content}
 									</p>
 									{isNote && item.scope === "exact" && !currentExact && (
-										<div className="mt-2 text-[10px] text-gray-400 truncate">
-											📍{" "}
+										<div className="mt-2 text-[10px] text-gray-400 truncate flex items-center gap-1">
+											<MapPin className="w-3 h-3" aria-hidden="true" />
 											{getSafeUrl(item.url_pattern)?.pathname ??
 												item.url_pattern}
 										</div>
@@ -149,9 +165,12 @@ export function MiddlePaneList({
 						})}
 					</div>
 				) : (
-					<div className="flex flex-col items-center justify-center h-64 p-8 text-center">
-						<div className="text-4xl mb-4">📭</div>
-						<p className="text-gray-500 text-sm">
+					<div className="flex flex-col items-center justify-center h-64 p-8 text-center text-gray-400">
+						<Inbox
+							className="w-12 h-12 mb-4 text-gray-200"
+							aria-hidden="true"
+						/>
+						<p className="text-sm">
 							No {currentView === "drafts" ? "drafts" : "notes"} found for this
 							category.
 						</p>

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -3,6 +3,7 @@
 import type { Draft, Note } from "../types";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { MousePointerClick, Pencil, Pin, Star, Info, AlertTriangle, Lightbulb } from "lucide-react";
 import TextareaAutosize from "react-textarea-autosize";
 import { createClient } from "@/utils/supabase/client";
 
@@ -27,11 +28,12 @@ export function RightPaneDetail({ note, draft }: Props) {
 
 	if (!note && !draft) {
 		return (
-			<div className="flex-1 flex flex-col items-center justify-center bg-gray-50 text-gray-500 p-8">
-				<div className="text-6xl mb-6 animate-pulse" aria-hidden="true">
-					👈
-				</div>
-				<p className="text-lg font-medium text-gray-400">
+			<div className="flex-1 flex flex-col items-center justify-center bg-gray-50 text-gray-400 p-8">
+				<MousePointerClick
+					className="w-12 h-12 text-gray-300 mb-6 animate-pulse"
+					aria-hidden="true"
+				/>
+				<p className="text-lg font-medium">
 					左のリストからノートまたはドラフトを選択してください
 				</p>
 			</div>
@@ -102,18 +104,25 @@ export function RightPaneDetail({ note, draft }: Props) {
 						<div className="flex items-center gap-2">
 							{note ? (
 								<span
-									className={`text-xs uppercase font-bold px-2 py-0.5 rounded ${
+									className={`flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase ${
 										note.note_type === "alert"
-											? "bg-red-100 text-red-700"
+											? "bg-rose-50 text-rose-500"
 											: note.note_type === "idea"
-												? "bg-yellow-100 text-yellow-700"
-												: "bg-blue-100 text-blue-700"
+												? "bg-amber-50 text-amber-500"
+												: "bg-blue-50 text-blue-500"
 									}`}
 								>
+									{note.note_type === "alert" ? (
+										<AlertTriangle className="w-3.5 h-3.5" aria-hidden="true" />
+									) : note.note_type === "idea" ? (
+										<Lightbulb className="w-3.5 h-3.5" aria-hidden="true" />
+									) : (
+										<Info className="w-3.5 h-3.5" aria-hidden="true" />
+									)}
 									{note.note_type}
 								</span>
 							) : (
-								<span className="text-xs uppercase font-bold px-2 py-0.5 rounded bg-purple-100 text-purple-700">
+								<span className="bg-purple-50 text-purple-500 px-2.5 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase">
 									{draft?.target_platform || "Draft"}
 								</span>
 							)}
@@ -127,11 +136,9 @@ export function RightPaneDetail({ note, draft }: Props) {
 							<button
 								type="button"
 								onClick={handleEdit}
-								className="text-xs font-medium px-3 py-1.5 rounded-md bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 hover:text-gray-900 transition-colors flex items-center gap-1.5"
+								className="px-3 py-1.5 bg-neutral-900 text-white text-sm font-medium rounded-md hover:bg-neutral-800 transition-colors flex items-center gap-1.5"
 							>
-								<span aria-hidden="true" className="text-sm">
-									✏️
-								</span>
+								<Pencil className="w-3.5 h-3.5" aria-hidden="true" />
 								Edit
 							</button>
 						)}
@@ -140,7 +147,7 @@ export function RightPaneDetail({ note, draft }: Props) {
 								<button
 									type="button"
 									onClick={handleCancel}
-									className="text-xs font-medium px-3 py-1.5 rounded-md hover:bg-gray-100 text-gray-600 transition-colors"
+									className="text-sm font-medium px-3 py-1.5 rounded-md text-neutral-500 hover:text-neutral-900 transition-colors"
 									disabled={isSaving}
 								>
 									Cancel
@@ -148,7 +155,7 @@ export function RightPaneDetail({ note, draft }: Props) {
 								<button
 									type="button"
 									onClick={handleSave}
-									className="text-xs font-medium px-4 py-1.5 rounded-md bg-neutral-900 text-white hover:bg-neutral-800 transition-colors disabled:opacity-50"
+									className="px-3 py-1.5 bg-neutral-900 text-white text-sm font-medium rounded-md hover:bg-neutral-800 transition-colors disabled:opacity-50"
 									disabled={isSaving}
 								>
 									{isSaving ? "Saving..." : "Save"}
@@ -157,24 +164,20 @@ export function RightPaneDetail({ note, draft }: Props) {
 						)}
 						<div className="flex gap-2 ml-2">
 							{note?.is_pinned && (
-								<span
-									role="img"
-									className="text-xl"
-									title="Pinned"
-									aria-label="Pinned"
-								>
-									📌
-								</span>
+								<div title="Pinned">
+									<Pin
+										className="w-4 h-4 fill-current text-neutral-800"
+										aria-label="Pinned"
+									/>
+								</div>
 							)}
 							{note?.is_favorite && (
-								<span
-									role="img"
-									className="text-xl"
-									title="Favorite"
-									aria-label="Favorite"
-								>
-									⭐
-								</span>
+								<div title="Favorite">
+									<Star
+										className="w-4 h-4 fill-current text-amber-400"
+										aria-label="Favorite"
+									/>
+								</div>
 							)}
 						</div>
 					</div>
@@ -188,7 +191,7 @@ export function RightPaneDetail({ note, draft }: Props) {
 					</div>
 				)}
 
-				{note && (
+				{note && note.scope !== "inbox" && (
 					<div className="mb-10">
 						<div className="text-sm text-gray-400 mb-2 uppercase tracking-tight font-medium">
 							Source URL

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.93.1",
+        "lucide-react": "^1.7.0",
         "next": "^16.1.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -1380,7 +1381,7 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
+    "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -2187,6 +2188,8 @@
     "router/path-to-regexp": ["path-to-regexp@8.4.1", "", {}, "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw=="],
 
     "sitecue-extension/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+
+    "sitecue-extension/lucide-react": ["lucide-react@0.563.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 


### PR DESCRIPTION
Why:
- To provide a consistent, seamless user experience across the Chrome extension and the web dashboard.
- To establish a unified design language by replacing legacy emojis with a standard icon set and matching color palettes.

What:
- Installed `lucide-react` in `apps/app` and replaced emojis with accessible icons (`aria-hidden="true"`).
- Synchronized note type badges (Info, Alert, Idea) to match the extension's colors, rounded corners, and icons.
- Updated action buttons (Edit, Save, Cancel) to a premium, black-based (`neutral-900`) styling.
- Hid the invalid "SOURCE URL" section for notes categorized under the `inbox` scope.