### PR TITLE
feat(launchpad): upgrade root page to base camp with pinned sites and…

### DIFF
--- a/apps/app/src/app/_actions/pinned-sites.ts
+++ b/apps/app/src/app/_actions/pinned-sites.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/utils/supabase/server";
+
+export async function addPinnedSite(formData: FormData) {
+	const supabase = await createClient();
+	const title = formData.get("title") as string;
+	const url = formData.get("url") as string;
+
+	if (!title || !url) {
+		throw new Error("Title and URL are required");
+	}
+
+	const { error } = await supabase
+		.from("sitecue_pinned_sites")
+		.insert([{ title, url }]);
+
+	if (error) {
+		console.error("Error adding pinned site:", error);
+		throw new Error("Failed to add pinned site");
+	}
+
+	revalidatePath("/");
+}
+
+export async function deletePinnedSite(id: string) {
+	const supabase = await createClient();
+
+	const { error } = await supabase
+		.from("sitecue_pinned_sites")
+		.delete()
+		.eq("id", id);
+
+	if (error) {
+		console.error("Error deleting pinned site:", error);
+		throw new Error("Failed to delete pinned site");
+	}
+
+	revalidatePath("/");
+}

--- a/apps/app/src/app/_components/PinnedSitesManager.test.tsx
+++ b/apps/app/src/app/_components/PinnedSitesManager.test.tsx
@@ -1,0 +1,28 @@
+/** @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PinnedSitesManager } from "./PinnedSitesManager";
+
+// Mock server actions to avoid import issues in limited test
+vi.mock("../_actions/pinned-sites", () => ({
+	addPinnedSite: vi.fn(),
+	deletePinnedSite: vi.fn(),
+}));
+
+const mockSites = [
+	{
+		id: "1",
+		title: "Google",
+		url: "https://google.com",
+		user_id: "user1",
+		created_at: new Date().toISOString(),
+	},
+];
+
+describe("PinnedSitesManager (Rendering only)", () => {
+	it("renders initial sites correctly", () => {
+		render(<PinnedSitesManager initialSites={mockSites} />);
+		expect(screen.getByText("Google")).toBeDefined();
+		expect(screen.getByText("google.com")).toBeDefined();
+	});
+});

--- a/apps/app/src/app/_components/PinnedSitesManager.tsx
+++ b/apps/app/src/app/_components/PinnedSitesManager.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { ExternalLink, Plus, Trash2, X } from "lucide-react";
+import { useOptimistic, useState, useTransition } from "react";
+import type { PinnedSite } from "../../../../../types/app";
+import { addPinnedSite, deletePinnedSite } from "../_actions/pinned-sites";
+
+interface PinnedSitesManagerProps {
+	initialSites: PinnedSite[];
+}
+
+export function PinnedSitesManager({ initialSites }: PinnedSitesManagerProps) {
+	const [isAdding, setIsAdding] = useState(false);
+	const [isPending, startTransition] = useTransition();
+	const [optimisticSites, addOptimisticAction] = useOptimistic<
+		PinnedSite[],
+		{ type: "add"; site: PinnedSite } | { type: "delete"; id: string }
+	>(initialSites, (state, action) => {
+		if (action.type === "add") {
+			return [action.site, ...state];
+		}
+		if (action.type === "delete") {
+			return state.filter((s) => s.id !== action.id);
+		}
+		return state;
+	});
+
+	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		const formData = new FormData(e.currentTarget);
+		const title = formData.get("title") as string;
+		const url = formData.get("url") as string;
+
+		if (!title || !url) return;
+
+		const tempId = Math.random().toString();
+		const newSite: PinnedSite = {
+			id: tempId,
+			title,
+			url,
+			user_id: "",
+			created_at: new Date().toISOString(),
+		};
+
+		startTransition(async () => {
+			addOptimisticAction({ type: "add", site: newSite });
+			setIsAdding(false);
+			try {
+				await addPinnedSite(formData);
+			} catch (error) {
+				console.error("Failed to add pinned site:", error);
+			}
+		});
+	};
+
+	const handleDelete = async (id: string) => {
+		startTransition(async () => {
+			addOptimisticAction({ type: "delete", id });
+			try {
+				await deletePinnedSite(id);
+			} catch (error) {
+				console.error("Failed to delete pinned site:", error);
+			}
+		});
+	};
+
+	const getHostname = (url: string) => {
+		try {
+			return new URL(url).hostname;
+		} catch {
+			return url;
+		}
+	};
+
+	return (
+		<section className="mb-16">
+			<div className="mb-8 flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<span className="text-xl">📌</span>
+					<h2 className="text-lg font-semibold text-neutral-800">
+						Pinned Sites
+					</h2>
+				</div>
+				<button
+					type="button"
+					onClick={() => setIsAdding(!isAdding)}
+					className="flex items-center gap-1 text-sm font-medium text-neutral-500 hover:text-neutral-900 transition-colors cursor-pointer"
+					aria-label={isAdding ? "Close add form" : "Add pinned site"}
+				>
+					{isAdding ? (
+						<>
+							<X className="w-4 h-4" /> Cancel
+						</>
+					) : (
+						<>
+							<Plus className="w-4 h-4" /> Add Site
+						</>
+					)}
+				</button>
+			</div>
+
+			{isAdding && (
+				<form
+					onSubmit={handleSubmit}
+					className="mb-8 p-6 rounded-2xl border border-neutral-200 bg-white shadow-sm animate-in fade-in slide-in-from-top-2 duration-200"
+				>
+					<div className="grid gap-4 sm:grid-cols-2">
+						<div className="space-y-2">
+							<label
+								htmlFor="title"
+								className="text-xs font-semibold text-neutral-500 uppercase tracking-wider"
+							>
+								Title
+							</label>
+							<input
+								type="text"
+								id="title"
+								name="title"
+								required
+								placeholder="e.g. My Blog"
+								className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-neutral-900 transition-shadow"
+							/>
+						</div>
+						<div className="space-y-2">
+							<label
+								htmlFor="url"
+								className="text-xs font-semibold text-neutral-500 uppercase tracking-wider"
+							>
+								URL
+							</label>
+							<input
+								type="url"
+								id="url"
+								name="url"
+								required
+								placeholder="https://example.com"
+								className="w-full rounded-lg border border-neutral-200 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-neutral-900 transition-shadow"
+							/>
+						</div>
+					</div>
+					<div className="mt-6 flex justify-end">
+						<button
+							type="submit"
+							disabled={isPending}
+							className="rounded-full bg-neutral-900 px-6 py-2 text-sm font-semibold text-white transition-all hover:bg-neutral-500 disabled:opacity-50 cursor-pointer"
+						>
+							{isPending ? "Adding..." : "Add Pinned Site"}
+						</button>
+					</div>
+				</form>
+			)}
+
+			<div className="grid gap-4 grid-cols-2 sm:grid-cols-4 lg:grid-cols-5">
+				{optimisticSites.length === 0 && !isAdding && (
+					<div className="col-span-full py-12 flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-neutral-100 bg-neutral-50/50">
+						<p className="text-sm text-neutral-400 italic">
+							No pinned sites yet. Add your favorite tools or references here.
+						</p>
+					</div>
+				)}
+				{optimisticSites.map((site) => (
+					<div
+						key={site.id}
+						className="group relative flex flex-col justify-between rounded-xl border border-neutral-200 bg-white p-4 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900"
+					>
+						<div className="mb-3 flex items-start justify-between">
+							<div className="rounded-lg bg-neutral-50 p-2 group-hover:bg-neutral-100 transition-colors">
+								<ExternalLink className="w-4 h-4 text-neutral-600" />
+							</div>
+							<button
+								type="button"
+								onClick={() => handleDelete(site.id)}
+								disabled={isPending}
+								className="opacity-0 group-hover:opacity-100 p-1 text-neutral-400 hover:text-red-600 transition-all cursor-pointer"
+								title="Delete"
+							>
+								<Trash2 className="w-4 h-4" />
+							</button>
+						</div>
+						<a
+							href={site.url}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="block cursor-pointer outline-none"
+						>
+							<h3 className="font-bold text-neutral-900 line-clamp-1 group-hover:underline">
+								{site.title}
+							</h3>
+							<p className="mt-1 text-xs text-neutral-500 truncate">
+								{getHostname(site.url)}
+							</p>
+						</a>
+					</div>
+				))}
+			</div>
+		</section>
+	);
+}

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -1,7 +1,38 @@
-import { BookOpen, FileText, Library, MessageSquareText } from "lucide-react";
+import {
+	ArrowRight,
+	BookOpen,
+	Calendar,
+	FileText,
+	Library,
+	MessageSquareText,
+} from "lucide-react";
 import Link from "next/link";
+import { createClient } from "@/utils/supabase/server";
+import type { PinnedSite } from "../../../../types/app";
+import { PinnedSitesManager } from "./_components/PinnedSitesManager";
 
-export default function LaunchpadPage() {
+export default async function LaunchpadPage() {
+	const supabase = await createClient();
+
+	const [
+		{ count: notesCount },
+		{ count: draftsCount },
+		{ data: recentDrafts },
+		{ data: pinnedSites },
+	] = await Promise.all([
+		supabase.from("sitecue_notes").select("*", { count: "exact", head: true }),
+		supabase.from("sitecue_drafts").select("*", { count: "exact", head: true }),
+		supabase
+			.from("sitecue_drafts")
+			.select("*")
+			.order("updated_at", { ascending: false })
+			.limit(5),
+		supabase
+			.from("sitecue_pinned_sites")
+			.select("*")
+			.order("created_at", { ascending: false }),
+	]);
+
 	return (
 		<div className="min-h-screen bg-neutral-50 text-neutral-950 font-sans">
 			<header className="border-b border-neutral-200 bg-white">
@@ -10,9 +41,11 @@ export default function LaunchpadPage() {
 						<h1 className="text-3xl font-bold tracking-tight">
 							sitecue base camp
 						</h1>
-						<p className="mt-2 text-neutral-500">
-							Cultivate your thoughts right from here.
-						</p>
+						<div className="mt-2 flex items-center gap-2 text-sm text-neutral-500 font-medium">
+							<span>Total Notes: {notesCount ?? 0}</span>
+							<span className="text-neutral-300">|</span>
+							<span>Total Drafts: {draftsCount ?? 0}</span>
+						</div>
 					</div>
 					<nav className="flex items-center gap-6">
 						<Link
@@ -38,6 +71,11 @@ export default function LaunchpadPage() {
 			</header>
 
 			<main className="mx-auto max-w-5xl px-6 py-12">
+				{/* Pinned Sites */}
+				<PinnedSitesManager
+					initialSites={(pinnedSites as PinnedSite[]) ?? []}
+				/>
+
 				{/* Launchpad Section */}
 				<section className="mb-16">
 					<div className="mb-8 flex items-center gap-2">
