### PR TITLE
feat(ui): add resolved notes visibility toggle and refactor styling

### DIFF
--- a/apps/app/src/app/notes/_components/MiddlePaneList.test.tsx
+++ b/apps/app/src/app/notes/_components/MiddlePaneList.test.tsx
@@ -99,4 +99,31 @@ describe("MiddlePaneList Bulk Actions", () => {
 		await user.click(screen.getByRole("button", { name: /cancel/i }));
 		expect(screen.queryByText(/selected/i)).not.toBeInTheDocument();
 	});
+
+	it("should hide resolved notes by default and show them when toggle is clicked", async () => {
+		const user = userEvent.setup();
+		render(
+			<MiddlePaneList
+				items={[
+					...mockItems,
+					{
+						...mockItems[0],
+						id: "resolved-note",
+						content: "Resolved Content",
+						is_resolved: true,
+					},
+				]}
+				currentView="inbox"
+				currentDomain="inbox"
+				currentExact={null}
+				selectedNoteId={null}
+				selectedDraftId={null}
+			/>,
+		);
+		expect(screen.queryByText("Resolved Content")).not.toBeInTheDocument();
+
+		const toggleBtn = screen.getByTitle("Show Resolved Notes");
+		await user.click(toggleBtn);
+		expect(screen.getByText("Resolved Content")).toBeInTheDocument();
+	});
 });

