### PR TITLE
feat(notes): refine UX for note deletion and metadata editing

### DIFF
--- a/apps/app/src/app/notes/_components/RightPaneDetail.test.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.test.tsx
@@ -13,7 +13,18 @@ import {
 	vi,
 } from "vitest";
 import { createClient } from "@/utils/supabase/client";
+import type { Note } from "../types";
 import { RightPaneDetail } from "./RightPaneDetail";
+
+// Define mock type to avoid 'any'
+type SupabaseMock = {
+	from: Mock;
+	update: Mock;
+	delete: Mock;
+	eq: Mock;
+};
+
+type Mock = ReturnType<typeof vi.fn>;
 
 // Mock note data
 const mockNote = {
@@ -34,14 +45,17 @@ const mockNote = {
 };
 
 // Next.js useRouter mock (already in setup.ts but redefining for clarity/specifics)
+// Next.js useRouter mock
 const refreshMock = vi.fn();
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
 vi.mock("next/navigation", () => ({
 	useRouter: () => ({
 		refresh: refreshMock,
-		push: vi.fn(),
-		replace: vi.fn(),
+		push: pushMock,
+		replace: replaceMock,
 	}),
-	useSearchParams: () => new URLSearchParams(),
+	useSearchParams: () => new URLSearchParams("filter=all&sort=newest"),
 }));
 
 // Supabase client mock to trigger fetch-based MSW interception
@@ -54,7 +68,7 @@ vi.mock("@/utils/supabase/client", () => ({
 const server = setupServer();
 
 describe("RightPaneDetail Component Phase 1 Improvements", () => {
-	let supabaseMock: any;
+	let supabaseMock: SupabaseMock;
 
 	beforeAll(() => server.listen());
 	afterEach(() => {
@@ -69,29 +83,35 @@ describe("RightPaneDetail Component Phase 1 Improvements", () => {
 		supabaseMock = {
 			from: vi.fn().mockReturnThis(),
 			update: vi.fn().mockReturnThis(),
+			delete: vi.fn().mockReturnThis(),
 			eq: vi.fn().mockResolvedValue({ error: null }),
-		};
-		(createClient as any).mockReturnValue(supabaseMock);
+		} as unknown as SupabaseMock;
+		vi.mocked(createClient).mockReturnValue(
+			supabaseMock as unknown as ReturnType<typeof createClient>,
+		);
 
 		// Minimal MSW handler to satisfy network rules even if we use mocks for logic
 		server.use(
 			http.patch("*/rest/v1/sitecue_notes*", () => {
 				return HttpResponse.json({ success: true });
 			}),
+			http.delete("*/rest/v1/sitecue_notes*", () => {
+				return HttpResponse.json({ success: true });
+			}),
 		);
 	});
 
-	it("should display 'Page' instead of 'exact' in the scope part/popover", async () => {
+	it("should NOT display Scope selection heading in the popover (removed in Phase 2.5)", async () => {
 		const user = userEvent.setup();
 		render(<RightPaneDetail note={mockNote as unknown as Note} />);
 
-		// Open popover to see scope options
+		// Open popover
 		const moreButton = screen.getByLabelText(/more options/i);
 		await user.click(moreButton);
 
-		// Check for "page" text (will be capitalized by CSS, but the DOM text is "page")
-		const pageLabel = await screen.findByText("page");
-		expect(pageLabel).toBeInTheDocument();
+		// Check that "Scope" label (the heading) is NOT present
+		// We use a exact match to avoid matching "Edit Scope/URL" button
+		expect(screen.queryByText(/^Scope$/i)).not.toBeInTheDocument();
 	});
 
 	it("should toggle pin status when Pin button is clicked", async () => {
@@ -146,7 +166,163 @@ describe("RightPaneDetail Component Phase 1 Improvements", () => {
 		await screen.findByRole("button", {
 			name: /Copy Source URL/i,
 		});
-		// Since we swap the icon, we can check if the button contains a check icon
-		// (Simplified check as finding specific SVGs is hard, but findByText/Role works)
+	});
+
+	it("should show delete confirmation dialog and handle deletion", async () => {
+		const user = userEvent.setup();
+		render(<RightPaneDetail note={mockNote as unknown as Note} />);
+
+		// Open popover
+		const moreButton = screen.getByLabelText(/more options/i);
+		await user.click(moreButton);
+
+		// Click Delete Note
+		const deleteButton = screen.getByText(/Delete Note/i);
+		await user.click(deleteButton);
+
+		// Verify dialog is shown
+		expect(screen.getByText(/Are you absolutely sure/i)).toBeInTheDocument();
+
+		// Click Confirm Delete
+		const confirmButton = screen.getByRole("button", { name: /^Delete$/ });
+		await user.click(confirmButton);
+
+		// Verify deletion call
+		expect(supabaseMock.from).toHaveBeenCalledWith("sitecue_notes");
+		expect(supabaseMock.delete).toHaveBeenCalled();
+		// Should maintain other params but remove noteId
+		expect(replaceMock).toHaveBeenCalledWith("/notes?filter=all&sort=newest");
+		expect(refreshMock).toHaveBeenCalled();
+	});
+
+	it("should show edit metadata dialog and handle updates", async () => {
+		const user = userEvent.setup();
+		render(<RightPaneDetail note={mockNote as unknown as Note} />);
+
+		// Open popover
+		const moreButton = screen.getByLabelText(/more options/i);
+		await user.click(moreButton);
+
+		// Click Edit Scope/URL
+		const editButton = screen.getByText(/Edit Scope\/URL/i);
+		await user.click(editButton);
+
+		// Verify dialog is shown
+		expect(
+			await screen.findByText(/Edit Note Scope & URL/i),
+		).toBeInTheDocument();
+
+		// Update URL
+		const urlInput = await screen.findByLabelText(/Source URL/i);
+		await user.clear(urlInput);
+		await user.type(urlInput, "new-example.com");
+
+		// After clearing, scope defaults to Inbox. Select Page back.
+		const selectTrigger = screen.getByRole("combobox");
+		await user.click(selectTrigger);
+		const pageOption = await screen.findByRole("option", { name: /Page/i });
+		await user.click(pageOption);
+
+		// Click Save
+		const saveButton = screen.getByText(/Save changes/i);
+		await user.click(saveButton);
+
+		// Verify update call
+		expect(supabaseMock.from).toHaveBeenCalledWith("sitecue_notes");
+		expect(supabaseMock.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url_pattern: "new-example.com",
+			}),
+		);
+	});
+
+	it("should force Inbox scope and disable others when URL is empty", async () => {
+		const user = userEvent.setup();
+		render(<RightPaneDetail note={mockNote as unknown as Note} />);
+
+		// Open edit dialog
+		const moreButton = screen.getByLabelText(/more options/i);
+		await user.click(moreButton);
+		const editButton = screen.getByText(/Edit Scope\/URL/i);
+		await user.click(editButton);
+
+		// Clear URL
+		const urlInput = await screen.findByLabelText(/Source URL/i);
+		await user.clear(urlInput);
+
+		// Verify Scope is forced to Inbox (Value "inbox")
+		expect(await screen.findByText("Inbox")).toBeInTheDocument();
+
+		// Click Select Trigger to see options
+		const selectTrigger = screen.getByRole("combobox");
+		await user.click(selectTrigger);
+
+		// Base-UI/Radix uses data-disabled instead of aria-disabled
+		const pageOption = await screen.findByRole("option", { name: /Page/i });
+		const domainOption = await screen.findByRole("option", { name: /Domain/i });
+		expect(pageOption).toHaveAttribute("data-disabled");
+		expect(domainOption).toHaveAttribute("data-disabled");
+	});
+
+	it("should cleanse URL when saving with domain scope", async () => {
+		const user = userEvent.setup();
+		render(<RightPaneDetail note={mockNote as unknown as Note} />);
+
+		// Open edit dialog
+		const moreButton = screen.getByLabelText(/more options/i);
+		await user.click(moreButton);
+		const editButton = screen.getByText(/Edit Scope\/URL/i);
+		await user.click(editButton);
+
+		// Set URL to full path and Scope to Domain
+		const urlInput = await screen.findByLabelText(/Source URL/i);
+		await user.clear(urlInput);
+		await user.type(urlInput, "https://github.com/taikiwt/sitecue/issues/1");
+
+		const selectTrigger = screen.getByRole("combobox");
+		await user.click(selectTrigger);
+		const domainOption = await screen.findByRole("option", { name: /Domain/i });
+		await user.click(domainOption);
+
+		// Save
+		const saveButton = screen.getByText(/Save changes/i);
+		await user.click(saveButton);
+
+		// Verify that only the hostname was saved
+		expect(supabaseMock.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url_pattern: "github.com",
+				scope: "domain",
+			}),
+		);
+	});
+
+	it("should clear URL when saving with inbox scope", async () => {
+		const user = userEvent.setup();
+		render(<RightPaneDetail note={mockNote as unknown as Note} />);
+
+		// Open edit dialog
+		const moreButton = screen.getByLabelText(/more options/i);
+		await user.click(moreButton);
+		const editButton = screen.getByText(/Edit Scope\/URL/i);
+		await user.click(editButton);
+
+		// Set Scope to Inbox
+		const selectTrigger = screen.getByRole("combobox");
+		await user.click(selectTrigger);
+		const inboxOption = await screen.findByRole("option", { name: /Inbox/i });
+		await user.click(inboxOption);
+
+		// Save
+		const saveButton = screen.getByText(/Save changes/i);
+		await user.click(saveButton);
+
+		// Verify that URL was cleared
+		expect(supabaseMock.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url_pattern: "",
+				scope: "inbox",
+			}),
+		);
 	});
 });

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -14,15 +14,41 @@ import {
 	Pin,
 	Star,
 } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { NotesEditor } from "@/components/editor/NotesEditor";
 import MarkdownRenderer from "@/components/MarkdownRenderer";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
 	Popover,
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { createClient } from "@/utils/supabase/client";
 import type { Draft, Note } from "../types";
@@ -34,6 +60,7 @@ type Props = {
 
 export function RightPaneDetail({ note, draft }: Props) {
 	const router = useRouter();
+	const searchParams = useSearchParams();
 	const [isEditing, setIsEditing] = useState(false);
 	const [editContent, setEditContent] = useState("");
 	const [isSaving, setIsSaving] = useState(false);
@@ -55,6 +82,27 @@ export function RightPaneDetail({ note, draft }: Props) {
 		null,
 	);
 	const [isCopyingUrl, setIsCopyingUrl] = useState(false);
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+	const [isEditMetaDialogOpen, setIsEditMetaDialogOpen] = useState(false);
+	const [editUrl, setEditUrl] = useState(note?.url_pattern || "");
+	const [editScope, setEditScope] = useState<Note["scope"]>(
+		note?.scope || "inbox",
+	);
+
+	// Sync edit states when note changes
+	useEffect(() => {
+		if (note) {
+			setEditUrl(note.url_pattern || "");
+			setEditScope(note.scope || "inbox");
+		}
+	}, [note]);
+
+	// Force inbox scope if URL is empty
+	useEffect(() => {
+		if (editUrl === "" && editScope !== "inbox") {
+			setEditScope("inbox");
+		}
+	}, [editUrl, editScope]);
 
 	// Reset state when note or draft changes
 	useEffect(() => {
@@ -111,7 +159,7 @@ export function RightPaneDetail({ note, draft }: Props) {
 		optimisticNoteType !== null
 			? optimisticNoteType
 			: note?.note_type || "info";
-	const currentScope =
+	const _currentScope =
 		optimisticScope !== null ? optimisticScope : note?.scope || "inbox";
 	const currentPinned =
 		optimisticPinned !== null ? optimisticPinned : note?.is_pinned || false;
@@ -190,6 +238,67 @@ export function RightPaneDetail({ note, draft }: Props) {
 			if ("scope" in updates) setOptimisticScope(null);
 			if ("is_pinned" in updates) setOptimisticPinned(null);
 			if ("is_favorite" in updates) setOptimisticFavorite(null);
+		}
+	};
+
+	const handleDeleteNote = async () => {
+		if (!note) return;
+		setIsSaving(true);
+		try {
+			const supabase = createClient();
+			const { error } = await supabase
+				.from("sitecue_notes")
+				.delete()
+				.eq("id", note.id);
+			if (error) throw error;
+			setIsDeleteDialogOpen(false);
+
+			const params = new URLSearchParams(searchParams.toString());
+			params.delete("noteId");
+			router.replace(`/notes?${params.toString()}`);
+			router.refresh();
+		} catch (err) {
+			console.error("Failed to delete note:", err);
+			alert("Failed to delete the note.");
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	const handleSaveMeta = async () => {
+		if (!note) return;
+		setIsSaving(true);
+		try {
+			let finalUrl = editUrl;
+			if (editScope === "inbox") {
+				finalUrl = "";
+			} else if (editScope === "domain" && finalUrl) {
+				try {
+					const urlObj = new URL(
+						finalUrl.startsWith("http") ? finalUrl : `https://${finalUrl}`,
+					);
+					finalUrl = urlObj.hostname;
+				} catch (_e) {
+					// invalid URLの場合はそのままにする
+				}
+			}
+
+			const supabase = createClient();
+			const { error } = await supabase
+				.from("sitecue_notes")
+				.update({
+					url_pattern: finalUrl,
+					scope: editScope,
+				})
+				.eq("id", note.id);
+			if (error) throw error;
+			setIsEditMetaDialogOpen(false);
+			router.refresh();
+		} catch (err) {
+			console.error("Failed to save metadata:", err);
+			alert("Failed to save metadata.");
+		} finally {
+			setIsSaving(false);
 		}
 	};
 
@@ -330,35 +439,30 @@ export function RightPaneDetail({ note, draft }: Props) {
 												</div>
 											</div>
 
+
 											<div className="pt-2 border-t border-neutral-100">
 												<div className="text-[10px] font-bold text-neutral-400 uppercase tracking-widest mb-2 px-2">
-													Scope
+													Actions
 												</div>
 												<div className="flex flex-col gap-1">
-													{["inbox", "domain", "exact"].map((scope) => (
-														<button
-															key={scope}
-															type="button"
-															onClick={() =>
-																handleUpdateProperty({
-																	scope: scope as Note["scope"],
-																})
-															}
-															className={cn(
-																"flex items-center gap-2 w-full px-2 py-1.5 text-xs font-medium rounded-lg transition-colors cursor-pointer",
-																currentScope === scope
-																	? "bg-neutral-100 text-neutral-900"
-																	: "text-neutral-500 hover:bg-neutral-50 hover:text-neutral-900",
-															)}
-														>
-															<span className="capitalize">
-																{scope === "exact" ? "page" : scope}
-															</span>
-															{currentScope === scope && (
-																<Check className="w-3 h-3 ml-auto" />
-															)}
-														</button>
-													))}
+													<button
+														type="button"
+														onClick={() => {
+															setEditUrl(note?.url_pattern || "");
+															setEditScope(note?.scope || "inbox");
+															setIsEditMetaDialogOpen(true);
+														}}
+														className="flex items-center gap-2 w-full px-2 py-1.5 text-xs font-medium rounded-lg text-neutral-500 hover:bg-neutral-50 hover:text-neutral-900 transition-colors cursor-pointer"
+													>
+														Edit Scope/URL
+													</button>
+													<button
+														type="button"
+														onClick={() => setIsDeleteDialogOpen(true)}
+														className="flex items-center gap-2 w-full px-2 py-1.5 text-xs font-medium rounded-lg text-red-600 hover:bg-red-50 transition-colors cursor-pointer"
+													>
+														Delete Note
+													</button>
 												</div>
 											</div>
 										</div>
@@ -522,6 +626,106 @@ export function RightPaneDetail({ note, draft }: Props) {
 					</p>
 				</div>
 			</div>
+
+			<AlertDialog
+				open={isDeleteDialogOpen}
+				onOpenChange={setIsDeleteDialogOpen}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This action cannot be undone. This will permanently delete your
+							note and remove it from our servers.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel disabled={isSaving}>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={(e) => {
+								e.preventDefault();
+								handleDeleteNote();
+							}}
+							className="bg-red-600 hover:bg-red-700"
+							disabled={isSaving}
+						>
+							{isSaving ? "Deleting..." : "Delete"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<Dialog
+				open={isEditMetaDialogOpen}
+				onOpenChange={setIsEditMetaDialogOpen}
+			>
+				<DialogContent className="sm:max-w-[425px]">
+					<DialogHeader>
+						<DialogTitle>Edit Note Scope & URL</DialogTitle>
+					</DialogHeader>
+					<div className="grid gap-4 py-4">
+						<div className="grid items-center gap-2">
+							<Label htmlFor="url" className="text-xs font-bold uppercase">
+								Source URL
+							</Label>
+							<Input
+								id="url"
+								value={editUrl}
+								onChange={(e) => setEditUrl(e.target.value)}
+								placeholder="example.com/page"
+								className="col-span-3"
+								disabled={isSaving}
+							/>
+							<p className="text-[10px] text-neutral-400">
+								Leave empty to move this note to Inbox.
+							</p>
+						</div>
+						<div className="grid items-center gap-2">
+							<Label htmlFor="scope" className="text-xs font-bold uppercase">
+								Scope
+							</Label>
+							<Select
+								value={editScope}
+								onValueChange={(val: string | null) => {
+									if (val) setEditScope(val as Note["scope"]);
+								}}
+								disabled={isSaving}
+							>
+								<SelectTrigger className="w-full">
+									<SelectValue placeholder="Select scope" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="exact" disabled={editUrl === ""}>
+										Page
+									</SelectItem>
+									<SelectItem value="domain" disabled={editUrl === ""}>
+										Domain
+									</SelectItem>
+									<SelectItem value="inbox">Inbox</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+					</div>
+					<DialogFooter>
+						<button
+							type="button"
+							onClick={() => setIsEditMetaDialogOpen(false)}
+							className="px-4 py-2 text-sm font-medium text-neutral-500 hover:text-neutral-900 disabled:opacity-50"
+							disabled={isSaving}
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							onClick={handleSaveMeta}
+							className="px-4 py-2 bg-neutral-900 text-white text-sm font-medium rounded-md hover:bg-neutral-800 disabled:opacity-50"
+							disabled={isSaving}
+						>
+							{isSaving ? "Saving..." : "Save changes"}
+						</button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 }

--- a/apps/app/src/components/ui/alert-dialog.tsx
+++ b/apps/app/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+	return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+	return (
+		<AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+	);
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+	return (
+		<AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+	);
+}
+
+function AlertDialogOverlay({
+	className,
+	...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+	return (
+		<AlertDialogPrimitive.Backdrop
+			data-slot="alert-dialog-overlay"
+			className={cn(
+				"fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogContent({
+	className,
+	size = "default",
+	...props
+}: AlertDialogPrimitive.Popup.Props & {
+	size?: "default" | "sm";
+}) {
+	return (
+		<AlertDialogPortal>
+			<AlertDialogOverlay />
+			<AlertDialogPrimitive.Popup
+				data-slot="alert-dialog-content"
+				data-size={size}
+				className={cn(
+					"group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+					className,
+				)}
+				{...props}
+			/>
+		</AlertDialogPortal>
+	);
+}
+
+function AlertDialogHeader({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="alert-dialog-header"
+			className={cn(
+				"grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogFooter({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="alert-dialog-footer"
+			className={cn(
+				"-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogMedia({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="alert-dialog-media"
+			className={cn(
+				"mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+	return (
+		<AlertDialogPrimitive.Title
+			data-slot="alert-dialog-title"
+			className={cn(
+				"font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+	return (
+		<AlertDialogPrimitive.Description
+			data-slot="alert-dialog-description"
+			className={cn(
+				"text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogAction({
+	className,
+	...props
+}: React.ComponentProps<typeof Button>) {
+	return (
+		<Button
+			data-slot="alert-dialog-action"
+			className={cn(className)}
+			{...props}
+		/>
+	);
+}
+
+function AlertDialogCancel({
+	className,
+	variant = "outline",
+	size = "default",
+	...props
+}: AlertDialogPrimitive.Close.Props &
+	Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+	return (
+		<AlertDialogPrimitive.Close
+			data-slot="alert-dialog-cancel"
+			className={cn(className)}
+			render={<Button variant={variant} size={size} />}
+			{...props}
+		/>
+	);
+}
+
+export {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogMedia,
+	AlertDialogOverlay,
+	AlertDialogPortal,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+};

--- a/apps/app/src/components/ui/input.tsx
+++ b/apps/app/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import { Input as InputPrimitive } from "@base-ui/react/input";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+	return (
+		<InputPrimitive
+			type={type}
+			data-slot="input"
+			className={cn(
+				"h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Input };

--- a/apps/app/src/components/ui/label.tsx
+++ b/apps/app/src/components/ui/label.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+	return (
+		// biome-ignore lint/a11y/noLabelWithoutControl: This is a primitive component that receives its control via props
+		<label
+			data-slot="label"
+			className={cn(
+				"flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Label };

--- a/apps/app/src/components/ui/popover.tsx
+++ b/apps/app/src/components/ui/popover.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
-import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 function Popover({ ...props }: PopoverPrimitive.Root.Props) {

--- a/apps/app/src/components/ui/select.tsx
+++ b/apps/app/src/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+	return (
+		<SelectPrimitive.Group
+			data-slot="select-group"
+			className={cn("scroll-my-1 p-1", className)}
+			{...props}
+		/>
+	);
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+	return (
+		<SelectPrimitive.Value
+			data-slot="select-value"
+			className={cn("flex flex-1 text-left", className)}
+			{...props}
+		/>
+	);
+}
+
+function SelectTrigger({
+	className,
+	size = "default",
+	children,
+	...props
+}: SelectPrimitive.Trigger.Props & {
+	size?: "sm" | "default";
+}) {
+	return (
+		<SelectPrimitive.Trigger
+			data-slot="select-trigger"
+			data-size={size}
+			className={cn(
+				"flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			<SelectPrimitive.Icon
+				render={
+					<ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+				}
+			/>
+		</SelectPrimitive.Trigger>
+	);
+}
+
+function SelectContent({
+	className,
+	children,
+	side = "bottom",
+	sideOffset = 4,
+	align = "center",
+	alignOffset = 0,
+	alignItemWithTrigger = true,
+	...props
+}: SelectPrimitive.Popup.Props &
+	Pick<
+		SelectPrimitive.Positioner.Props,
+		"align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+	>) {
+	return (
+		<SelectPrimitive.Portal>
+			<SelectPrimitive.Positioner
+				side={side}
+				sideOffset={sideOffset}
+				align={align}
+				alignOffset={alignOffset}
+				alignItemWithTrigger={alignItemWithTrigger}
+				className="isolate z-50"
+			>
+				<SelectPrimitive.Popup
+					data-slot="select-content"
+					data-align-trigger={alignItemWithTrigger}
+					className={cn(
+						"relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+						className,
+					)}
+					{...props}
+				>
+					<SelectScrollUpButton />
+					<SelectPrimitive.List>{children}</SelectPrimitive.List>
+					<SelectScrollDownButton />
+				</SelectPrimitive.Popup>
+			</SelectPrimitive.Positioner>
+		</SelectPrimitive.Portal>
+	);
+}
+
+function SelectLabel({
+	className,
+	...props
+}: SelectPrimitive.GroupLabel.Props) {
+	return (
+		<SelectPrimitive.GroupLabel
+			data-slot="select-label"
+			className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+function SelectItem({
+	className,
+	children,
+	...props
+}: SelectPrimitive.Item.Props) {
+	return (
+		<SelectPrimitive.Item
+			data-slot="select-item"
+			className={cn(
+				"relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				className,
+			)}
+			{...props}
+		>
+			<SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+				{children}
+			</SelectPrimitive.ItemText>
+			<SelectPrimitive.ItemIndicator
+				render={
+					<span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+				}
+			>
+				<CheckIcon className="pointer-events-none" />
+			</SelectPrimitive.ItemIndicator>
+		</SelectPrimitive.Item>
+	);
+}
+
+function SelectSeparator({
+	className,
+	...props
+}: SelectPrimitive.Separator.Props) {
+	return (
+		<SelectPrimitive.Separator
+			data-slot="select-separator"
+			className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+			{...props}
+		/>
+	);
+}
+
+function SelectScrollUpButton({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+	return (
+		<SelectPrimitive.ScrollUpArrow
+			data-slot="select-scroll-up-button"
+			className={cn(
+				"top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		>
+			<ChevronUpIcon />
+		</SelectPrimitive.ScrollUpArrow>
+	);
+}
+
+function SelectScrollDownButton({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+	return (
+		<SelectPrimitive.ScrollDownArrow
+			data-slot="select-scroll-down-button"
+			className={cn(
+				"bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		>
+			<ChevronDownIcon />
+		</SelectPrimitive.ScrollDownArrow>
+	);
+}
+
+export {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectScrollDownButton,
+	SelectScrollUpButton,
+	SelectSeparator,
+	SelectTrigger,
+	SelectValue,
+};

--- a/apps/app/test_output.txt
+++ b/apps/app/test_output.txt
@@ -1,0 +1,15 @@
+$ vitest src/app/notes/_components/RightPaneDetail.test.tsx --run
+The plugin "vite-tsconfig-paths" is detected. Vite now supports tsconfig paths resolution natively via the resolve.tsconfigPaths option. You can remove the plugin and set resolve.tsconfigPaths: true in your Vite config instead.
+[vite:react-swc] We recommend switching to `@vitejs/plugin-react` for improved performance as no swc plugins are used. More information at https://vite.dev/rolldown
+
+ RUN  v4.1.2 /home/iatik/dev/github.com/claude-3/sitecue/apps/app
+
+ ✓ src/app/notes/_components/RightPaneDetail.test.tsx (9 tests) 2414ms
+     ✓ should show edit metadata dialog and handle updates  537ms
+     ✓ should cleanse URL when saving with domain scope  696ms
+
+ Test Files  1 passed (1)
+      Tests  9 passed (9)
+   Start at  01:30:54
+   Duration  3.63s (transform 154ms, setup 172ms, import 475ms, tests 2.41s, environment 468ms)
+


### PR DESCRIPTION
Why:
- Redirecting to the base `/notes` after deletion disrupted the user's workflow by clearing active filters.
- Quick scope changes from the popover lacked URL validation, risking unintended data states and sudden UI shifts.
- Changing scopes (e.g., to Inbox or Domain) without cleansing the URL left stale or invalid URL data in the database.

What:
- Update delete action to preserve current search parameters (Domain/Page filters) using `router.replace` instead of pushing to root.
- Implement URL data cleansing on save (clears URL for Inbox, extracts hostname for Domain).
- Remove the quick Scope selection menu from the popover to enforce the use of the validated edit modal.
- Add and update MSW test cases to verify the new navigation and URL cleansing logic.