@@ -46,115 +84,121 @@ export default function LaunchpadPage() {
 							Quick Start
 						</h2>
 					</div>
-					<div className="grid gap-6 sm:grid-cols-3">
+					<div className="grid gap-6 sm:grid-cols-4">
 						<Link
 							href="/studio/new?target=x"
-							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-8 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900 cursor-pointer"
+							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-6 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900 cursor-pointer"
 						>
-							<div className="mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-50 transition-colors group-hover:bg-neutral-100">
-								<MessageSquareText className="w-6 h-6 text-neutral-600" />
+							<div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-neutral-50 transition-colors group-hover:bg-neutral-100">
+								<MessageSquareText className="w-5 h-5 text-neutral-600" />
 							</div>
-							<h3 className="mb-2 font-bold text-neutral-900">X (Twitter)</h3>
-							<p className="text-sm text-neutral-500">
+							<h3 className="mb-1 font-bold text-neutral-900">X (Twitter)</h3>
+							<p className="text-xs text-neutral-500 line-clamp-2">
 								Save your sudden ideas as drafts for X.
 							</p>
-							<div className="mt-6 flex items-center text-xs font-semibold text-neutral-400 group-hover:text-neutral-900">
-								Start Creating{" "}
-								<span className="ml-1 transition-transform group-hover:translate-x-1">
-									→
-								</span>
-							</div>
 						</Link>
 
 						<Link
 							href="/studio/new?target=zenn"
-							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-8 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900 cursor-pointer"
+							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-6 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900 cursor-pointer"
 						>
-							<div className="mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-50 transition-colors group-hover:bg-neutral-100">
-								<BookOpen className="w-6 h-6 text-neutral-600" />
+							<div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-neutral-50 transition-colors group-hover:bg-neutral-100">
+								<BookOpen className="w-5 h-5 text-neutral-600" />
 							</div>
-							<h3 className="mb-2 font-bold text-neutral-900">Zenn</h3>
-							<p className="text-sm text-neutral-500">
+							<h3 className="mb-1 font-bold text-neutral-900">Zenn</h3>
+							<p className="text-xs text-neutral-500 line-clamp-2">
 								Draft and organize your technical articles for Zenn.
 							</p>
-							<div className="mt-6 flex items-center text-xs font-semibold text-neutral-400 group-hover:text-neutral-900">
-								Start Writing{" "}
-								<span className="ml-1 transition-transform group-hover:translate-x-1">
-									→
-								</span>
-							</div>
 						</Link>
 
 						<Link
 							href="/studio/new?target=generic"
-							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-8 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900 cursor-pointer"
+							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-6 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900 cursor-pointer"
 						>
-							<div className="mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-50 transition-colors group-hover:bg-neutral-100">
-								<FileText className="w-6 h-6 text-neutral-600" />
+							<div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-neutral-50 transition-colors group-hover:bg-neutral-100">
+								<FileText className="w-5 h-5 text-neutral-600" />
 							</div>
-							<h3 className="mb-2 font-bold text-neutral-900">Generic Note</h3>
-							<p className="text-sm text-neutral-500">
+							<h3 className="mb-1 font-bold text-neutral-900">Generic Note</h3>
+							<p className="text-xs text-neutral-500 line-clamp-2">
 								Free-form notes not limited to any specific platform.
 							</p>
-							<div className="mt-6 flex items-center text-xs font-semibold text-neutral-400 group-hover:text-neutral-900">
-								Create Note{" "}
-								<span className="ml-1 transition-transform group-hover:translate-x-1">
-									→
-								</span>
-							</div>
 						</Link>
 
 						<Link
 							href="/notes"
-							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-8 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900 cursor-pointer"
+							className="group relative flex flex-col items-start rounded-2xl border border-neutral-200 bg-white p-6 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900 cursor-pointer"
 						>
-							<div className="mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-neutral-50 transition-colors group-hover:bg-neutral-100">
-								<Library className="w-6 h-6 text-neutral-600" />
+							<div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-neutral-50 transition-colors group-hover:bg-neutral-100">
+								<Library className="w-5 h-5 text-neutral-600" />
 							</div>
-							<h3 className="mb-2 font-bold text-neutral-900">Manage Notes</h3>
-							<p className="text-sm text-neutral-500">
+							<h3 className="mb-1 font-bold text-neutral-900">Manage Notes</h3>
+							<p className="text-xs text-neutral-500 line-clamp-2">
 								View and organize all your created notes and drafts.
 							</p>
-							<div className="mt-6 flex items-center text-xs font-semibold text-neutral-400 group-hover:text-neutral-900">
-								Go to Dashboard{" "}
-								<span className="ml-1 transition-transform group-hover:translate-x-1">
-									→
-								</span>
-							</div>
 						</Link>
 					</div>
 				</section>
 
-				{/* Stats section (Placeholder) */}
-				<section>
-					<div className="mb-8 flex items-center gap-2">
-						<span className="text-xl">📊</span>
-						<h2 className="text-lg font-semibold text-neutral-800">Activity</h2>
+				{/* Recent Drafts Section */}
+				<section className="mb-16">
+					<div className="mb-8 flex items-center justify-between">
+						<div className="flex items-center gap-2">
+							<span className="text-xl">✍️</span>
+							<h2 className="text-lg font-semibold text-neutral-800">
+								Recent Drafts
+							</h2>
+						</div>
+						<Link
+							href="/notes?domain=draft"
+							className="text-sm font-medium text-neutral-400 hover:text-neutral-900 transition-colors"
+						>
+							View all drafts
+						</Link>
 					</div>
-					<div className="grid gap-6 rounded-2xl border border-neutral-200 bg-white p-10 sm:grid-cols-3">
-						<div className="flex flex-col">
-							<span className="mb-1 text-sm font-medium text-neutral-400 uppercase tracking-tight">
-								Total Notes
-							</span>
-							<span className="text-4xl font-bold text-neutral-900">--</span>
-						</div>
-						<div className="flex flex-col">
-							<span className="mb-1 text-sm font-medium text-neutral-400 uppercase tracking-tight">
-								Weekly Drafts
-							</span>
-							<span className="text-4xl font-bold text-neutral-900">--</span>
-						</div>
-						<div className="flex flex-col">
-							<span className="mb-1 text-sm font-medium text-neutral-400 uppercase tracking-tight">
-								Published Items
-							</span>
-							<span className="text-4xl font-bold text-neutral-900">--</span>
-						</div>
-					</div>
-					<div className="mt-8 flex items-center justify-center rounded-2xl border-2 border-dashed border-neutral-100 py-12">
-						<p className="text-sm text-neutral-400 italic">
-							Statistics will appear here as your activity data grows.
-						</p>
+
+					<div className="grid gap-4">
+						{(!recentDrafts || recentDrafts.length === 0) && (
+							<div className="py-12 flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-neutral-100 bg-neutral-50/50">
+								<p className="text-sm text-neutral-400 italic">
+									No drafts yet. Start writing something to see them here.
+								</p>
+							</div>
+						)}
+						{recentDrafts?.map((draft) => (
+							<Link
+								key={draft.id}
+								href={`/studio/${draft.id}`}
+								className="group flex items-center justify-between rounded-xl border border-neutral-200 bg-white p-4 transition-all hover:border-neutral-900 hover:ring-1 hover:ring-neutral-900"
+							>
+								<div className="flex items-center gap-4">
+									<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-neutral-50 text-neutral-600 transition-colors group-hover:bg-neutral-100">
+										{draft.target_platform === "x" ? (
+											<MessageSquareText className="w-5 h-5" />
+										) : draft.target_platform === "zenn" ? (
+											<BookOpen className="w-5 h-5" />
+										) : (
+											<FileText className="w-5 h-5" />
+										)}
+									</div>
+									<div>
+										<h3 className="font-bold text-neutral-900">
+											{draft.title || "Untitled Draft"}
+										</h3>
+										<div className="mt-1 flex items-center gap-2 text-xs text-neutral-400">
+											<span className="capitalize">
+												{draft.target_platform}
+											</span>
+											<span>•</span>
+											<span className="flex items-center gap-1">
+												<Calendar className="w-3 h-3" />
+												{new Date(draft.updated_at).toLocaleDateString()}
+											</span>
+										</div>
+									</div>
+								</div>
+								<ArrowRight className="w-5 h-5 text-neutral-300 transition-transform group-hover:translate-x-1 group-hover:text-neutral-900" />
+							</Link>
+						))}
 					</div>
 				</section>
 			</main>

--- a/apps/app/vitest.setup.ts
+++ b/apps/app/vitest.setup.ts
@@ -1,4 +1,9 @@
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { expect } from "vitest";
 import "@testing-library/jest-dom";
+expect.extend(matchers);
+
+import { cleanup } from "@testing-library/react";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, vi } from "vitest";
 import { handlers } from "./src/mocks/handlers";
