### PR TITLE
feat: add bulk actions and context-aware new note creation

### DIFF
--- a/apps/app/src/app/notes/_components/LeftPaneNavigation.tsx
+++ b/apps/app/src/app/notes/_components/LeftPaneNavigation.tsx
@@ -7,6 +7,7 @@ import {
 	Globe,
 	Inbox,
 	PenSquare,
+	Plus,
 	Search,
 } from "lucide-react";
 import Image from "next/image";
@@ -54,6 +55,13 @@ export function LeftPaneNavigation({
 		},
 	);
 
+	const newNoteParams = new URLSearchParams();
+	if (currentView) newNoteParams.set("view", currentView);
+	if (currentDomain) newNoteParams.set("domain", currentDomain);
+	if (currentExact) newNoteParams.set("exact", currentExact);
+	newNoteParams.set("new", "note");
+	const newNoteHref = `/notes?${newNoteParams.toString()}`;
+
 	return (
 		<div className="flex flex-col h-full bg-gray-50 border-r border-gray-200 w-72 overflow-hidden">
 			<div className="p-4 border-b border-gray-200 bg-white">
@@ -88,6 +96,14 @@ export function LeftPaneNavigation({
 						onChange={(e) => setSearchQuery(e.target.value)}
 					/>
 				</div>
+
+				<Link
+					href={newNoteHref}
+					className="mt-4 flex w-full items-center justify-center gap-2 rounded-md bg-neutral-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-neutral-500 cursor-pointer"
+				>
+					<Plus className="w-4 h-4" aria-hidden="true" />
+					New Note
+				</Link>
 			</div>
 
 			<nav className="flex-1 py-4 overflow-y-auto">

--- a/apps/app/src/app/notes/_components/MiddlePaneList.test.tsx
+++ b/apps/app/src/app/notes/_components/MiddlePaneList.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Note } from "../types";
+import { MiddlePaneList } from "./MiddlePaneList";
+
+// Mock Supabase client
+vi.mock("@/utils/supabase/client", () => ({
+	createClient: vi.fn(() => ({
+		from: vi.fn().mockReturnThis(),
+		update: vi.fn().mockReturnThis(),
+		delete: vi.fn().mockReturnThis(),
+		in: vi.fn().mockResolvedValue({ error: null }),
+	})),
+}));
+
+// Mock Next.js navigation
+const refreshMock = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({
+		refresh: refreshMock,
+	}),
+	useSearchParams: () => new URLSearchParams(),
+}));
+
+const mockItems: Note[] = [
+	{
+		id: "note-1",
+		content: "Note 1",
+		note_type: "info",
+		created_at: new Date().toISOString(),
+		updated_at: new Date().toISOString(),
+		user_id: "user-1",
+		scope: "inbox",
+		url_pattern: "",
+		is_expanded: false,
+		is_favorite: false,
+		is_pinned: false,
+		is_resolved: false,
+		sort_order: 0,
+		draft_id: null,
+	},
+	{
+		id: "note-2",
+		content: "Note 2",
+		note_type: "idea",
+		created_at: new Date().toISOString(),
+		updated_at: new Date().toISOString(),
+		user_id: "user-1",
+		scope: "inbox",
+		url_pattern: "",
+		is_expanded: false,
+		is_favorite: false,
+		is_pinned: false,
+		is_resolved: false,
+		sort_order: 1,
+		draft_id: null,
+	},
+];
+
+describe("MiddlePaneList Bulk Actions", () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("should show checkboxes and action bar when selection is enabled", async () => {
+		const user = userEvent.setup();
+		render(
+			<MiddlePaneList
+				items={mockItems}
+				currentView="inbox"
+				currentDomain="inbox"
+				currentExact={null}
+				selectedNoteId={null}
+				selectedDraftId={null}
+			/>,
+		);
+
+		// Initially no action bar
+		expect(screen.queryByText(/selected/i)).not.toBeInTheDocument();
+
+		// Enable select mode first
+		const selectModeButton = screen.getByTitle("Select Mode");
+		await user.click(selectModeButton);
+
+		// Check the first note
+		const checkboxes = screen.getAllByRole("checkbox");
+		expect(checkboxes).toHaveLength(2);
+
+		await user.click(checkboxes[0]);
+
+		// Now action bar should be visible
+		expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /delete/i })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+
+		// Cancel selection
+		await user.click(screen.getByRole("button", { name: /cancel/i }));
+		expect(screen.queryByText(/selected/i)).not.toBeInTheDocument();
+	});
+});