--- a/apps/app/src/app/notes/_components/MiddlePaneList.tsx
+++ b/apps/app/src/app/notes/_components/MiddlePaneList.tsx
@@ -18,6 +18,7 @@ import { CSS } from "@dnd-kit/utilities";
 import {
 	AlertTriangle,
 	ArrowLeft,
+	CheckCircle2,
 	CheckSquare,
 	GripVertical,
 	Inbox,
@@ -90,6 +91,7 @@ export function MiddlePaneList(props: Props) {
 	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 	const [isDeletingBulk, setIsDeletingBulk] = useState(false);
 	const [isSelectMode, setIsSelectMode] = useState(false);
+	const [showResolved, setShowResolved] = useState(false);
 
 	useEffect(() => {
 		// Ensure items have an id and are unique to prevent key warnings and dnd-kit crashes
@@ -198,6 +200,11 @@ export function MiddlePaneList(props: Props) {
 		setSelectedIds(newSelected);
 	};
 
+	const displayItems = localItems.filter((item) => {
+		if ("note_type" in item && item.is_resolved && !showResolved) return false;
+		return true;
+	});
+
 	return (
 		<div className="flex flex-col h-full bg-base-bg border-r border-base-border w-96">
 			<div className="p-4 border-b border-base-border sticky top-0 bg-base-bg z-10">
@@ -216,6 +223,16 @@ export function MiddlePaneList(props: Props) {
 						>
 							<Plus className="w-4 h-4" />
 						</Link>
+						<Button
+							type="button"
+							variant={showResolved ? "secondary" : "ghost"}
+							size="icon-sm"
+							onClick={() => setShowResolved(!showResolved)}
+							className="transition-colors cursor-pointer"
+							title="Show Resolved Notes"
+						>
+							<CheckCircle2 className="w-4 h-4" />
+						</Button>
 						<Button
 							type="button"
 							variant={isSelectMode ? "secondary" : "ghost"}
@@ -263,7 +280,7 @@ export function MiddlePaneList(props: Props) {
 				) : (
 					<p className="text-xs text-gray-500 mt-1">
 						{isSelected
-							? `${items.length} ${currentView === "drafts" ? "drafts" : "notes"}`
+							? `${displayItems.length} ${currentView === "drafts" ? "drafts" : "notes"}`
 							: "Waiting for selection"}
 					</p>
 				)}
@@ -285,10 +302,10 @@ export function MiddlePaneList(props: Props) {
 							to see the list of items
 						</p>
 					</div>
-				) : items.length > 0 ? (
+				) : displayItems.length > 0 ? (
 					<div className="divide-y divide-base-border">
 						{currentView === "drafts" ? (
-							localItems.map((item) => (
+							displayItems.map((item) => (
 								<NoteItem
 									key={item.id}
 									item={item}
@@ -307,10 +324,10 @@ export function MiddlePaneList(props: Props) {
 								onDragEnd={handleDragEnd}
 							>
 								<SortableContext
-									items={localItems.map((item) => item.id)}
+									items={displayItems.map((item) => item.id)}
 									strategy={verticalListSortingStrategy}
 								>
-									{localItems.map((item) => (
+									{displayItems.map((item) => (
 										<SortableNoteItem
 											key={item.id}
 											item={item}
@@ -369,6 +386,7 @@ function NoteItem({
 	onSelectChange?: (id: string, checked: boolean) => void;
 }) {
 	const isNote = "note_type" in item;
+	const isResolved = isNote && item.is_resolved;
 	const isActive = isNote
 		? selectedNoteId === item.id
 		: selectedDraftId === item.id;
@@ -386,7 +404,7 @@ function NoteItem({
 		<div
 			className={`group relative flex items-stretch transition-colors ${
 				isActive ? "bg-base-surface" : "hover:bg-base-surface/50"
-			}`}
+			} ${isResolved ? "opacity-50" : ""}`}
 		>
 			{/* Left Action Area (DnD & Checkbox) */}
 			<div className="flex items-center pl-2 shrink-0">
@@ -442,10 +460,14 @@ function NoteItem({
 						{formatDate(isNote ? item.created_at : item.updated_at)}
 					</span>
 				</div>
-				<h3 className="text-sm font-bold text-action truncate mb-0.5">
+				<h3
+					className={`text-sm font-bold text-action truncate mb-0.5 ${isResolved ? "line-through" : ""}`}
+				>
 					{!isNote && (item.title || "Untitled Draft")}
 				</h3>
-				<p className="text-sm text-action line-clamp-2 wrap-break-word">
+				<p
+					className={`text-sm text-action line-clamp-2 wrap-break-word ${isResolved ? "line-through" : ""}`}
+				>
 					{item.content}
 				</p>
 				{isNote && item.scope === "exact" && !currentExact && (

--- a/apps/app/src/app/notes/_components/RightPaneDetail.test.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.test.tsx
@@ -373,4 +373,18 @@ describe("RightPaneDetail Component Phase 1 Improvements", () => {
 		expect(editLink).toHaveAttribute("href", "/studio/test-draft-1");
 		expect(screen.getByText("My Draft")).toBeInTheDocument();
 	});
+
+	it("should toggle resolved status when note type badge is clicked", async () => {
+		const user = userEvent.setup();
+		render(<RightPaneDetail note={mockNote as unknown as Note} />);
+
+		// Infoバッジ（現在のnote_type）をクリック
+		const resolvedButton = screen.getByRole("button", { name: /info/i });
+		await user.click(resolvedButton);
+
+		expect(supabaseMock.from).toHaveBeenCalledWith("sitecue_notes");
+		expect(supabaseMock.update).toHaveBeenCalledWith(
+			expect.objectContaining({ is_resolved: true }),
+		);
+	});
 });

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -29,6 +29,7 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { CustomLink } from "@/components/ui/custom-link";
 import {
 	Dialog,
 	DialogContent,
@@ -52,7 +53,6 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { createClient } from "@/utils/supabase/client";
-import { CustomLink } from "@/components/ui/custom-link";
 import type { Draft, Note } from "../types";
 
 type Props = {
@@ -404,13 +404,11 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 									}
 									className={cn(
 										"flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase transition-all hover:opacity-80 active:scale-95 cursor-pointer",
-										currentResolved
-											? "bg-green-50 text-green-600 border border-green-200"
-											: currentNoteType === "alert"
-												? "bg-note-alert/10 text-note-alert border border-note-alert/20"
-												: currentNoteType === "idea"
-													? "bg-note-idea/10 text-note-idea border border-note-idea/20"
-													: "bg-note-info/10 text-note-info border border-note-info/20",
+										currentNoteType === "alert"
+											? "bg-note-alert/10 text-note-alert border border-note-alert/20"
+											: currentNoteType === "idea"
+												? "bg-note-idea/10 text-note-idea border border-note-idea/20"
+												: "bg-note-info/10 text-note-info border border-note-info/20",
 									)}
 								>
 									{currentResolved ? (
@@ -422,7 +420,7 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 									) : (
 										<Info className="w-3.5 h-3.5" aria-hidden="true" />
 									)}
-									{currentResolved ? "Completed" : currentNoteType}
+									{currentNoteType}
 								</button>
 							) : (
 								<span className="bg-purple-50 text-purple-500 px-2.5 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase">
@@ -692,7 +690,12 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 					</div>
 				)}
 
-				<div className="space-y-4">
+				<div
+					className={cn(
+						"space-y-4",
+						currentResolved && "opacity-50 transition-opacity",
+					)}
+				>
 					<div className="text-[10px] font-bold text-neutral-400 uppercase tracking-widest px-1">
 						{note ? "Note Content" : "Draft Content"}
 					</div>


### PR DESCRIPTION
- Why: Resolved notes currently clutter the inbox, and the "COMPLETED" badge obscures the original note type information in the detail view.
- What: Implement a "Show Resolved Notes" toggle in MiddlePaneList and apply opacity-50 and line-through styles to resolved items for UX consistency.
- What: Update RightPaneDetail to retain original note type badges while indicating completion via checkmark icons and content transparency.