@@ -37,6 +42,8 @@ const server = setupServer(...handlers);
 beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
 afterEach(() => {
 	server.resetHandlers();
+	cleanup();
 	vi.clearAllMocks();
 });
+
 afterAll(() => server.close());

--- a/supabase/migrations/20260409073355_add_pinned_sites.sql
+++ b/supabase/migrations/20260409073355_add_pinned_sites.sql
@@ -1,0 +1,33 @@
+create table "public"."sitecue_pinned_sites" (
+    "id" uuid not null default gen_random_uuid(),
+    "user_id" uuid not null default auth.uid(),
+    "title" text not null,
+    "url" text not null,
+    "created_at" timestamp with time zone not null default now()
+);
+
+alter table "public"."sitecue_pinned_sites" enable row level security;
+
+CREATE UNIQUE INDEX sitecue_pinned_sites_pkey ON public.sitecue_pinned_sites USING btree (id);
+
+alter table "public"."sitecue_pinned_sites" add constraint "sitecue_pinned_sites_pkey" PRIMARY KEY using index "sitecue_pinned_sites_pkey";
+
+alter table "public"."sitecue_pinned_sites" add constraint "sitecue_pinned_sites_user_id_fkey" FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+create policy "Users can view their own pinned sites"
+on "public"."sitecue_pinned_sites"
+for select
+to authenticated
+using ((auth.uid() = user_id));
+
+create policy "Users can insert their own pinned sites"
+on "public"."sitecue_pinned_sites"
+for insert
+to authenticated
+with check ((auth.uid() = user_id));
+
+create policy "Users can delete their own pinned sites"
+on "public"."sitecue_pinned_sites"
+for delete
+to authenticated
+using ((auth.uid() = user_id));

