### PR TITLE
feat(studio): implement user-defined templates for draft writing

### DIFF
--- a/apps/app/src/app/_components/DraftEditor.tsx
+++ b/apps/app/src/app/_components/DraftEditor.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/drawer";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { createClient } from "@/utils/supabase/client";
-import type { Draft, DraftPlatform, Note } from "../../../../../types/app.ts";
+import type { Draft, Note, Template } from "../../../../../types/app.ts";
 import PaywallModal from "../studio/_components/PaywallModal";
 import StudioMaterialsPane from "../studio/_components/StudioMaterialsPane";
 import StudioReviewPane from "../studio/_components/StudioReviewPane";
@@ -26,18 +26,17 @@ import UndoRedoControls from "../studio/_components/UndoRedoControls";
 type NoteType = "info" | "alert" | "idea";
 
 interface DraftEditorProps {
-	targetPlatform?: DraftPlatform;
+	template?: Template | null;
 	initialDraft?: Draft;
 }
 
 export default function DraftEditor({
-	targetPlatform,
+	template,
 	initialDraft,
 }: DraftEditorProps) {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const supabase = createClient();
-	const target = targetPlatform || initialDraft?.target_platform || "generic";
 	const activePane = searchParams.get("pane") || "review";
 	const isDesktop = useMediaQuery("(min-width: 768px)");
 
@@ -45,7 +44,7 @@ export default function DraftEditor({
 		"idle",
 	);
 	const [savedState, setSavedState] = useState({
-		content: initialDraft?.content || "",
+		content: initialDraft?.content || template?.boilerplate || "",
 		title: initialDraft?.title || "",
 		slug: initialDraft?.metadata?.slug || "",
 	});
@@ -328,12 +327,13 @@ export default function DraftEditor({
 	};
 
 	const charCount = content.length;
+	const maxLength = template?.max_length;
 
 	const handleSave = async () => {
 		setStatus("saving");
 		try {
 			const metadata =
-				target === "zenn" ? { slug } : initialDraft?.metadata || {};
+				template?.name === "Zenn" ? { slug } : initialDraft?.metadata || {};
 
 			let currentDraftId = initialDraft?.id;
 
@@ -356,7 +356,7 @@ export default function DraftEditor({
 					.insert({
 						title,
 						content,
-						target_platform: target,
+						template_id: template?.id || null,
 						metadata,
 					})
 					.select()
@@ -430,12 +430,11 @@ export default function DraftEditor({
 						</Link>
 						<div className="h-4 w-px bg-base-border" />
 						<span className="text-sm font-medium text-action">
-							{target === "x" &&
-								(initialDraft ? "Edit Draft for X" : "New Draft for X")}
-							{target === "zenn" &&
-								(initialDraft ? "Edit Draft for Zenn" : "New Draft for Zenn")}
-							{target === "generic" &&
-								(initialDraft ? "Edit Note" : "New Note")}
+							{template
+								? `Draft for ${template.name}`
+								: initialDraft
+									? "Edit Draft"
+									: "New Blank Canvas"}
 						</span>
 					</div>
 
@@ -471,31 +470,35 @@ export default function DraftEditor({
 				</header>
 
 				<div className="border-b border-neutral-100 bg-neutral-50/50 px-8 py-6">
-					{target === "x" && (
-						<div className="flex items-center justify-between">
+					{maxLength && (
+						<div className="flex items-center justify-between mb-4">
 							<span className="text-sm font-medium text-neutral-500 uppercase tracking-wider">
 								Character Count
 							</span>
 							<span
-								className={`text-2xl font-mono font-bold ${charCount > 140 ? "text-note-alert" : "text-action"}`}
+								className={`text-2xl font-mono font-bold ${charCount > maxLength ? "text-note-alert" : "text-action"}`}
 							>
-								{charCount} / 140
+								{charCount} / {maxLength}
 							</span>
 						</div>
 					)}
 
-					{target === "zenn" && (
-						<div className="grid gap-4">
-							<div className="flex items-center gap-2">
-								<input
-									type="text"
-									placeholder="Enter article title..."
-									value={title}
-									onChange={(e) => setTitle(e.target.value)}
-									className="w-full bg-transparent text-2xl font-bold placeholder:text-neutral-300 focus:outline-none"
-								/>
-								<InlineCopyButton text={title} />
-							</div>
+					<div className="grid gap-4">
+						<div className="flex items-center gap-2">
+							<input
+								type="text"
+								placeholder={
+									template?.name === "Zenn"
+										? "Enter article title..."
+										: "Title (optional)"
+								}
+								value={title}
+								onChange={(e) => setTitle(e.target.value)}
+								className="w-full bg-transparent text-2xl font-bold placeholder:text-neutral-300 focus:outline-none"
+							/>
+							<InlineCopyButton text={title} />
+						</div>
+						{template?.name === "Zenn" && (
 							<div className="flex items-center gap-2 text-sm text-neutral-400">
 								<span>slug:</span>
 								<input
@@ -507,21 +510,8 @@ export default function DraftEditor({
 								/>
 								<InlineCopyButton text={slug} />
 							</div>
-						</div>
-					)}
-
-					{target === "generic" && (
-						<div className="flex items-center gap-2">
-							<input
-								type="text"
-								placeholder="Title (optional)"
-								value={title}
-								onChange={(e) => setTitle(e.target.value)}
-								className="w-full bg-transparent text-2xl font-bold placeholder:text-neutral-300 focus:outline-none"
-							/>
-							<InlineCopyButton text={title} />
-						</div>
-					)}
+						)}
+					</div>
 				</div>
 
 				<main className="flex-1 overflow-y-auto px-8 py-10">

--- a/apps/app/src/app/notes/_components/MiddlePaneList.tsx
+++ b/apps/app/src/app/notes/_components/MiddlePaneList.tsx
@@ -434,8 +434,8 @@ function NoteItem({
 							{item.note_type}
 						</span>
 					) : (
-						<span className="bg-note-info/10 text-note-info px-2.5 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase">
-							{item.target_platform || "draft"}
+						<span className="bg-purple-50 text-purple-500 px-2.5 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase">
+							Draft
 						</span>
 					)}
 					<span className="text-[10px] text-gray-400">

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -425,7 +425,7 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 								</button>
 							) : (
 								<span className="bg-purple-50 text-purple-500 px-2.5 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase">
-									{draft?.target_platform || "Draft"}
+									Draft
 								</span>
 							)}
 							<span className="text-sm text-gray-400">

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -1,12 +1,4 @@
-import {
-	ArrowRight,
-	BookOpen,
-	Calendar,
-	FileText,
-	Library,
-	MessageSquareText,
-	Plus,
-} from "lucide-react";
+import { ArrowRight, Calendar, FileText, Library, Plus } from "lucide-react";
 import Image from "next/image";
 import { buttonVariants } from "@/components/ui/button";
 import { CustomLink as Link } from "@/components/ui/custom-link";
@@ -18,12 +10,12 @@ import { UserMenu } from "./_components/UserMenu";
 
 export default async function LaunchpadPage() {
 	const supabase = await createClient();
-
 	const [
 		{ count: notesCount },
 		{ count: draftsCount },
 		{ data: recentDrafts },
 		{ data: pinnedSites },
+		{ data: templates },
 	] = await Promise.all([
 		supabase.from("sitecue_notes").select("*", { count: "exact", head: true }),
 		supabase.from("sitecue_drafts").select("*", { count: "exact", head: true }),
@@ -36,6 +28,10 @@ export default async function LaunchpadPage() {
 			.from("sitecue_pinned_sites")
 			.select("*")
 			.order("created_at", { ascending: false }),
+		supabase
+			.from("sitecue_templates")
+			.select("*")
+			.order("created_at", { ascending: true }),
 	]);
 
 	return (
@@ -112,33 +108,7 @@ export default async function LaunchpadPage() {
 					</div>
 					<div className="grid gap-8 sm:grid-cols-3">
 						<Link
-							href="/studio/new?target=x"
-							className="group relative flex flex-col items-start rounded-xl border border-base-border bg-base-surface p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:border-base-border/50 cursor-pointer"
-						>
-							<div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-base-bg transition-colors group-hover:bg-base-surface">
-								<MessageSquareText className="w-5 h-5 text-neutral-600" />
-							</div>
-							<h3 className="mb-1 font-bold text-action">Short Post</h3>
-							<p className="text-xs text-neutral-500 line-clamp-2">
-								Save your sudden ideas as drafts for X.
-							</p>
-						</Link>
-
-						<Link
-							href="/studio/new?target=zenn"
-							className="group relative flex flex-col items-start rounded-xl border border-base-border bg-base-surface p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:border-base-border/50 cursor-pointer"
-						>
-							<div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-base-bg transition-colors group-hover:bg-base-surface">
-								<BookOpen className="w-5 h-5 text-neutral-600" />
-							</div>
-							<h3 className="mb-1 font-bold text-action">Article</h3>
-							<p className="text-xs text-neutral-500 line-clamp-2">
-								Draft and organize your technical articles for Zenn.
-							</p>
-						</Link>
-
-						<Link
-							href="/studio/new?target=generic"
+							href="/studio/new"
 							className="group relative flex flex-col items-start rounded-xl border border-base-border bg-base-surface p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:border-base-border/50 cursor-pointer"
 						>
 							<div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-base-bg transition-colors group-hover:bg-base-surface">
@@ -146,9 +116,30 @@ export default async function LaunchpadPage() {
 							</div>
 							<h3 className="mb-1 font-bold text-action">Blank Canvas</h3>
 							<p className="text-xs text-neutral-500 line-clamp-2">
-								Free-form notes not limited to any specific platform.
+								Free-form notes not limited to any specific template.
 							</p>
 						</Link>
+
+						{templates?.map((template) => (
+							<Link
+								key={template.id}
+								href={`/studio/new?template_id=${template.id}`}
+								className="group relative flex flex-col items-start rounded-xl border border-base-border bg-base-surface p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:border-base-border/50 cursor-pointer"
+							>
+								<div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-base-bg transition-colors group-hover:bg-base-surface">
+									<FileText className="w-5 h-5 text-neutral-600" />
+								</div>
+								<h3 className="mb-1 font-bold text-action">{template.name}</h3>
+								{template.max_length && (
+									<p className="text-[10px] text-neutral-400 font-mono mb-1">
+										Max: {template.max_length} chars
+									</p>
+								)}
+								<p className="text-xs text-neutral-500 line-clamp-2">
+									Use this template for your workflow.
+								</p>
+							</Link>
+						))}
 					</div>
 				</section>
 
@@ -209,22 +200,18 @@ export default async function LaunchpadPage() {
 							>
 								<div className="flex items-center gap-4">
 									<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-base-bg text-neutral-600 transition-colors group-hover:bg-base-surface">
-										{draft.target_platform === "x" ? (
-											<MessageSquareText className="w-5 h-5" />
-										) : draft.target_platform === "zenn" ? (
-											<BookOpen className="w-5 h-5" />
-										) : (
-											<FileText className="w-5 h-5" />
-										)}
+										<FileText className="w-5 h-5" />
 									</div>
 									<div>
 										<h3 className="font-bold text-action">
 											{draft.title || "Untitled Draft"}
 										</h3>
 										<div className="mt-1 flex items-center gap-2 text-xs text-neutral-400">
-											<span className="capitalize">
-												{draft.target_platform}
-											</span>
+											{draft.template_id ? (
+												<span className="capitalize">Template User</span>
+											) : (
+												<span className="capitalize">Blank Canvas</span>
+											)}
 											<span>•</span>
 											<span className="flex items-center gap-1">
 												<Calendar className="w-3 h-3" />

--- a/apps/app/src/app/studio/[id]/page.tsx
+++ b/apps/app/src/app/studio/[id]/page.tsx
@@ -15,7 +15,7 @@ export default async function DraftEditPage({ params }: DraftPageProps) {
 
 	const { data: draft, error } = await supabase
 		.from("sitecue_drafts")
-		.select("*")
+		.select("*, sitecue_templates(*)")
 		.eq("id", id)
 		.single();
 
@@ -26,9 +26,15 @@ export default async function DraftEditPage({ params }: DraftPageProps) {
 	// 型の整合性を合わせる（supabaseのRowからDraft型へ）
 	const formattedDraft: Draft = {
 		...draft,
-		target_platform: draft.target_platform as Draft["target_platform"],
 		metadata: draft.metadata as Draft["metadata"],
+		sitecue_templates:
+			draft.sitecue_templates as unknown as Draft["sitecue_templates"],
 	};
 
-	return <DraftEditor initialDraft={formattedDraft} />;
+	return (
+		<DraftEditor
+			initialDraft={formattedDraft}
+			template={formattedDraft.sitecue_templates}
+		/>
+	);
 }

--- a/apps/app/src/app/studio/new/page.tsx
+++ b/apps/app/src/app/studio/new/page.tsx
@@ -1,27 +1,23 @@
-"use client";
-
-import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
-import type { DraftPlatform } from "../../../../../../types/app.ts";
+import { createClient } from "@/utils/supabase/server";
 import DraftEditor from "../../_components/DraftEditor";
 
-function FocusModeEditor() {
-	const searchParams = useSearchParams();
-	const target = (searchParams.get("target") as DraftPlatform) || "generic";
+export default async function FocusModePage({
+	searchParams,
+}: {
+	searchParams: Promise<{ template_id?: string }>;
+}) {
+	const resolvedParams = await searchParams;
+	let template = null;
 
-	return <DraftEditor targetPlatform={target} />;
-}
+	if (resolvedParams.template_id) {
+		const supabase = await createClient();
+		const { data } = await supabase
+			.from("sitecue_templates")
+			.select("*")
+			.eq("id", resolvedParams.template_id)
+			.single();
+		template = data;
+	}
 
-export default function FocusModePage() {
-	return (
-		<Suspense
-			fallback={
-				<div className="flex h-screen items-center justify-center bg-white text-neutral-400">
-					Loading Studio...
-				</div>
-			}
-		>
-			<FocusModeEditor />
-		</Suspense>
-	);
+	return <DraftEditor template={template} />;
 }

--- a/docs/guide-repomix.md
+++ b/docs/guide-repomix.md
@@ -142,7 +142,7 @@ supabase/migrations/
 ### 生成コマンド
 
 ```bash
-# 1. プロジェクト全体のスケルトン（地図）を生成する(設定ファイルが反映される)
+# 1. プロジェクト全体のスケルトン（地図）を生成する(設定ファイルを使って生成)
 bun x repomix --config repomix-skeleton.config.json
 
 # 2. プロジェクト全体を網羅して生成する( `repomix-output.xml` が作られる)

--- a/supabase/migrations/20260416041024_create_templates_and_modify_drafts.sql
+++ b/supabase/migrations/20260416041024_create_templates_and_modify_drafts.sql
@@ -1,0 +1,31 @@
+-- 1. Create Templates Table
+CREATE TABLE sitecue_templates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    icon TEXT,
+    max_length INTEGER,
+    boilerplate TEXT,
+    weave_prompt TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Enable RLS
+ALTER TABLE sitecue_templates ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+CREATE POLICY "Users can manage their own templates"
+    ON sitecue_templates FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- 2. Modify Drafts Table
+-- Add template_id first
+ALTER TABLE sitecue_drafts ADD COLUMN template_id UUID REFERENCES sitecue_templates(id) ON DELETE SET NULL;
+
+-- Drop target_platform
+ALTER TABLE sitecue_drafts DROP COLUMN target_platform;
+
+-- Create an index for performance
+CREATE INDEX idx_sitecue_drafts_template_id ON sitecue_drafts(template_id);

--- a/types/app.ts
+++ b/types/app.ts
@@ -9,17 +9,14 @@ export type Note = Omit<
 	scope: NoteScope;
 };
 
-export type DraftPlatform = "x" | "zenn" | "generic";
+export type Template = Database["public"]["Tables"]["sitecue_templates"]["Row"];
 
-export type Draft = Omit<
-	Database["public"]["Tables"]["sitecue_drafts"]["Row"],
-	"target_platform"
-> & {
-	target_platform: DraftPlatform;
+export type Draft = Database["public"]["Tables"]["sitecue_drafts"]["Row"] & {
 	metadata: {
 		slug?: string;
 		[key: string]: unknown;
 	} | null;
+	sitecue_templates?: Template | null;
 };
 
 export type PinnedSite =

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,481 +1,523 @@
 export type Json =
-	| string
-	| number
-	| boolean
-	| null
-	| { [key: string]: Json | undefined }
-	| Json[];
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
 export type Database = {
-	graphql_public: {
-		Tables: {
-			[_ in never]: never;
-		};
-		Views: {
-			[_ in never]: never;
-		};
-		Functions: {
-			graphql: {
-				Args: {
-					extensions?: Json;
-					operationName?: string;
-					query?: string;
-					variables?: Json;
-				};
-				Returns: Json;
-			};
-		};
-		Enums: {
-			[_ in never]: never;
-		};
-		CompositeTypes: {
-			[_ in never]: never;
-		};
-	};
-	public: {
-		Tables: {
-			sitecue_domain_settings: {
-				Row: {
-					color: string | null;
-					created_at: string;
-					domain: string;
-					id: string;
-					label: string | null;
-					updated_at: string;
-					user_id: string;
-				};
-				Insert: {
-					color?: string | null;
-					created_at?: string;
-					domain: string;
-					id?: string;
-					label?: string | null;
-					updated_at?: string;
-					user_id: string;
-				};
-				Update: {
-					color?: string | null;
-					created_at?: string;
-					domain?: string;
-					id?: string;
-					label?: string | null;
-					updated_at?: string;
-					user_id?: string;
-				};
-				Relationships: [];
-			};
-			sitecue_drafts: {
-				Row: {
-					content: string | null;
-					created_at: string;
-					id: string;
-					metadata: Json | null;
-					target_platform: string;
-					title: string | null;
-					updated_at: string;
-					user_id: string;
-				};
-				Insert: {
-					content?: string | null;
-					created_at?: string;
-					id?: string;
-					metadata?: Json | null;
-					target_platform: string;
-					title?: string | null;
-					updated_at?: string;
-					user_id?: string;
-				};
-				Update: {
-					content?: string | null;
-					created_at?: string;
-					id?: string;
-					metadata?: Json | null;
-					target_platform?: string;
-					title?: string | null;
-					updated_at?: string;
-					user_id?: string;
-				};
-				Relationships: [];
-			};
-			sitecue_links: {
-				Row: {
-					created_at: string;
-					domain: string;
-					id: string;
-					label: string;
-					target_url: string;
-					type: string;
-					user_id: string;
-				};
-				Insert: {
-					created_at?: string;
-					domain: string;
-					id?: string;
-					label: string;
-					target_url: string;
-					type: string;
-					user_id?: string;
-				};
-				Update: {
-					created_at?: string;
-					domain?: string;
-					id?: string;
-					label?: string;
-					target_url?: string;
-					type?: string;
-					user_id?: string;
-				};
-				Relationships: [];
-			};
-			sitecue_notes: {
-				Row: {
-					content: string;
-					created_at: string;
-					draft_id: string | null;
-					id: string;
-					is_expanded: boolean;
-					is_favorite: boolean;
-					is_pinned: boolean;
-					is_resolved: boolean;
-					note_type: string;
-					scope: string;
-					sort_order: number;
-					updated_at: string;
-					url_pattern: string;
-					user_id: string;
-				};
-				Insert: {
-					content: string;
-					created_at?: string;
-					draft_id?: string | null;
-					id?: string;
-					is_expanded?: boolean;
-					is_favorite?: boolean;
-					is_pinned?: boolean;
-					is_resolved?: boolean;
-					note_type?: string;
-					scope?: string;
-					sort_order?: number;
-					updated_at?: string;
-					url_pattern: string;
-					user_id: string;
-				};
-				Update: {
-					content?: string;
-					created_at?: string;
-					draft_id?: string | null;
-					id?: string;
-					is_expanded?: boolean;
-					is_favorite?: boolean;
-					is_pinned?: boolean;
-					is_resolved?: boolean;
-					note_type?: string;
-					scope?: string;
-					sort_order?: number;
-					updated_at?: string;
-					url_pattern?: string;
-					user_id?: string;
-				};
-				Relationships: [
-					{
-						foreignKeyName: "sitecue_notes_draft_id_fkey";
-						columns: ["draft_id"];
-						isOneToOne: false;
-						referencedRelation: "sitecue_drafts";
-						referencedColumns: ["id"];
-					},
-				];
-			};
-			sitecue_page_contents: {
-				Row: {
-					content: string;
-					created_at: string;
-					id: string;
-					url: string;
-					user_id: string;
-				};
-				Insert: {
-					content: string;
-					created_at?: string;
-					id?: string;
-					url: string;
-					user_id: string;
-				};
-				Update: {
-					content?: string;
-					created_at?: string;
-					id?: string;
-					url?: string;
-					user_id?: string;
-				};
-				Relationships: [];
-			};
-			sitecue_pinned_sites: {
-				Row: {
-					created_at: string;
-					id: string;
-					title: string;
-					url: string;
-					user_id: string;
-				};
-				Insert: {
-					created_at?: string;
-					id?: string;
-					title: string;
-					url: string;
-					user_id?: string;
-				};
-				Update: {
-					created_at?: string;
-					id?: string;
-					title?: string;
-					url?: string;
-					user_id?: string;
-				};
-				Relationships: [];
-			};
-			sitecue_profiles: {
-				Row: {
-					ai_usage_count: number;
-					ai_usage_reset_at: string | null;
-					created_at: string;
-					id: string;
-					plan: string;
-				};
-				Insert: {
-					ai_usage_count?: number;
-					ai_usage_reset_at?: string | null;
-					created_at?: string;
-					id: string;
-					plan?: string;
-				};
-				Update: {
-					ai_usage_count?: number;
-					ai_usage_reset_at?: string | null;
-					created_at?: string;
-					id?: string;
-					plan?: string;
-				};
-				Relationships: [];
-			};
-			todo01_profiles: {
-				Row: {
-					created_at: string;
-					display_name: string | null;
-					id: string;
-					updated_at: string;
-				};
-				Insert: {
-					created_at?: string;
-					display_name?: string | null;
-					id: string;
-					updated_at?: string;
-				};
-				Update: {
-					created_at?: string;
-					display_name?: string | null;
-					id?: string;
-					updated_at?: string;
-				};
-				Relationships: [];
-			};
-			todo01_tasks: {
-				Row: {
-					created_at: string;
-					id: string;
-					is_complete: boolean | null;
-					title: string;
-					user_id: string;
-				};
-				Insert: {
-					created_at?: string;
-					id?: string;
-					is_complete?: boolean | null;
-					title: string;
-					user_id: string;
-				};
-				Update: {
-					created_at?: string;
-					id?: string;
-					is_complete?: boolean | null;
-					title?: string;
-					user_id?: string;
-				};
-				Relationships: [
-					{
-						foreignKeyName: "todo01_tasks_user_id_fkey";
-						columns: ["user_id"];
-						isOneToOne: false;
-						referencedRelation: "todo01_profiles";
-						referencedColumns: ["id"];
-					},
-				];
-			};
-		};
-		Views: {
-			[_ in never]: never;
-		};
-		Functions: {
-			get_matching_notes: {
-				Args: { p_domain: string; p_exact: string };
-				Returns: {
-					content: string;
-					created_at: string;
-					draft_id: string | null;
-					id: string;
-					is_expanded: boolean;
-					is_favorite: boolean;
-					is_pinned: boolean;
-					is_resolved: boolean;
-					note_type: string;
-					scope: string;
-					sort_order: number;
-					updated_at: string;
-					url_pattern: string;
-					user_id: string;
-				}[];
-				SetofOptions: {
-					from: "*";
-					to: "sitecue_notes";
-					isOneToOne: false;
-					isSetofReturn: true;
-				};
-			};
-		};
-		Enums: {
-			[_ in never]: never;
-		};
-		CompositeTypes: {
-			[_ in never]: never;
-		};
-	};
-};
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      sitecue_domain_settings: {
+        Row: {
+          color: string | null
+          created_at: string
+          domain: string
+          id: string
+          label: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          color?: string | null
+          created_at?: string
+          domain: string
+          id?: string
+          label?: string | null
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          color?: string | null
+          created_at?: string
+          domain?: string
+          id?: string
+          label?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      sitecue_drafts: {
+        Row: {
+          content: string | null
+          created_at: string
+          id: string
+          metadata: Json | null
+          template_id: string | null
+          title: string | null
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          content?: string | null
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          template_id?: string | null
+          title?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Update: {
+          content?: string | null
+          created_at?: string
+          id?: string
+          metadata?: Json | null
+          template_id?: string | null
+          title?: string | null
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sitecue_drafts_template_id_fkey"
+            columns: ["template_id"]
+            isOneToOne: false
+            referencedRelation: "sitecue_templates"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      sitecue_links: {
+        Row: {
+          created_at: string
+          domain: string
+          id: string
+          label: string
+          target_url: string
+          type: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          domain: string
+          id?: string
+          label: string
+          target_url: string
+          type: string
+          user_id?: string
+        }
+        Update: {
+          created_at?: string
+          domain?: string
+          id?: string
+          label?: string
+          target_url?: string
+          type?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      sitecue_notes: {
+        Row: {
+          content: string
+          created_at: string
+          draft_id: string | null
+          id: string
+          is_expanded: boolean
+          is_favorite: boolean
+          is_pinned: boolean
+          is_resolved: boolean
+          note_type: string
+          scope: string
+          sort_order: number
+          updated_at: string
+          url_pattern: string
+          user_id: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          draft_id?: string | null
+          id?: string
+          is_expanded?: boolean
+          is_favorite?: boolean
+          is_pinned?: boolean
+          is_resolved?: boolean
+          note_type?: string
+          scope?: string
+          sort_order?: number
+          updated_at?: string
+          url_pattern: string
+          user_id: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          draft_id?: string | null
+          id?: string
+          is_expanded?: boolean
+          is_favorite?: boolean
+          is_pinned?: boolean
+          is_resolved?: boolean
+          note_type?: string
+          scope?: string
+          sort_order?: number
+          updated_at?: string
+          url_pattern?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sitecue_notes_draft_id_fkey"
+            columns: ["draft_id"]
+            isOneToOne: false
+            referencedRelation: "sitecue_drafts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      sitecue_page_contents: {
+        Row: {
+          content: string
+          created_at: string
+          id: string
+          url: string
+          user_id: string
+        }
+        Insert: {
+          content: string
+          created_at?: string
+          id?: string
+          url: string
+          user_id: string
+        }
+        Update: {
+          content?: string
+          created_at?: string
+          id?: string
+          url?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      sitecue_pinned_sites: {
+        Row: {
+          created_at: string
+          id: string
+          title: string
+          url: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          title: string
+          url: string
+          user_id?: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          title?: string
+          url?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      sitecue_profiles: {
+        Row: {
+          ai_usage_count: number
+          ai_usage_reset_at: string | null
+          created_at: string
+          id: string
+          plan: string
+        }
+        Insert: {
+          ai_usage_count?: number
+          ai_usage_reset_at?: string | null
+          created_at?: string
+          id: string
+          plan?: string
+        }
+        Update: {
+          ai_usage_count?: number
+          ai_usage_reset_at?: string | null
+          created_at?: string
+          id?: string
+          plan?: string
+        }
+        Relationships: []
+      }
+      sitecue_templates: {
+        Row: {
+          boilerplate: string | null
+          created_at: string
+          icon: string | null
+          id: string
+          max_length: number | null
+          name: string
+          updated_at: string
+          user_id: string
+          weave_prompt: string | null
+        }
+        Insert: {
+          boilerplate?: string | null
+          created_at?: string
+          icon?: string | null
+          id?: string
+          max_length?: number | null
+          name: string
+          updated_at?: string
+          user_id: string
+          weave_prompt?: string | null
+        }
+        Update: {
+          boilerplate?: string | null
+          created_at?: string
+          icon?: string | null
+          id?: string
+          max_length?: number | null
+          name?: string
+          updated_at?: string
+          user_id?: string
+          weave_prompt?: string | null
+        }
+        Relationships: []
+      }
+      todo01_profiles: {
+        Row: {
+          created_at: string
+          display_name: string | null
+          id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          display_name?: string | null
+          id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          display_name?: string | null
+          id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      todo01_tasks: {
+        Row: {
+          created_at: string
+          id: string
+          is_complete: boolean | null
+          title: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          is_complete?: boolean | null
+          title: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          is_complete?: boolean | null
+          title?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "todo01_tasks_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "todo01_profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      get_matching_notes: {
+        Args: { p_domain: string; p_exact: string }
+        Returns: {
+          content: string
+          created_at: string
+          draft_id: string | null
+          id: string
+          is_expanded: boolean
+          is_favorite: boolean
+          is_pinned: boolean
+          is_resolved: boolean
+          note_type: string
+          scope: string
+          sort_order: number
+          updated_at: string
+          url_pattern: string
+          user_id: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "sitecue_notes"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<
-	keyof Database,
-	"public"
->];
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
-	DefaultSchemaTableNameOrOptions extends
-		| keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
-		| { schema: keyof DatabaseWithoutInternals },
-	TableName extends DefaultSchemaTableNameOrOptions extends {
-		schema: keyof DatabaseWithoutInternals;
-	}
-		? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-				DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-		: never = never,
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-	schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-	? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-			DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-			Row: infer R;
-		}
-		? R
-		: never
-	: DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-				DefaultSchema["Views"])
-		? (DefaultSchema["Tables"] &
-				DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-				Row: infer R;
-			}
-			? R
-			: never
-		: never;
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
 
 export type TablesInsert<
-	DefaultSchemaTableNameOrOptions extends
-		| keyof DefaultSchema["Tables"]
-		| { schema: keyof DatabaseWithoutInternals },
-	TableName extends DefaultSchemaTableNameOrOptions extends {
-		schema: keyof DatabaseWithoutInternals;
-	}
-		? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-		: never = never,
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-	schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-	? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-			Insert: infer I;
-		}
-		? I
-		: never
-	: DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-		? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-				Insert: infer I;
-			}
-			? I
-			: never
-		: never;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
 
 export type TablesUpdate<
-	DefaultSchemaTableNameOrOptions extends
-		| keyof DefaultSchema["Tables"]
-		| { schema: keyof DatabaseWithoutInternals },
-	TableName extends DefaultSchemaTableNameOrOptions extends {
-		schema: keyof DatabaseWithoutInternals;
-	}
-		? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-		: never = never,
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-	schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-	? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-			Update: infer U;
-		}
-		? U
-		: never
-	: DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-		? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-				Update: infer U;
-			}
-			? U
-			: never
-		: never;
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
 
 export type Enums<
-	DefaultSchemaEnumNameOrOptions extends
-		| keyof DefaultSchema["Enums"]
-		| { schema: keyof DatabaseWithoutInternals },
-	EnumName extends DefaultSchemaEnumNameOrOptions extends {
-		schema: keyof DatabaseWithoutInternals;
-	}
-		? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-		: never = never,
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-	schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-	? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-	: DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-		? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-		: never;
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
-	PublicCompositeTypeNameOrOptions extends
-		| keyof DefaultSchema["CompositeTypes"]
-		| { schema: keyof DatabaseWithoutInternals },
-	CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-		schema: keyof DatabaseWithoutInternals;
-	}
-		? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-		: never = never,
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-	schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
-	? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-	: PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-		? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-		: never;
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
 
 export const Constants = {
-	graphql_public: {
-		Enums: {},
-	},
-	public: {
-		Enums: {},
-	},
-} as const;
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+} as const
+


### PR DESCRIPTION
Why:
- To transition Studio from a hardcoded platform-based workflow (e.g., X, Zenn) to a flexible, user-driven workspace.
- To enable users to create and manage their own writing templates with custom boilerplates and character limits.

What:
- Create `sitecue_templates` table with RLS policies in the database.
- Drop `target_platform` column from `sitecue_drafts` and add `template_id` foreign key.
- Refactor Launchpad to dynamically fetch and display user templates in the Quick Start section.
- Refactor `DraftEditor` to adapt dynamically to the selected template (e.g., character count visibility, initial text).
- Update frontend type definitions to reflect database schema changes.