### PR TITLE
feat(studio): add success feedback to save button

### DIFF
--- a/apps/app/src/app/_components/DraftEditor.tsx
+++ b/apps/app/src/app/_components/DraftEditor.tsx
@@ -41,7 +41,9 @@ export default function DraftEditor({
 	const activePane = searchParams.get("pane") || "review";
 	const isDesktop = useMediaQuery("(min-width: 768px)");
 
-	const [status, setStatus] = useState<"idle" | "saving" | "error">("idle");
+	const [status, setStatus] = useState<"idle" | "saving" | "success" | "error">(
+		"idle",
+	);
 	const [savedState, setSavedState] = useState({
 		content: initialDraft?.content || "",
 		title: initialDraft?.title || "",
@@ -390,7 +392,8 @@ export default function DraftEditor({
 					router.push(`/studio/${data.id}`);
 				}
 			}
-			setStatus("idle");
+			setStatus("success");
+			setTimeout(() => setStatus("idle"), 2000);
 		} catch (error) {
 			console.error("Failed to save draft:", error);
 			alert("Failed to save the draft. Check the console for details.");
@@ -446,11 +449,23 @@ export default function DraftEditor({
 
 						<Button
 							onClick={handleSave}
-							disabled={status === "saving"}
+							disabled={status === "saving" || status === "success"}
 							size="sm"
 							className="w-24 rounded-full"
 						>
-							{status === "saving" ? "Saving..." : "Save"}
+							{status === "saving" ? (
+								"Saving..."
+							) : status === "success" ? (
+								<span className="flex items-center gap-1">
+									<Check
+										className="w-4 h-4 text-green-500"
+										aria-hidden="true"
+									/>
+									Saved
+								</span>
+							) : (
+								"Save"
+							)}
 						</Button>
 					</div>
 				</header>


### PR DESCRIPTION
- Why: The current UI reverts from "Saving..." to "Save" too quickly, making it difficult for users to visually confirm if the save operation was successful.

- What:
  - Add a `success` state to the save button logic.
  - Implement a visual feedback showing a checkmark and "Saved" label upon successful completion.
  - Set a 2-second delay before the button state returns to `idle`.