### PR TITLE
refactor(studio-weave): replace action buttons with common button com…

### DIFF
--- a/apps/app/src/app/_components/DraftEditor.tsx
+++ b/apps/app/src/app/_components/DraftEditor.tsx
@@ -4,7 +4,9 @@ import { ArrowLeft, Sparkles } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { StudioEditor } from "@/components/editor/StudioEditor";
+import { Button } from "@/components/ui/button";
 import { CustomLink as Link } from "@/components/ui/custom-link";
+
 import {
 	Drawer,
 	DrawerContent,
@@ -408,14 +410,15 @@ export default function DraftEditor({
 			<div className="flex flex-1 flex-col overflow-hidden border-r border-neutral-200 bg-white">
 				<header className="flex items-center justify-between border-b border-neutral-100 px-6 py-4">
 					<div className="flex items-center gap-4">
-						<button
-							type="button"
+						<Button
+							variant="ghost"
+							size="icon"
 							onClick={handleBack}
-							className="cursor-pointer text-neutral-400 hover:text-neutral-900 transition-colors p-1 -ml-2"
+							className="text-neutral-400 -ml-2"
 							aria-label="Go back"
 						>
 							<ArrowLeft className="w-5 h-5" aria-hidden="true" />
-						</button>
+						</Button>
 						<Link
 							href="/"
 							className="text-xl font-bold tracking-tight text-neutral-900 transition-colors hover:text-neutral-500 cursor-pointer block"
@@ -441,16 +444,14 @@ export default function DraftEditor({
 							onRedo={handleRedo}
 						/>
 
-						<button
-							type="button"
+						<Button
 							onClick={handleSave}
 							disabled={status === "saving"}
-							className={`rounded-full bg-neutral-900 px-6 py-1.5 text-sm font-medium text-white transition-colors hover:bg-neutral-500 cursor-pointer ${
-								status === "saving" ? "opacity-50 cursor-not-allowed" : ""
-							}`}
+							size="sm"
+							className="rounded-full px-6"
 						>
 							{status === "saving" ? "Saving..." : "Save"}
-						</button>
+						</Button>
 					</div>
 				</header>
 

--- a/apps/app/src/app/notes/_components/MiddlePaneList.tsx
+++ b/apps/app/src/app/notes/_components/MiddlePaneList.tsx
@@ -29,8 +29,8 @@ import {
 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
-import { CustomLink as Link } from "@/components/ui/custom-link";
 import { Button } from "@/components/ui/button";
+import { CustomLink as Link } from "@/components/ui/custom-link";
 import { createClient } from "@/utils/supabase/client";
 import { getSafeUrl } from "@/utils/url";
 import type { Draft, Note } from "../types";

--- a/apps/app/src/app/studio/_components/PaywallModal.tsx
+++ b/apps/app/src/app/studio/_components/PaywallModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Crown, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface PaywallModalProps {
 	isOpen: boolean;
@@ -19,14 +20,15 @@ export default function PaywallModal({
 		<div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-neutral-900/30 backdrop-blur-sm animate-in fade-in duration-200">
 			<div className="w-full max-w-md bg-white rounded-3xl shadow-2xl overflow-hidden animate-in zoom-in-95 duration-200">
 				<div className="relative p-8 text-center text-neutral-900">
-					<button
-						type="button"
+					<Button
+						variant="ghost"
+						size="icon"
 						onClick={onClose}
 						aria-label="Close modal"
-						className="absolute top-4 right-4 p-2 text-neutral-400 hover:text-neutral-900 transition-colors cursor-pointer"
+						className="absolute top-4 right-4 text-neutral-400"
 					>
 						<X size={20} />
-					</button>
+					</Button>
 
 					<div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-amber-50 text-amber-500">
 						<Crown size={32} />
@@ -43,19 +45,19 @@ export default function PaywallModal({
 					</p>
 
 					<div className="flex flex-col gap-3">
-						<button
-							type="button"
-							className="w-full rounded-2xl bg-neutral-900 py-4 text-sm font-bold text-white transition-all hover:bg-neutral-800 hover:scale-[1.02] active:scale-[0.98] cursor-pointer"
+						<Button
+							variant="default"
+							className="w-full rounded-2xl py-6 text-sm font-bold"
 						>
 							Upgrade to Pro
-						</button>
-						<button
-							type="button"
+						</Button>
+						<Button
+							variant="outline"
 							onClick={onClose}
-							className="w-full rounded-2xl bg-white border border-neutral-200 py-4 text-sm font-bold text-neutral-600 transition-all hover:bg-neutral-50 cursor-pointer"
+							className="w-full rounded-2xl py-6 text-sm font-bold text-neutral-600"
 						>
 							Maybe Later
-						</button>
+						</Button>
 					</div>
 				</div>
 

--- a/apps/app/src/app/studio/_components/UndoRedoControls.tsx
+++ b/apps/app/src/app/studio/_components/UndoRedoControls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Redo2, Undo2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface UndoRedoControlsProps {
 	canUndo: boolean;
@@ -17,32 +18,26 @@ export default function UndoRedoControls({
 }: UndoRedoControlsProps) {
 	return (
 		<div className="flex items-center gap-1 border-x border-neutral-100 px-4">
-			<button
-				type="button"
+			<Button
+				variant="ghost"
+				size="icon"
 				onClick={onUndo}
 				disabled={!canUndo}
 				title="Undo (Ctrl+Z)"
-				className={`rounded p-1.5 transition-colors ${
-					canUndo
-						? "text-neutral-600 hover:bg-neutral-100 cursor-pointer"
-						: "text-neutral-300 cursor-not-allowed"
-				}`}
+				className="h-8 w-8"
 			>
 				<Undo2 size={18} aria-hidden="true" />
-			</button>
-			<button
-				type="button"
+			</Button>
+			<Button
+				variant="ghost"
+				size="icon"
 				onClick={onRedo}
 				disabled={!canRedo}
 				title="Redo (Ctrl+Y)"
-				className={`rounded p-1.5 transition-colors ${
-					canRedo
-						? "text-neutral-600 hover:bg-neutral-100 cursor-pointer"
-						: "text-neutral-300 cursor-not-allowed"
-				}`}
+				className="h-8 w-8"
 			>
 				<Redo2 size={18} aria-hidden="true" />
-			</button>
+			</Button>
 		</div>
 	);
 }

--- a/apps/app/src/app/weave/WeaveUI.tsx
+++ b/apps/app/src/app/weave/WeaveUI.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
 import { createClient } from "@/utils/supabase/client";
 
 type Note = {
@@ -173,13 +174,9 @@ function WeaveUIInner({ initialNotes }: { initialNotes: Note[] }) {
 						</p>
 					</div>
 					<div className="pt-2">
-						<button
-							type="button"
-							onClick={() => window.location.reload()}
-							className="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black transition-all"
-						>
+						<Button variant="outline" onClick={() => window.location.reload()}>
 							Retry Sync
-						</button>
+						</Button>
 					</div>
 				</div>
 			</div>
@@ -317,8 +314,8 @@ function WeaveUIInner({ initialNotes }: { initialNotes: Note[] }) {
 					</div>
 
 					<div className="mb-6">
-						<button
-							type="button"
+						<Button
+							variant="default"
 							onClick={handleGenerate}
 							disabled={
 								selectedNoteIds.size === 0 ||
@@ -326,7 +323,7 @@ function WeaveUIInner({ initialNotes }: { initialNotes: Note[] }) {
 								(usageCount !== null &&
 									usageCount >= (plan === "pro" ? 100 : 3))
 							}
-							className="w-full inline-flex justify-center items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-black hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+							className="w-full"
 						>
 							{isLoading ? (
 								<>
@@ -356,7 +353,7 @@ function WeaveUIInner({ initialNotes }: { initialNotes: Note[] }) {
 							) : (
 								"✨ Generate"
 							)}
-						</button>
+						</Button>
 						<div className="mt-2 h-4 flex items-center justify-center">
 							{usageCount !== null && !isLoading && (
 								<p className="text-xs text-gray-400 font-light">


### PR DESCRIPTION
…ponent

- Why: Enhance UI consistency and theme resilience by continuing the transition from raw <button> tags to the shared Button component.
- What: Replace standard action buttons in DraftEditor.tsx, WeaveUI.tsx, UndoRedoControls.tsx, and PaywallModal.tsx with the shared Button component, excluding those with unique complex layouts.