### PR TITLE
feat: add "Edit in Studio" link to draft header

### DIFF
--- a/apps/app/src/app/notes/_components/RightPaneDetail.test.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.test.tsx
@@ -13,7 +13,7 @@ import {
 	vi,
 } from "vitest";
 import { createClient } from "@/utils/supabase/client";
-import type { Note } from "../types";
+import type { Draft, Note } from "../types";
 import { RightPaneDetail } from "./RightPaneDetail";
 
 // Define mock type to avoid 'any'
@@ -355,5 +355,22 @@ describe("RightPaneDetail Component Phase 1 Improvements", () => {
 				scope: "inbox",
 			}),
 		);
+	});
+
+	it("should show 'Edit in Studio' button when a draft is provided", () => {
+		const mockDraft = {
+			id: "test-draft-1",
+			title: "My Draft",
+			content: "Draft content",
+			created_at: "2026-04-12T00:00:00Z",
+			updated_at: "2026-04-12T00:00:00Z",
+			user_id: "test-user",
+		};
+		render(<RightPaneDetail draft={mockDraft as unknown as Draft} />);
+
+		const editLink = screen.getByRole("link", { name: /Edit in Studio/i });
+		expect(editLink).toBeInTheDocument();
+		expect(editLink).toHaveAttribute("href", "/studio/test-draft-1");
+		expect(screen.getByText("My Draft")).toBeInTheDocument();
 	});
 });

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { createClient } from "@/utils/supabase/client";
+import { CustomLink } from "@/components/ui/custom-link";
 import type { Draft, Note } from "../types";
 
 type Props = {
@@ -574,6 +575,16 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 									{isSaving ? "Saving..." : "Save"}
 								</Button>
 							</div>
+						)}
+
+						{!note && draft && (
+							<CustomLink
+								href={`/studio/${draft.id}`}
+								className="flex items-center gap-1.5 px-3 py-1.5 bg-action text-action-text hover:bg-action-hover rounded-md text-sm font-medium shadow-sm transition-colors cursor-pointer"
+							>
+								<Pencil className="size-3.5" aria-hidden="true" />
+								Edit in Studio
+							</CustomLink>
 						)}
 						<div className="flex gap-1 ml-2">
 							{note && (


### PR DESCRIPTION
- Why: Currently, users can only preview drafts in the notes list and lack a seamless way to transition to the editor.
- What: Add a link button to the RightPaneDetail header that navigates to the Studio page (/studio/[id]) when a draft is selected.