### PR TITLE
feat(ai): integrate template prompts into weave generation process

### DIFF
--- a/apps/api/src/services/ai.ts
+++ b/apps/api/src/services/ai.ts
@@ -16,6 +16,7 @@ export async function weaveDocument(
 		format: string;
 		context_id?: string;
 		draft_content?: string;
+		template_id?: string;
 	},
 ) {
 	const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY, {
@@ -48,7 +49,6 @@ export async function weaveDocument(
 		currentResetAt = nextMonth.toISOString();
 	}
 
-	// Ensure we have a reset date (defensive)
 	if (!currentResetAt) {
 		const nextMonth = new Date();
 		nextMonth.setMonth(nextMonth.getMonth() + 1);
@@ -65,13 +65,12 @@ export async function weaveDocument(
 		);
 	}
 
-	const { contexts, format, context_id, draft_content } = body;
+	const { contexts, format, context_id, draft_content, template_id } = body;
 
 	if (!Array.isArray(contexts) || typeof format !== "string") {
 		throw new Error("Invalid request body");
 	}
 
-	// 👇 ここにフォーマット判定のルールを追加
 	const formatRule =
 		format === "plaintext"
 			? "- マークダウン記号（# や ** など）は一切使用せず、見出しや箇条書きも含めて純粋なプレーンテキストのみで出力してください。"
@@ -88,7 +87,6 @@ export async function weaveDocument(
 		if (!pageError && pageData) {
 			referenceContent = `【現在のページ内容】\n${pageData.content}`;
 
-			// 使い捨てを保証するため直ちに削除
 			await supabase
 				.from("sitecue_page_contents")
 				.delete()
@@ -107,9 +105,27 @@ export async function weaveDocument(
 		})
 		.join("\n\n");
 
-	// 👇 出力の絶対ルールに ${formatRule} と言語指定を組み込み
-	const fullPrompt = `あなたは優秀なクリエイティブ・パートナーです。
-ユーザーからの直接の指示はありません。以下の【参考ページの内容】を背景知識とし、<user_notes>タグで囲まれた【ユーザーのメモ】を絶対的なディレクションとして、最適なドキュメントを自律的に推論して作成してください。
+	// --- テンプレートのWeave Prompt取得 ---
+	let customWeavePrompt = "";
+	if (template_id) {
+		const { data: templateData, error: templateError } = await supabase
+			.from("sitecue_templates")
+			.select("weave_prompt")
+			.eq("id", template_id)
+			.single();
+
+		if (!templateError && templateData) {
+			// any型エラー回避のため明示的に型をアサーション
+			const tData = templateData as { weave_prompt: string | null };
+			customWeavePrompt = tData.weave_prompt || "";
+		}
+	}
+
+	const systemInstruction = customWeavePrompt
+		? `【システムプロンプト（最優先のフォーマット・トーン指示）】\n${customWeavePrompt}\n\n上記のシステムプロンプトの指示・トーンを最優先で厳守し、以下の【参考ページの内容】と<user_notes>タグ内の【ユーザーのメモ】をもとにドキュメントを作成してください。`
+		: `あなたは優秀なクリエイティブ・パートナーです。\nユーザーからの直接の指示はありません。以下の【参考ページの内容】を背景知識とし、<user_notes>タグで囲まれた【ユーザーのメモ】を絶対的なディレクションとして、最適なドキュメントを自律的に推論して作成してください。`;
+
+	const fullPrompt = `${systemInstruction}
 
 # 出力の絶対ルール（厳守）
 - 前置き（「ご提示いただいたメモに基づき…」「〜を作成しました」等の挨拶や説明）は一切不要です。

--- a/apps/app/src/app/_components/DraftEditor.tsx
+++ b/apps/app/src/app/_components/DraftEditor.tsx
@@ -315,6 +315,7 @@ export default function DraftEditor({
 					contexts: reviewNotes,
 					format: "markdown",
 					draft_content: content,
+					template_id: activeTemplate?.id || null,
 				}),
 			});
 

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,523 +1,525 @@
 export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+	| string
+	| number
+	| boolean
+	| null
+	| { [key: string]: Json | undefined }
+	| Json[];
 
 export type Database = {
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-  public: {
-    Tables: {
-      sitecue_domain_settings: {
-        Row: {
-          color: string | null
-          created_at: string
-          domain: string
-          id: string
-          label: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          color?: string | null
-          created_at?: string
-          domain: string
-          id?: string
-          label?: string | null
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          color?: string | null
-          created_at?: string
-          domain?: string
-          id?: string
-          label?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
-      sitecue_drafts: {
-        Row: {
-          content: string | null
-          created_at: string
-          id: string
-          metadata: Json | null
-          template_id: string | null
-          title: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          content?: string | null
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          template_id?: string | null
-          title?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Update: {
-          content?: string | null
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          template_id?: string | null
-          title?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "sitecue_drafts_template_id_fkey"
-            columns: ["template_id"]
-            isOneToOne: false
-            referencedRelation: "sitecue_templates"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      sitecue_links: {
-        Row: {
-          created_at: string
-          domain: string
-          id: string
-          label: string
-          target_url: string
-          type: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          domain: string
-          id?: string
-          label: string
-          target_url: string
-          type: string
-          user_id?: string
-        }
-        Update: {
-          created_at?: string
-          domain?: string
-          id?: string
-          label?: string
-          target_url?: string
-          type?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
-      sitecue_notes: {
-        Row: {
-          content: string
-          created_at: string
-          draft_id: string | null
-          id: string
-          is_expanded: boolean
-          is_favorite: boolean
-          is_pinned: boolean
-          is_resolved: boolean
-          note_type: string
-          scope: string
-          sort_order: number
-          updated_at: string
-          url_pattern: string
-          user_id: string
-        }
-        Insert: {
-          content: string
-          created_at?: string
-          draft_id?: string | null
-          id?: string
-          is_expanded?: boolean
-          is_favorite?: boolean
-          is_pinned?: boolean
-          is_resolved?: boolean
-          note_type?: string
-          scope?: string
-          sort_order?: number
-          updated_at?: string
-          url_pattern: string
-          user_id: string
-        }
-        Update: {
-          content?: string
-          created_at?: string
-          draft_id?: string | null
-          id?: string
-          is_expanded?: boolean
-          is_favorite?: boolean
-          is_pinned?: boolean
-          is_resolved?: boolean
-          note_type?: string
-          scope?: string
-          sort_order?: number
-          updated_at?: string
-          url_pattern?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "sitecue_notes_draft_id_fkey"
-            columns: ["draft_id"]
-            isOneToOne: false
-            referencedRelation: "sitecue_drafts"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      sitecue_page_contents: {
-        Row: {
-          content: string
-          created_at: string
-          id: string
-          url: string
-          user_id: string
-        }
-        Insert: {
-          content: string
-          created_at?: string
-          id?: string
-          url: string
-          user_id: string
-        }
-        Update: {
-          content?: string
-          created_at?: string
-          id?: string
-          url?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
-      sitecue_pinned_sites: {
-        Row: {
-          created_at: string
-          id: string
-          title: string
-          url: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          title: string
-          url: string
-          user_id?: string
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          title?: string
-          url?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
-      sitecue_profiles: {
-        Row: {
-          ai_usage_count: number
-          ai_usage_reset_at: string | null
-          created_at: string
-          id: string
-          plan: string
-        }
-        Insert: {
-          ai_usage_count?: number
-          ai_usage_reset_at?: string | null
-          created_at?: string
-          id: string
-          plan?: string
-        }
-        Update: {
-          ai_usage_count?: number
-          ai_usage_reset_at?: string | null
-          created_at?: string
-          id?: string
-          plan?: string
-        }
-        Relationships: []
-      }
-      sitecue_templates: {
-        Row: {
-          boilerplate: string | null
-          created_at: string
-          icon: string | null
-          id: string
-          max_length: number | null
-          name: string
-          updated_at: string
-          user_id: string
-          weave_prompt: string | null
-        }
-        Insert: {
-          boilerplate?: string | null
-          created_at?: string
-          icon?: string | null
-          id?: string
-          max_length?: number | null
-          name: string
-          updated_at?: string
-          user_id: string
-          weave_prompt?: string | null
-        }
-        Update: {
-          boilerplate?: string | null
-          created_at?: string
-          icon?: string | null
-          id?: string
-          max_length?: number | null
-          name?: string
-          updated_at?: string
-          user_id?: string
-          weave_prompt?: string | null
-        }
-        Relationships: []
-      }
-      todo01_profiles: {
-        Row: {
-          created_at: string
-          display_name: string | null
-          id: string
-          updated_at: string
-        }
-        Insert: {
-          created_at?: string
-          display_name?: string | null
-          id: string
-          updated_at?: string
-        }
-        Update: {
-          created_at?: string
-          display_name?: string | null
-          id?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
-      todo01_tasks: {
-        Row: {
-          created_at: string
-          id: string
-          is_complete: boolean | null
-          title: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          is_complete?: boolean | null
-          title: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          is_complete?: boolean | null
-          title?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "todo01_tasks_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "todo01_profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      get_matching_notes: {
-        Args: { p_domain: string; p_exact: string }
-        Returns: {
-          content: string
-          created_at: string
-          draft_id: string | null
-          id: string
-          is_expanded: boolean
-          is_favorite: boolean
-          is_pinned: boolean
-          is_resolved: boolean
-          note_type: string
-          scope: string
-          sort_order: number
-          updated_at: string
-          url_pattern: string
-          user_id: string
-        }[]
-        SetofOptions: {
-          from: "*"
-          to: "sitecue_notes"
-          isOneToOne: false
-          isSetofReturn: true
-        }
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+	graphql_public: {
+		Tables: {
+			[_ in never]: never;
+		};
+		Views: {
+			[_ in never]: never;
+		};
+		Functions: {
+			graphql: {
+				Args: {
+					extensions?: Json;
+					operationName?: string;
+					query?: string;
+					variables?: Json;
+				};
+				Returns: Json;
+			};
+		};
+		Enums: {
+			[_ in never]: never;
+		};
+		CompositeTypes: {
+			[_ in never]: never;
+		};
+	};
+	public: {
+		Tables: {
+			sitecue_domain_settings: {
+				Row: {
+					color: string | null;
+					created_at: string;
+					domain: string;
+					id: string;
+					label: string | null;
+					updated_at: string;
+					user_id: string;
+				};
+				Insert: {
+					color?: string | null;
+					created_at?: string;
+					domain: string;
+					id?: string;
+					label?: string | null;
+					updated_at?: string;
+					user_id: string;
+				};
+				Update: {
+					color?: string | null;
+					created_at?: string;
+					domain?: string;
+					id?: string;
+					label?: string | null;
+					updated_at?: string;
+					user_id?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_drafts: {
+				Row: {
+					content: string | null;
+					created_at: string;
+					id: string;
+					metadata: Json | null;
+					template_id: string | null;
+					title: string | null;
+					updated_at: string;
+					user_id: string;
+				};
+				Insert: {
+					content?: string | null;
+					created_at?: string;
+					id?: string;
+					metadata?: Json | null;
+					template_id?: string | null;
+					title?: string | null;
+					updated_at?: string;
+					user_id?: string;
+				};
+				Update: {
+					content?: string | null;
+					created_at?: string;
+					id?: string;
+					metadata?: Json | null;
+					template_id?: string | null;
+					title?: string | null;
+					updated_at?: string;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "sitecue_drafts_template_id_fkey";
+						columns: ["template_id"];
+						isOneToOne: false;
+						referencedRelation: "sitecue_templates";
+						referencedColumns: ["id"];
+					},
+				];
+			};
+			sitecue_links: {
+				Row: {
+					created_at: string;
+					domain: string;
+					id: string;
+					label: string;
+					target_url: string;
+					type: string;
+					user_id: string;
+				};
+				Insert: {
+					created_at?: string;
+					domain: string;
+					id?: string;
+					label: string;
+					target_url: string;
+					type: string;
+					user_id?: string;
+				};
+				Update: {
+					created_at?: string;
+					domain?: string;
+					id?: string;
+					label?: string;
+					target_url?: string;
+					type?: string;
+					user_id?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_notes: {
+				Row: {
+					content: string;
+					created_at: string;
+					draft_id: string | null;
+					id: string;
+					is_expanded: boolean;
+					is_favorite: boolean;
+					is_pinned: boolean;
+					is_resolved: boolean;
+					note_type: string;
+					scope: string;
+					sort_order: number;
+					updated_at: string;
+					url_pattern: string;
+					user_id: string;
+				};
+				Insert: {
+					content: string;
+					created_at?: string;
+					draft_id?: string | null;
+					id?: string;
+					is_expanded?: boolean;
+					is_favorite?: boolean;
+					is_pinned?: boolean;
+					is_resolved?: boolean;
+					note_type?: string;
+					scope?: string;
+					sort_order?: number;
+					updated_at?: string;
+					url_pattern: string;
+					user_id: string;
+				};
+				Update: {
+					content?: string;
+					created_at?: string;
+					draft_id?: string | null;
+					id?: string;
+					is_expanded?: boolean;
+					is_favorite?: boolean;
+					is_pinned?: boolean;
+					is_resolved?: boolean;
+					note_type?: string;
+					scope?: string;
+					sort_order?: number;
+					updated_at?: string;
+					url_pattern?: string;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "sitecue_notes_draft_id_fkey";
+						columns: ["draft_id"];
+						isOneToOne: false;
+						referencedRelation: "sitecue_drafts";
+						referencedColumns: ["id"];
+					},
+				];
+			};
+			sitecue_page_contents: {
+				Row: {
+					content: string;
+					created_at: string;
+					id: string;
+					url: string;
+					user_id: string;
+				};
+				Insert: {
+					content: string;
+					created_at?: string;
+					id?: string;
+					url: string;
+					user_id: string;
+				};
+				Update: {
+					content?: string;
+					created_at?: string;
+					id?: string;
+					url?: string;
+					user_id?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_pinned_sites: {
+				Row: {
+					created_at: string;
+					id: string;
+					title: string;
+					url: string;
+					user_id: string;
+				};
+				Insert: {
+					created_at?: string;
+					id?: string;
+					title: string;
+					url: string;
+					user_id?: string;
+				};
+				Update: {
+					created_at?: string;
+					id?: string;
+					title?: string;
+					url?: string;
+					user_id?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_profiles: {
+				Row: {
+					ai_usage_count: number;
+					ai_usage_reset_at: string | null;
+					created_at: string;
+					id: string;
+					plan: string;
+				};
+				Insert: {
+					ai_usage_count?: number;
+					ai_usage_reset_at?: string | null;
+					created_at?: string;
+					id: string;
+					plan?: string;
+				};
+				Update: {
+					ai_usage_count?: number;
+					ai_usage_reset_at?: string | null;
+					created_at?: string;
+					id?: string;
+					plan?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_templates: {
+				Row: {
+					boilerplate: string | null;
+					created_at: string;
+					icon: string | null;
+					id: string;
+					max_length: number | null;
+					name: string;
+					updated_at: string;
+					user_id: string;
+					weave_prompt: string | null;
+				};
+				Insert: {
+					boilerplate?: string | null;
+					created_at?: string;
+					icon?: string | null;
+					id?: string;
+					max_length?: number | null;
+					name: string;
+					updated_at?: string;
+					user_id: string;
+					weave_prompt?: string | null;
+				};
+				Update: {
+					boilerplate?: string | null;
+					created_at?: string;
+					icon?: string | null;
+					id?: string;
+					max_length?: number | null;
+					name?: string;
+					updated_at?: string;
+					user_id?: string;
+					weave_prompt?: string | null;
+				};
+				Relationships: [];
+			};
+			todo01_profiles: {
+				Row: {
+					created_at: string;
+					display_name: string | null;
+					id: string;
+					updated_at: string;
+				};
+				Insert: {
+					created_at?: string;
+					display_name?: string | null;
+					id: string;
+					updated_at?: string;
+				};
+				Update: {
+					created_at?: string;
+					display_name?: string | null;
+					id?: string;
+					updated_at?: string;
+				};
+				Relationships: [];
+			};
+			todo01_tasks: {
+				Row: {
+					created_at: string;
+					id: string;
+					is_complete: boolean | null;
+					title: string;
+					user_id: string;
+				};
+				Insert: {
+					created_at?: string;
+					id?: string;
+					is_complete?: boolean | null;
+					title: string;
+					user_id: string;
+				};
+				Update: {
+					created_at?: string;
+					id?: string;
+					is_complete?: boolean | null;
+					title?: string;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "todo01_tasks_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: false;
+						referencedRelation: "todo01_profiles";
+						referencedColumns: ["id"];
+					},
+				];
+			};
+		};
+		Views: {
+			[_ in never]: never;
+		};
+		Functions: {
+			get_matching_notes: {
+				Args: { p_domain: string; p_exact: string };
+				Returns: {
+					content: string;
+					created_at: string;
+					draft_id: string | null;
+					id: string;
+					is_expanded: boolean;
+					is_favorite: boolean;
+					is_pinned: boolean;
+					is_resolved: boolean;
+					note_type: string;
+					scope: string;
+					sort_order: number;
+					updated_at: string;
+					url_pattern: string;
+					user_id: string;
+				}[];
+				SetofOptions: {
+					from: "*";
+					to: "sitecue_notes";
+					isOneToOne: false;
+					isSetofReturn: true;
+				};
+			};
+		};
+		Enums: {
+			[_ in never]: never;
+		};
+		CompositeTypes: {
+			[_ in never]: never;
+		};
+	};
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<
+	keyof Database,
+	"public"
+>];
 
 export type Tables<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-    : never = never,
+	DefaultSchemaTableNameOrOptions extends
+		| keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+		| { schema: keyof DatabaseWithoutInternals },
+	TableName extends DefaultSchemaTableNameOrOptions extends {
+		schema: keyof DatabaseWithoutInternals;
+	}
+		? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+				DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+		: never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+	schema: keyof DatabaseWithoutInternals;
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
-    }
-    ? R
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
-      }
-      ? R
-      : never
-    : never
+	? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+			DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+			Row: infer R;
+		}
+		? R
+		: never
+	: DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+				DefaultSchema["Views"])
+		? (DefaultSchema["Tables"] &
+				DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+				Row: infer R;
+			}
+			? R
+			: never
+		: never;
 
 export type TablesInsert<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+	DefaultSchemaTableNameOrOptions extends
+		| keyof DefaultSchema["Tables"]
+		| { schema: keyof DatabaseWithoutInternals },
+	TableName extends DefaultSchemaTableNameOrOptions extends {
+		schema: keyof DatabaseWithoutInternals;
+	}
+		? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+		: never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+	schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
-    }
-    ? I
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
-      }
-      ? I
-      : never
-    : never
+	? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+			Insert: infer I;
+		}
+		? I
+		: never
+	: DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+		? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+				Insert: infer I;
+			}
+			? I
+			: never
+		: never;
 
 export type TablesUpdate<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+	DefaultSchemaTableNameOrOptions extends
+		| keyof DefaultSchema["Tables"]
+		| { schema: keyof DatabaseWithoutInternals },
+	TableName extends DefaultSchemaTableNameOrOptions extends {
+		schema: keyof DatabaseWithoutInternals;
+	}
+		? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+		: never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+	schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
-    }
-    ? U
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
-      }
-      ? U
-      : never
-    : never
+	? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+			Update: infer U;
+		}
+		? U
+		: never
+	: DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+		? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+				Update: infer U;
+			}
+			? U
+			: never
+		: never;
 
 export type Enums<
-  DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
-    | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
+	DefaultSchemaEnumNameOrOptions extends
+		| keyof DefaultSchema["Enums"]
+		| { schema: keyof DatabaseWithoutInternals },
+	EnumName extends DefaultSchemaEnumNameOrOptions extends {
+		schema: keyof DatabaseWithoutInternals;
+	}
+		? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+		: never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+	schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+	? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+	: DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+		? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+		: never;
 
 export type CompositeTypes<
-  PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
-    | { schema: keyof DatabaseWithoutInternals },
-  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never,
+	PublicCompositeTypeNameOrOptions extends
+		| keyof DefaultSchema["CompositeTypes"]
+		| { schema: keyof DatabaseWithoutInternals },
+	CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+		schema: keyof DatabaseWithoutInternals;
+	}
+		? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+		: never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+	schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+	? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+	: PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+		? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+		: never;
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
-  public: {
-    Enums: {},
-  },
-} as const
-
+	graphql_public: {
+		Enums: {},
+	},
+	public: {
+		Enums: {},
+	},
+} as const;


### PR DESCRIPTION
- Why:
  - Eliminate the cognitive load for users to manually specify formats or tones in every request.
  - Enable consistent AI output by applying predefined template instructions (weave_prompt) as system prompts.

- What:
  - Modify DraftEditor.tsx to include template_id in the /ai/weave request payload.
  - Update the backend AI service to fetch weave_prompt from Supabase using the provided template_id.
  - Inject the retrieved weave_prompt as a high-priority system prompt at the beginning of the AI generation logic.