--- a/types/app.ts
+++ b/types/app.ts
@@ -21,3 +21,6 @@ export type Draft = Omit<
 		[key: string]: unknown;
 	} | null;
 };
+
+export type PinnedSite =
+	Database["public"]["Tables"]["sitecue_pinned_sites"]["Row"];

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -66,14 +66,14 @@ export type Database = {
 			};
 			sitecue_drafts: {
 				Row: {
-					id: string;
 					content: string | null;
+					created_at: string;
+					id: string;
 					metadata: Json | null;
 					target_platform: string;
 					title: string | null;
-					user_id: string;
-					created_at: string;
 					updated_at: string;
+					user_id: string;
 				};
 				Insert: {
 					content?: string | null;
@@ -131,6 +131,7 @@ export type Database = {
 				Row: {
 					content: string;
 					created_at: string;
+					draft_id: string | null;
 					id: string;
 					is_expanded: boolean;
 					is_favorite: boolean;
@@ -142,11 +143,11 @@ export type Database = {
 					updated_at: string;
 					url_pattern: string;
 					user_id: string;
-					draft_id: string | null;
 				};
 				Insert: {
 					content: string;
 					created_at?: string;
+					draft_id?: string | null;
 					id?: string;
 					is_expanded?: boolean;
 					is_favorite?: boolean;
@@ -158,11 +159,11 @@ export type Database = {
 					updated_at?: string;
 					url_pattern: string;
 					user_id: string;
-					draft_id?: string | null;
 				};
 				Update: {
 					content?: string;
 					created_at?: string;
+					draft_id?: string | null;
 					id?: string;
 					is_expanded?: boolean;
 					is_favorite?: boolean;
@@ -174,9 +175,16 @@ export type Database = {
 					updated_at?: string;
 					url_pattern?: string;
 					user_id?: string;
-					draft_id?: string | null;
 				};
-				Relationships: [];
+				Relationships: [
+					{
+						foreignKeyName: "sitecue_notes_draft_id_fkey";
+						columns: ["draft_id"];
+						isOneToOne: false;
+						referencedRelation: "sitecue_drafts";
+						referencedColumns: ["id"];
+					},
+				];
 			};
 			sitecue_page_contents: {
 				Row: {
@@ -197,6 +205,30 @@ export type Database = {
 					content?: string;
 					created_at?: string;
 					id?: string;
+					url?: string;
+					user_id?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_pinned_sites: {
+				Row: {
+					created_at: string;
+					id: string;
+					title: string;
+					url: string;
+					user_id: string;
+				};
+				Insert: {
+					created_at?: string;
+					id?: string;
+					title: string;
+					url: string;
+					user_id?: string;
+				};
+				Update: {
+					created_at?: string;
+					id?: string;
+					title?: string;
 					url?: string;
 					user_id?: string;
 				};


### PR DESCRIPTION
… activity stats

Why:
- The root dashboard (`/`) was previously a static page and needed to function as a dynamic "Base Camp" for information gathering and content creation.
- Displaying user activity (stats) and providing quick access to frequently used sites and recent drafts boosts user motivation and workflow efficiency.

What:
- Add `sitecue_pinned_sites` table via Supabase migration to store user-defined URL shortcuts with RLS policies.
- Implement a compact Activity Strip at the top of the page to display the total number of notes and drafts.
- Create `PinnedSitesManager` client component utilizing Next.js Server Actions and optimistic UI (`useOptimistic`) for instantaneous add/delete operations.
- Integrate a "Recent Drafts" section that fetches and displays the 5 most recently updated drafts for quick resumption of work.
- Refactor `apps/app/src/app/page.tsx` to fetch all initial data concurrently on the server side, ensuring a zero-flicker loading experience.