--- a/apps/app/src/app/notes/_components/MiddlePaneList.tsx
+++ b/apps/app/src/app/notes/_components/MiddlePaneList.tsx
@@ -18,11 +18,14 @@ import { CSS } from "@dnd-kit/utilities";
 import {
 	AlertTriangle,
 	ArrowLeft,
+	CheckSquare,
 	GripVertical,
 	Inbox,
 	Info,
 	Lightbulb,
 	MapPin,
+	Plus,
+	Trash2,
 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -70,18 +73,22 @@ const getNoteTypeStyles = (type: string | null) => {
 	}
 };
 
-export function MiddlePaneList({
-	items,
-	currentView,
-	currentDomain,
-	currentExact,
-	selectedNoteId,
-	selectedDraftId,
-}: Props) {
+export function MiddlePaneList(props: Props) {
+	const {
+		items,
+		currentView,
+		currentDomain,
+		currentExact,
+		selectedNoteId,
+		selectedDraftId,
+	} = props;
 	const searchParams = useSearchParams();
 	const router = useRouter();
 	const supabase = createClient();
 	const [localItems, setLocalItems] = useState<(Note | Draft)[]>(items);
+	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+	const [isDeletingBulk, setIsDeletingBulk] = useState(false);
+	const [isSelectMode, setIsSelectMode] = useState(false);
 
 	useEffect(() => {
 		// Ensure items have an id and are unique to prevent key warnings and dnd-kit crashes
@@ -91,6 +98,13 @@ export function MiddlePaneList({
 		);
 		setLocalItems(uniqueItems);
 	}, [items]);
+
+	// Reset Select Mode and selection state when category changes
+	useEffect(() => {
+		const _unused = { currentView, currentDomain, currentExact };
+		setIsSelectMode(false);
+		setSelectedIds(new Set());
+	}, [currentView, currentDomain, currentExact]);
 
 	const sensors = useSensors(
 		useSensor(PointerSensor, {
@@ -152,20 +166,100 @@ export function MiddlePaneList({
 		}
 	};
 
+	const handleDeleteSelected = async () => {
+		if (selectedIds.size === 0) return;
+		setIsDeletingBulk(true);
+		try {
+			const { error } = await supabase
+				.from("sitecue_notes")
+				.delete()
+				.in("id", Array.from(selectedIds));
+
+			if (error) throw error;
+
+			setSelectedIds(new Set());
+			router.refresh();
+		} catch (err) {
+			console.error("Failed to delete selected notes:", err);
+			alert("Failed to delete selected notes.");
+		} finally {
+			setIsDeletingBulk(false);
+		}
+	};
+
+	const toggleSelect = (id: string, checked: boolean) => {
+		const newSelected = new Set(selectedIds);
+		if (checked) {
+			newSelected.add(id);
+		} else {
+			newSelected.delete(id);
+		}
+		setSelectedIds(newSelected);
+	};
+
 	return (
 		<div className="flex flex-col h-full bg-white border-r border-gray-200 w-96">
 			<div className="p-4 border-b border-gray-200 sticky top-0 bg-white z-10">
-				<h2
-					className="text-lg font-bold text-gray-900 truncate"
-					title={getTitle()}
-				>
-					{getTitle()}
-				</h2>
-				<p className="text-xs text-gray-500 mt-1">
-					{isSelected
-						? `${items.length} ${currentView === "drafts" ? "drafts" : "notes"}`
-						: "Waiting for selection"}
-				</p>
+				<div className="flex items-center justify-between">
+					<h2
+						className="text-lg font-bold text-gray-900 truncate"
+						title={getTitle()}
+					>
+						{getTitle()}
+					</h2>
+					<div className="flex items-center gap-1">
+						<Link
+							href={`/notes?domain=${currentDomain || "inbox"}${currentExact ? `&exact=${encodeURIComponent(currentExact)}` : ""}&new=note`}
+							className="p-1.5 text-neutral-400 hover:text-neutral-900 rounded-md hover:bg-neutral-100 transition-colors"
+							title="New Note here"
+						>
+							<Plus className="w-4 h-4" />
+						</Link>
+						<button
+							type="button"
+							onClick={() => {
+								setIsSelectMode(!isSelectMode);
+								if (!isSelectMode === false) setSelectedIds(new Set());
+							}}
+							className={`p-1.5 rounded-md transition-colors cursor-pointer ${isSelectMode ? "bg-neutral-200 text-neutral-900" : "text-neutral-400 hover:text-neutral-900 hover:bg-neutral-100"}`}
+							title="Select Mode"
+						>
+							<CheckSquare className="w-4 h-4" />
+						</button>
+					</div>
+				</div>
+				{selectedIds.size > 0 ? (
+					<div className="flex items-center justify-between mt-2 animate-in fade-in slide-in-from-top-1 duration-200">
+						<span className="text-xs font-semibold text-neutral-900">
+							{selectedIds.size} selected
+						</span>
+						<div className="flex items-center gap-2">
+							<button
+								type="button"
+								onClick={() => setSelectedIds(new Set())}
+								className="text-xs text-neutral-500 hover:text-neutral-900 font-medium transition-colors cursor-pointer"
+								disabled={isDeletingBulk}
+							>
+								Cancel
+							</button>
+							<button
+								type="button"
+								onClick={handleDeleteSelected}
+								className="flex items-center gap-1.5 px-3 py-1 bg-red-50 text-red-600 rounded-md text-xs font-bold hover:bg-red-100 transition-colors cursor-pointer"
+								disabled={isDeletingBulk}
+							>
+								<Trash2 className="w-3 h-3" aria-hidden="true" />
+								{isDeletingBulk ? "Deleting..." : "Delete"}
+							</button>
+						</div>
+					</div>
+				) : (
+					<p className="text-xs text-gray-500 mt-1">
+						{isSelected
+							? `${items.length} ${currentView === "drafts" ? "drafts" : "notes"}`
+							: "Waiting for selection"}
+					</p>
+				)}
 			</div>
 
 			<div className="flex-1 overflow-y-auto">
@@ -195,6 +289,7 @@ export function MiddlePaneList({
 									selectedNoteId={selectedNoteId}
 									selectedDraftId={selectedDraftId}
 									searchParams={searchParams}
+									selectable={false}
 								/>
 							))
 						) : (
@@ -217,6 +312,9 @@ export function MiddlePaneList({
 											selectedNoteId={selectedNoteId}
 											selectedDraftId={selectedDraftId}
 											searchParams={searchParams}
+											selectable={currentView !== "drafts" && isSelectMode}
+											isSelected={selectedIds.has(item.id)}
+											onSelectChange={toggleSelect}
 										/>
 									))}
 								</SortableContext>
@@ -248,6 +346,9 @@ function NoteItem({
 	searchParams,
 	isSortable = false,
 	dragHandleProps = {},
+	selectable = false,
+	isSelected = false,
+	onSelectChange,
 }: {
 	item: Note | Draft;
 	currentExact: string | null;
@@ -256,6 +357,9 @@ function NoteItem({
 	searchParams: URLSearchParams;
 	isSortable?: boolean;
 	dragHandleProps?: React.HTMLAttributes<HTMLButtonElement>;
+	selectable?: boolean;
+	isSelected?: boolean;
+	onSelectChange?: (id: string, checked: boolean) => void;
 }) {
 	const isNote = "note_type" in item;
 	const isActive = isNote
@@ -277,20 +381,37 @@ function NoteItem({
 				isActive ? "bg-neutral-100" : "hover:bg-neutral-50"
 			}`}
 		>
-			{isSortable && isNote && (
-				<button
-					type="button"
-					{...dragHandleProps}
-					style={{ touchAction: "none" }}
-					className="absolute left-2 top-0 bottom-0 flex items-center justify-center px-1 text-gray-300 hover:text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing z-20"
-					aria-label="Drag to reorder"
-				>
-					<GripVertical className="w-4 h-4" aria-hidden="true" />
-				</button>
-			)}
+			{/* Left Action Area (DnD & Checkbox) */}
+			<div className="flex items-center pl-2 shrink-0">
+				{isSortable && isNote && (
+					<button
+						type="button"
+						{...dragHandleProps}
+						style={{ touchAction: "none" }}
+						className="flex items-center justify-center p-1 text-gray-300 hover:text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing"
+						aria-label="Drag to reorder"
+					>
+						<GripVertical className="w-4 h-4" aria-hidden="true" />
+					</button>
+				)}
+				{!isSortable && isNote && <div className="w-6" />}
+
+				{selectable && (
+					<div className="flex items-center justify-center px-1">
+						<input
+							type="checkbox"
+							checked={isSelected}
+							onChange={(e) => onSelectChange?.(item.id, e.target.checked)}
+							onPointerDown={(e) => e.stopPropagation()}
+							className="w-4 h-4 cursor-pointer accent-neutral-900"
+						/>
+					</div>
+				)}
+			</div>
+
 			<Link
 				href={`/notes?${params.toString()}`}
-				className="flex-1 block p-4 pl-8 md:pl-10"
+				className="flex-1 block py-4 pr-4 pl-2"
 			>
 				<div className="flex justify-between items-start mb-1">
 					{isNote ? (
@@ -338,6 +459,9 @@ function SortableNoteItem({
 	selectedNoteId,
 	selectedDraftId,
 	searchParams,
+	selectable,
+	isSelected,
+	onSelectChange,
 }: {
 	item: Note | Draft;
 	currentView: string | null;
@@ -345,6 +469,9 @@ function SortableNoteItem({
 	selectedNoteId: string | null;
 	selectedDraftId: string | null;
 	searchParams: URLSearchParams;
+	selectable?: boolean;
+	isSelected?: boolean;
+	onSelectChange?: (id: string, checked: boolean) => void;
 }) {
 	const {
 		setNodeRef,
@@ -374,6 +501,9 @@ function SortableNoteItem({
 				searchParams={searchParams}
 				isSortable={currentView !== "drafts"}
 				dragHandleProps={{ ...attributes, ...listeners }}
+				selectable={selectable}
+				isSelected={isSelected}
+				onSelectChange={onSelectChange}
 			/>
 		</div>
 	);

--- a/apps/app/src/app/notes/_components/RightPaneDetail.test.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.test.tsx
@@ -22,6 +22,10 @@ type SupabaseMock = {
 	update: Mock;
 	delete: Mock;
 	eq: Mock;
+	auth: { getUser: Mock };
+	insert: Mock;
+	select: Mock;
+	single: Mock;
 };
 
 type Mock = ReturnType<typeof vi.fn>;
@@ -64,6 +68,24 @@ vi.mock("@/utils/supabase/client", () => ({
 	createClient: vi.fn(),
 }));
 
+vi.mock("@/components/editor/NotesEditor", () => ({
+	NotesEditor: ({
+		value,
+		onChange,
+		placeholder,
+	}: {
+		value: string;
+		onChange: (v: string) => void;
+		placeholder: string;
+	}) => (
+		<textarea
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+			placeholder={placeholder}
+		/>
+	),
+}));
+
 // Setup MSW server for this test
 const server = setupServer();
 
@@ -85,6 +107,15 @@ describe("RightPaneDetail Component Phase 1 Improvements", () => {
 			update: vi.fn().mockReturnThis(),
 			delete: vi.fn().mockReturnThis(),
 			eq: vi.fn().mockResolvedValue({ error: null }),
+			auth: {
+				getUser: vi.fn().mockResolvedValue({
+					data: { user: { id: "test-user" } },
+					error: null,
+				}),
+			},
+			insert: vi.fn().mockReturnThis(),
+			select: vi.fn().mockReturnThis(),
+			single: vi.fn().mockResolvedValue({ data: {}, error: null }),
 		} as unknown as SupabaseMock;
 		vi.mocked(createClient).mockReturnValue(
 			supabaseMock as unknown as ReturnType<typeof createClient>,
@@ -324,5 +355,66 @@ describe("RightPaneDetail Component Phase 1 Improvements", () => {
 				scope: "inbox",
 			}),
 		);
+	});
+
+	it("should render empty editor when isNewNote is true and handle save via insert", async () => {
+		const user = userEvent.setup();
+		const getUserMock = vi.fn().mockResolvedValue({
+			data: { user: { id: "test-user-id" } },
+			error: null,
+		});
+		const insertMock = vi.fn().mockReturnThis();
+		const selectMock = vi.fn().mockReturnThis();
+		const singleMock = vi.fn().mockResolvedValue({
+			data: { id: "new-note-id" },
+			error: null,
+		});
+
+		// Setup Supabase mock for this specific test
+		supabaseMock.auth.getUser = getUserMock;
+		supabaseMock.insert = insertMock;
+		supabaseMock.select = selectMock;
+		supabaseMock.single = singleMock;
+
+		render(<RightPaneDetail isNewNote={true} />);
+
+		// Verify editor is in editing mode and empty
+		const editor = screen.getByPlaceholderText(/What's on your mind\?/i);
+		expect(editor).toBeInTheDocument();
+		expect(editor).toHaveValue("");
+
+		// Type content
+		await user.type(editor, "New note content via insert");
+
+		// Click Save
+		const saveButton = screen.getByText(/^Save$/);
+		await user.click(saveButton);
+
+		// Verify insert call
+		expect(insertMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				content: "New note content via insert",
+				scope: "inbox",
+				user_id: "test-user-id",
+			}),
+		);
+		// Note: The mock `useSearchParams` returns "filter=all&sort=newest"
+		expect(replaceMock).toHaveBeenCalledWith(
+			"/notes?filter=all&sort=newest&noteId=new-note-id",
+		);
+		expect(refreshMock).toHaveBeenCalled();
+	});
+
+	it("should remove 'new' parameter when cancelling a new note", async () => {
+		const user = userEvent.setup();
+		// The search params in mock are already filter=all&sort=newest
+		render(<RightPaneDetail isNewNote={true} />);
+
+		const cancelButton = screen.getByText(/Cancel/i);
+		await user.click(cancelButton);
+
+		// Should preserve existing params and implicitly remove 'new' if it was added to the params
+		// (In this mock setup, searchParams doesn't have 'new', so it remains the same)
+		expect(replaceMock).toHaveBeenCalledWith("/notes?filter=all&sort=newest");
 	});
 });

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -56,9 +56,10 @@ import type { Draft, Note } from "../types";
 type Props = {
 	note?: Note;
 	draft?: Draft;
+	isNewNote?: boolean;
 };
 
-export function RightPaneDetail({ note, draft }: Props) {
+export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const [isEditing, setIsEditing] = useState(false);
@@ -97,6 +98,14 @@ export function RightPaneDetail({ note, draft }: Props) {
 		}
 	}, [note]);
 
+	// Initialize state for new notes
+	useEffect(() => {
+		if (isNewNote) {
+			setIsEditing(true);
+			setEditContent("");
+		}
+	}, [isNewNote]);
+
 	// Force inbox scope if URL is empty
 	useEffect(() => {
 		if (editUrl === "" && editScope !== "inbox") {
@@ -114,9 +123,13 @@ export function RightPaneDetail({ note, draft }: Props) {
 		setOptimisticPinned(null);
 		setOptimisticFavorite(null);
 		setEditContent(note?.content || "");
-	}, [note?.content]);
+		if (isNewNote) {
+			setIsEditing(true);
+			setEditContent("");
+		}
+	}, [note?.content, isNewNote]);
 
-	if (!note && !draft) {
+	if (!note && !draft && !isNewNote) {
 		return (
 			<div className="flex-1 flex flex-col items-center justify-center bg-gray-50 text-gray-400 p-8">
 				<MousePointerClick
@@ -174,33 +187,88 @@ export function RightPaneDetail({ note, draft }: Props) {
 	};
 
 	const handleCancel = () => {
-		setIsEditing(false);
-		setEditContent(note?.content || "");
+		if (isNewNote) {
+			const params = new URLSearchParams(searchParams.toString());
+			params.delete("new");
+			router.replace(`/notes?${params.toString()}`);
+		} else {
+			setIsEditing(false);
+			setEditContent(note?.content || "");
+		}
 	};
 
 	const handleSave = async () => {
-		if (!note) return;
+		if (!note && !isNewNote) return;
 
 		setIsSaving(true);
 		const newContent = editContent.trim();
 
 		// Optimistic update
-		setOptimisticContent(newContent);
+		if (note) {
+			setOptimisticContent(newContent);
+		}
 		setIsEditing(false);
 
 		try {
 			const supabase = createClient();
-			const { error } = await supabase
-				.from("sitecue_notes")
-				.update({ content: newContent })
-				.eq("id", note.id);
 
-			if (error) throw error;
+			if (isNewNote) {
+				const {
+					data: { user },
+				} = await supabase.auth.getUser();
+				if (!user) throw new Error("User not authenticated");
 
-			router.refresh();
+				const exactParam = searchParams.get("exact");
+				const domainParam = searchParams.get("domain");
+
+				let targetScope: Note["scope"] = "inbox";
+				let targetUrlPattern = "";
+
+				if (exactParam) {
+					targetScope = "exact";
+					targetUrlPattern = exactParam;
+				} else if (domainParam && domainParam !== "inbox") {
+					targetScope = "domain";
+					targetUrlPattern = domainParam;
+				}
+
+				const { data, error } = await supabase
+					.from("sitecue_notes")
+					.insert({
+						content: newContent,
+						scope: targetScope,
+						url_pattern: targetUrlPattern,
+						note_type: "info",
+						user_id: user.id,
+						is_expanded: false,
+						is_favorite: false,
+						is_pinned: false,
+						is_resolved: false,
+						sort_order: 0,
+					})
+					.select()
+					.single();
+
+				if (error) throw error;
+
+				setOptimisticContent(newContent);
+				const params = new URLSearchParams(searchParams.toString());
+				params.delete("new");
+				params.set("noteId", data.id);
+				router.replace(`/notes?${params.toString()}`);
+				router.refresh();
+			} else if (note) {
+				const { error } = await supabase
+					.from("sitecue_notes")
+					.update({ content: newContent })
+					.eq("id", note.id);
+
+				if (error) throw error;
+				router.refresh();
+			}
 		} catch (err) {
-			console.error("Failed to update note:", err);
-			alert("Failed to update the note.");
+			console.error("Failed to save note:", err);
+			alert("Failed to save the note.");
 			setOptimisticContent(null);
 			setIsEditing(true);
 		} finally {
@@ -438,7 +506,6 @@ export function RightPaneDetail({ note, draft }: Props) {
 													))}
 												</div>
 											</div>
-
 
 											<div className="pt-2 border-t border-neutral-100">
 												<div className="text-[10px] font-bold text-neutral-400 uppercase tracking-widest mb-2 px-2">

--- a/apps/app/src/app/notes/page.tsx
+++ b/apps/app/src/app/notes/page.tsx
@@ -5,15 +5,7 @@ import { LeftPaneNavigation } from "./_components/LeftPaneNavigation";
 import { MiddlePaneList } from "./_components/MiddlePaneList";
 import { ResponsiveNotesLayout } from "./_components/ResponsiveNotesLayout";
 import { RightPaneDetail } from "./_components/RightPaneDetail";
-import type { Draft, GroupedNotes, Note } from "./types";
-
-type SearchParams = {
-	view?: "inbox" | "drafts" | "domains";
-	domain?: string;
-	exact?: string;
-	noteId?: string;
-	draftId?: string;
-};
+import type { Draft, GroupedNotes, Note, SearchParams } from "./types";
 
 function groupNotes(notes: Note[], drafts: Draft[]): GroupedNotes {
 	const grouped: GroupedNotes = {
@@ -57,6 +49,7 @@ export default async function Dashboard(props: {
 }) {
 	const searchParams = await props.searchParams;
 	const { domain, exact } = searchParams;
+	const isNewNote = searchParams.new === "note";
 
 	const supabase = await createClient();
 
@@ -170,7 +163,13 @@ export default async function Dashboard(props: {
 					selectedDraftId={searchParams.draftId ?? null}
 				/>
 			}
-			rightNode={<RightPaneDetail note={selectedNote} draft={selectedDraft} />}
+			rightNode={
+				<RightPaneDetail
+					note={selectedNote}
+					draft={selectedDraft}
+					isNewNote={isNewNote}
+				/>
+			}
 		/>
 	);
 }

--- a/apps/app/src/app/notes/types.ts
+++ b/apps/app/src/app/notes/types.ts
@@ -15,3 +15,12 @@ export type GroupedNotes = {
 	drafts: Draft[];
 	domains: Record<string, DomainGroup>;
 };
+
+export type SearchParams = {
+	view?: "inbox" | "drafts" | "domains";
+	domain?: string;
+	exact?: string;
+	noteId?: string;
+	draftId?: string;
+	new?: string;
+};


### PR DESCRIPTION
Why:
- To allow users to manage multiple notes efficiently (e.g., bulk delete) without interfering with the existing drag-and-drop functionality.
- To enable quick note creation while preserving the current domain/page context, preventing disruptive UI resets and avoiding empty records in the database.

What:
- Added a Select Mode toggle and checkboxes to the middle pane for bulk deletion.
- Implemented a "New Note" button in the left and middle panes that dynamically inherits the current URL context (`domain`, `exact`).
- Introduced a delayed save architecture for new notes, inserting records into the database only upon the first save.
- Fixed routing issues where creating, saving, or canceling a new note would drop URL parameters and unintentionally reset the active panes.
- Fixed a bug where Select Mode remained active when navigating between different categories or domains.
- Resolved CSS layout overlaps between the DnD grip icon and checkboxes in the list items.