### PR TITLE
refactor(ui): replace note_type toggle with common button component

### DIFF
--- a/apps/app/src/app/_components/GlobalNewNoteDialog.tsx
+++ b/apps/app/src/app/_components/GlobalNewNoteDialog.tsx
@@ -203,18 +203,16 @@ export default function GlobalNewNoteDialog() {
 						<Label className="text-xs font-bold uppercase">Note Type</Label>
 						<div className="flex gap-2">
 							{(["info", "alert", "idea"] as const).map((type) => (
-								<button
+								<Button
 									key={type}
 									type="button"
+									variant={noteType === type ? "default" : "secondary"}
+									size="sm"
 									onClick={() => setNoteType(type as Note["note_type"])}
-									className={`px-3 py-1.5 text-sm font-medium rounded-md capitalize transition-colors cursor-pointer ${
-										noteType === type
-											? "bg-neutral-900 text-white"
-											: "bg-neutral-100 text-neutral-500 hover:bg-neutral-200"
-									}`}
+									className="capitalize cursor-pointer"
 								>
 									{type}
-								</button>
+								</Button>
 							))}
 						</div>
 					</div>

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -28,6 +28,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import {
 	Dialog,
 	DialogContent,
@@ -667,18 +668,16 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 							<Label className="text-xs font-bold uppercase">Note Type</Label>
 							<div className="flex gap-2">
 								{(["info", "alert", "idea"] as const).map((type) => (
-									<button
+									<Button
 										key={type}
 										type="button"
+										variant={noteType === type ? "default" : "secondary"}
+										size="sm"
 										onClick={() => setNoteType(type as Note["note_type"])}
-										className={`px-3 py-1.5 text-sm font-medium rounded-md capitalize transition-colors cursor-pointer ${
-											noteType === type
-												? "bg-neutral-900 text-white"
-												: "bg-neutral-100 text-neutral-500 hover:bg-neutral-200"
-										}`}
+										className="capitalize cursor-pointer"
 									>
 										{type}
-									</button>
+									</Button>
 								))}
 							</div>
 						</div>


### PR DESCRIPTION
- Why: Ensure UI consistency and improve maintainability for future design or theme updates.
- What: Replace raw <button> tags with the shared Button component in GlobalNewNoteDialog.tsx and RightPaneDetail.tsx.