### PR TITLE
fix(ui): resolve cursor and state flicker in new note dialog

### DIFF
--- a/apps/app/src/app/_components/GlobalNewNoteDialog.tsx
+++ b/apps/app/src/app/_components/GlobalNewNoteDialog.tsx
@@ -55,6 +55,13 @@ export default function GlobalNewNoteDialog() {
 		}
 	}, [isOpen, searchParams]);
 
+	// Reset state when modal opens to prevent flickering during close transition
+	useEffect(() => {
+		if (isOpen) {
+			setNoteType("info");
+		}
+	}, [isOpen]);
+
 	// Force inbox scope if URL is empty
 	useEffect(() => {
 		if (urlPattern === "" && scope !== "inbox") {
@@ -127,7 +134,6 @@ export default function GlobalNewNoteDialog() {
 			}
 
 			router.push(`/notes?${params.toString()}`);
-			setNoteType("info");
 			router.refresh();
 		} catch (err) {
 			console.error("Failed to save note:", err);
@@ -201,7 +207,7 @@ export default function GlobalNewNoteDialog() {
 									key={type}
 									type="button"
 									onClick={() => setNoteType(type as Note["note_type"])}
-									className={`px-3 py-1.5 text-sm font-medium rounded-md capitalize transition-colors ${
+									className={`px-3 py-1.5 text-sm font-medium rounded-md capitalize transition-colors cursor-pointer ${
 										noteType === type
 											? "bg-neutral-900 text-white"
 											: "bg-neutral-100 text-neutral-500 hover:bg-neutral-200"

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -671,7 +671,7 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 										key={type}
 										type="button"
 										onClick={() => setNoteType(type as Note["note_type"])}
-										className={`px-3 py-1.5 text-sm font-medium rounded-md capitalize transition-colors ${
+										className={`px-3 py-1.5 text-sm font-medium rounded-md capitalize transition-colors cursor-pointer ${
 											noteType === type
 												? "bg-neutral-900 text-white"
 												: "bg-neutral-100 text-neutral-500 hover:bg-neutral-200"


### PR DESCRIPTION
Why:
- Note type toggle buttons lack a hover pointer, degrading user experience.
- State reset in GlobalNewNoteDialog occurs immediately after saving, causing a visual flicker where the initial state (info) briefly appears during the modal fade-out.

What:
- Add `cursor-pointer` to the note type toggle buttons.
- Update the state reset timing to trigger when the modal opens instead of immediately after saving.