### PR TITLE
feat: apply custom theme and refine editor UI for a distraction-free …

### DIFF
--- a/apps/app/src/components/editor/NotesEditor.tsx
+++ b/apps/app/src/components/editor/NotesEditor.tsx
@@ -3,6 +3,7 @@
 import CodeMirror from "@uiw/react-codemirror";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { type EditorProps, editorExtensions } from "./EditorBase";
+import { sitecueTheme } from "./sitecueTheme";
 
 export const NotesEditor = ({
 	value,
@@ -13,12 +14,16 @@ export const NotesEditor = ({
 	useUnsavedChanges(isDirty);
 
 	return (
-		<div className="w-full border rounded-md border-neutral-300 focus-within:ring-2 focus-within:ring-blue-500 overflow-hidden bg-white">
+		<div className="w-full rounded-xl bg-neutral-50/50 focus-within:bg-white focus-within:shadow-sm border border-transparent focus-within:border-neutral-200 transition-all duration-200 p-6">
 			<CodeMirror
 				value={value}
 				onChange={onChange}
-				extensions={editorExtensions}
+				extensions={[...editorExtensions, sitecueTheme]}
 				placeholder={placeholder}
+				basicSetup={{
+					lineNumbers: false,
+					foldGutter: false,
+				}}
 				className="text-base"
 				theme="light"
 			/>

--- a/apps/app/src/components/editor/StudioEditor.tsx
+++ b/apps/app/src/components/editor/StudioEditor.tsx
@@ -3,6 +3,7 @@
 import CodeMirror from "@uiw/react-codemirror";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { type EditorProps, editorExtensions } from "./EditorBase";
+import { sitecueTheme } from "./sitecueTheme";
 
 export const StudioEditor = ({
 	value,
@@ -13,12 +14,16 @@ export const StudioEditor = ({
 	useUnsavedChanges(isDirty);
 
 	return (
-		<div className="w-full border rounded-md border-neutral-300 focus-within:ring-2 focus-within:ring-blue-500 overflow-hidden bg-white">
+		<div className="w-full rounded-xl bg-neutral-50/50 focus-within:bg-white focus-within:shadow-sm border border-transparent focus-within:border-neutral-200 transition-all duration-200 p-6">
 			<CodeMirror
 				value={value}
 				onChange={onChange}
-				extensions={editorExtensions}
+				extensions={[...editorExtensions, sitecueTheme]}
 				placeholder={placeholder}
+				basicSetup={{
+					lineNumbers: false,
+					foldGutter: false,
+				}}
 				className="text-base"
 				theme="light"
 			/>

--- a/apps/app/src/components/editor/sitecueTheme.ts
+++ b/apps/app/src/components/editor/sitecueTheme.ts
@@ -1,0 +1,35 @@
+import { EditorView } from "@uiw/react-codemirror";
+
+export const sitecueTheme = EditorView.theme({
+	"&": {
+		color: "#262626", // text-neutral-800相当
+		backgroundColor: "transparent",
+	},
+	"&.cm-focused": {
+		outline: "none", // デフォルトのアウトラインを消去
+	},
+	".cm-content": {
+		caretColor: "#171717", // text-neutral-900相当
+		fontFamily: "inherit",
+		padding: "0", // 外側のラッパーでpaddingを取るため内部は0
+	},
+	".cm-content span": {
+		textDecoration: "none !important",
+		borderBottom: "none !important",
+	},
+	".cm-cursor, .cm-dropCursor": {
+		borderLeftColor: "#171717",
+		borderLeftWidth: "2px",
+	},
+	"&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
+		{
+			backgroundColor: "#e5e5e5", // bg-neutral-200相当の柔らかな選択色
+		},
+	".cm-activeLine": {
+		backgroundColor: "transparent", // アクティブ行のハイライトを消去
+	},
+	".cm-scroller": {
+		fontFamily: "inherit",
+		lineHeight: "1.75", // leading-relaxed相当
+	},
+});


### PR DESCRIPTION
…experience

Why:
- The default CodeMirror styles (e.g., blue focus rings, line numbers, active line highlights, and markdown heading underlines) made the editor look too much like a developer tool.
- To align with sitecue's core concept of a simple, immersive, and plain notepad, these visual noises needed to be completely removed.

What:
- Created `sitecueTheme.ts` to customize text/cursor colors and remove default outlines, active line backgrounds, and markdown heading borders.
- Updated `NotesEditor` and `StudioEditor` wrapper components with Tailwind classes to add generous padding (`p-6`) and soft focus transitions (`bg-white`, `shadow-sm`, `border-neutral-200`).
- Disabled `lineNumbers` and `foldGutter` globally in the CodeMirror `basicSetup` configuration.