### PR TITLE
refactor(notes): implement slim fetching and intentional prefetching

### DIFF
--- a/apps/app/src/app/notes/_components/LeftPaneNavigation.test.tsx
+++ b/apps/app/src/app/notes/_components/LeftPaneNavigation.test.tsx
@@ -1,0 +1,79 @@
+/** @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { useNotesStore } from "@/store/useNotesStore";
+import type { GroupedNotes, Note } from "../types";
+import { LeftPaneNavigation } from "./LeftPaneNavigation";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: vi.fn() }),
+	useSearchParams: () => new URLSearchParams(),
+}));
+
+// Mock useNotesStore
+vi.mock("@/store/useNotesStore", () => ({
+	useNotesStore: vi.fn(),
+}));
+
+// Mock UserMenu to avoid Supabase calls
+vi.mock("../../_components/UserMenu", () => ({
+	UserMenu: () => <div data-testid="user-menu" />,
+}));
+
+const mockGroupedNotes = {
+	inbox: [],
+	drafts: [],
+	domains: {
+		"github.com": {
+			domainNotes: [
+				{
+					id: "n1",
+					url_pattern: "github.com",
+					scope: "domain",
+					content: undefined,
+				} as unknown as Note,
+			],
+			pages: {},
+		},
+	},
+} as unknown as GroupedNotes;
+
+describe("LeftPaneNavigation", () => {
+	it("should keep DOMAINS closed by default and fetch content on open", async () => {
+		const user = userEvent.setup();
+		const mockFetchContentForIds = vi.fn();
+
+		vi.mocked(useNotesStore).mockImplementation((selector) => {
+			return selector({
+				fetchContentForIds: mockFetchContentForIds,
+			} as unknown as Parameters<typeof selector>[0]);
+		});
+
+		render(
+			<LeftPaneNavigation
+				groupedNotes={mockGroupedNotes}
+				currentView="inbox"
+				currentDomain="inbox"
+				currentExact={null}
+			/>,
+		);
+
+		// ドメイン名が表示されていることを確認
+		const triggerButton = screen.getByRole("button", {
+			name: /github\.com/i,
+		});
+		expect(triggerButton).toBeDefined();
+
+		// 最初はアコーディオンが閉じていることを確認
+		expect(triggerButton.getAttribute("aria-expanded")).toBe("false");
+
+		// クリックして開く
+		await user.click(triggerButton);
+
+		// 開いた瞬間に、該当ドメインのノートID("n1")で fetchContentForIds が呼ばれることを検証
+		expect(mockFetchContentForIds).toHaveBeenCalledWith(["n1"]);
+		expect(triggerButton.getAttribute("aria-expanded")).toBe("true");
+	});
+});

--- a/apps/app/src/app/notes/_components/LeftPaneNavigation.tsx
+++ b/apps/app/src/app/notes/_components/LeftPaneNavigation.tsx
@@ -13,9 +13,10 @@ import {
 import Image from "next/image";
 import { useState } from "react";
 import { CustomLink as Link } from "@/components/ui/custom-link";
+import { useNotesStore } from "@/store/useNotesStore";
 import { getSafeUrl, normalizeUrlForGrouping } from "@/utils/url";
 import { UserMenu } from "../../_components/UserMenu";
-import type { DomainGroup, GroupedNotes } from "../types";
+import type { DomainGroup, GroupedNotes, Note } from "../types";
 
 type Props = {
 	groupedNotes: GroupedNotes;
@@ -195,7 +196,25 @@ function DomainAccordionItem({
 	currentExact,
 }: DomainAccordionItemProps) {
 	const isUnderThisDomain = currentDomain === domainName;
-	const [isOpen, setIsOpen] = useState(() => isUnderThisDomain);
+	const [isOpen, setIsOpen] = useState(false);
+	const fetchContentForIds = useNotesStore((state) => state.fetchContentForIds);
+
+	const handleOpenChange = (open: boolean) => {
+		setIsOpen(open);
+		if (open) {
+			// フォルダが開かれた瞬間にプリフェッチ
+			const ids = [
+				...domainData.domainNotes,
+				...Object.values(domainData.pages).flat(),
+			]
+				.filter((n): n is Note => n.content === undefined) // 未取得のものだけ抽出
+				.map((n) => n.id);
+
+			if (ids.length > 0) {
+				fetchContentForIds(ids);
+			}
+		}
+	};
 
 	// 検索中、またはこのドメイン配下を選択中の場合は強制展開
 	const effectiveIsOpen = isOpen || !!normalizedQuery || isUnderThisDomain;
@@ -213,7 +232,7 @@ function DomainAccordionItem({
 			{/* Domain Header: Toggles Only */}
 			<button
 				type="button"
-				onClick={() => setIsOpen(!isOpen)}
+				onClick={() => handleOpenChange(!isOpen)}
 				aria-label={`${effectiveIsOpen ? "Close" : "Open"} accordion for ${domainName}`}
 				aria-expanded={effectiveIsOpen}
 				className={`w-full flex items-center gap-1 group px-2 py-1.5 rounded-md text-sm transition-colors cursor-pointer ${

--- a/apps/app/src/app/notes/_components/NotesContainer.tsx
+++ b/apps/app/src/app/notes/_components/NotesContainer.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useMemo } from "react";
+import { useNotesStore } from "@/store/useNotesStore";
+import type { Draft, Note, SearchParams } from "../types";
+import { LeftPaneNavigation } from "./LeftPaneNavigation";
+import { MiddlePaneList } from "./MiddlePaneList";
+import { ResponsiveNotesLayout } from "./ResponsiveNotesLayout";
+import { RightPaneDetail } from "./RightPaneDetail";
+
+export function NotesContainer() {
+	const searchParams = useSearchParams();
+	const {
+		notes,
+		drafts,
+		groupedNotes,
+		isMetadataFetched,
+		fetchMetadata,
+		fetchContentForIds,
+	} = useNotesStore();
+
+	// Convert searchParams to our SearchParams type
+	const params: SearchParams = useMemo(() => {
+		return {
+			view: searchParams.get("view") as SearchParams["view"],
+			domain: searchParams.get("domain") || undefined,
+			exact: searchParams.get("exact") || undefined,
+			noteId: searchParams.get("noteId") || undefined,
+			draftId: searchParams.get("draftId") || undefined,
+			new: searchParams.get("new") || undefined,
+		};
+	}, [searchParams]);
+
+	// 初回メタデータ取得
+	useEffect(() => {
+		fetchMetadata();
+	}, [fetchMetadata]);
+
+	const { domain, exact } = params;
+	const isNewNote = params.new === "note";
+
+	const effectiveView = useMemo(
+		() => params.view || (params.domain ? "domains" : null),
+		[params.view, params.domain],
+	);
+
+	// フィルタリングされた一覧の計算 (既存の page.tsx から移植)
+	const filteredItems = useMemo(() => {
+		if (!groupedNotes) return [];
+
+		let items: (Note | Draft)[] = [];
+		if (effectiveView === "drafts") {
+			items = groupedNotes.drafts;
+		} else if (exact) {
+			items = groupedNotes.domains[domain || ""]?.pages[exact] || [];
+		} else if (effectiveView === "inbox" || domain === "inbox") {
+			items = groupedNotes.inbox;
+		} else if (domain) {
+			const domainData = groupedNotes.domains[domain];
+			if (domainData) {
+				items = [
+					...domainData.domainNotes,
+					...Object.values(domainData.pages).flat(),
+				];
+				// ソート
+				items.sort((a, b) => {
+					const noteA = a as Note;
+					const noteB = b as Note;
+
+					if (noteA.is_pinned !== noteB.is_pinned) {
+						return noteA.is_pinned ? -1 : 1;
+					}
+					if (noteA.sort_order !== noteB.sort_order) {
+						const orderA = noteA.sort_order ?? Number.MAX_SAFE_INTEGER;
+						const orderB = noteB.sort_order ?? Number.MAX_SAFE_INTEGER;
+						return orderA - orderB;
+					}
+					return (
+						new Date(noteB.created_at).getTime() -
+						new Date(noteA.created_at).getTime()
+					);
+				});
+			}
+		}
+		return items;
+	}, [groupedNotes, effectiveView, domain, exact]);
+
+	// フォールバック: 表示されているリストの中に本文(content)がないものがあれば自動取得
+	useEffect(() => {
+		if (!isMetadataFetched || filteredItems.length === 0) return;
+
+		const missingIds = filteredItems
+			.filter(
+				(item): item is Note =>
+					"url_pattern" in item && item.content === undefined,
+			)
+			.map((item) => item.id);
+
+		if (missingIds.length > 0) {
+			fetchContentForIds(missingIds);
+		}
+	}, [filteredItems, isMetadataFetched, fetchContentForIds]);
+
+	// 選択されたノートまたはドラフトの取得
+	const selectedNote = useMemo(
+		() =>
+			params.noteId ? notes.find((n) => n.id === params.noteId) : undefined,
+		[notes, params.noteId],
+	);
+	const selectedDraft = useMemo(
+		() =>
+			params.draftId ? drafts.find((d) => d.id === params.draftId) : undefined,
+		[drafts, params.draftId],
+	);
+
+	if (!isMetadataFetched || !groupedNotes) {
+		return null; // Initial loading state (handled by Suspense if we want a better fallback)
+	}
+
+	return (
+		<ResponsiveNotesLayout
+			selectedNoteId={params.noteId ?? null}
+			selectedDraftId={params.draftId ?? null}
+			leftNode={
+				<LeftPaneNavigation
+					groupedNotes={groupedNotes}
+					currentView={effectiveView}
+					currentDomain={domain ?? null}
+					currentExact={exact ?? null}
+				/>
+			}
+			middleNode={
+				<MiddlePaneList
+					items={filteredItems}
+					currentView={effectiveView}
+					currentDomain={domain ?? null}
+					currentExact={exact ?? null}
+					selectedNoteId={params.noteId ?? null}
+					selectedDraftId={params.draftId ?? null}
+				/>
+			}
+			rightNode={
+				<RightPaneDetail
+					note={selectedNote}
+					draft={selectedDraft}
+					isNewNote={isNewNote}
+				/>
+			}
+		/>
+	);
+}

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -161,7 +161,7 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 		optimisticContent !== null
 			? optimisticContent
 			: note
-				? note.content
+				? note.content ?? ""
 				: draft?.content || "";
 	const createdAt = note ? note.created_at : draft?.created_at || "";
 	const updatedAt = note ? note.updated_at : draft?.updated_at || "";

--- a/apps/app/src/app/notes/page.tsx
+++ b/apps/app/src/app/notes/page.tsx
@@ -1,55 +1,13 @@
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
 import { createClient } from "@/utils/supabase/server";
-import { normalizeUrlForGrouping } from "@/utils/url";
-import { LeftPaneNavigation } from "./_components/LeftPaneNavigation";
-import { MiddlePaneList } from "./_components/MiddlePaneList";
-import { ResponsiveNotesLayout } from "./_components/ResponsiveNotesLayout";
-import { RightPaneDetail } from "./_components/RightPaneDetail";
-import type { Draft, GroupedNotes, Note, SearchParams } from "./types";
-
-function groupNotes(notes: Note[], drafts: Draft[]): GroupedNotes {
-	const grouped: GroupedNotes = {
-		inbox: [],
-		drafts: drafts,
-		domains: {},
-	};
-
-	for (const note of notes) {
-		// scope === 'draft' は一時的なコメントなので除外
-		if (note.scope === "draft") continue;
-
-		if (note.scope === "inbox") {
-			grouped.inbox.push(note);
-			continue;
-		}
-
-		// 正規化したドメイン名（基底ドメイン）をキーにする
-		const normalized = normalizeUrlForGrouping(note.url_pattern);
-		const domain = normalized.split("/")[0];
-
-		if (!grouped.domains[domain]) {
-			grouped.domains[domain] = { domainNotes: [], pages: {} };
-		}
-
-		if (note.scope === "domain") {
-			grouped.domains[domain].domainNotes.push(note);
-		} else if (note.scope === "exact") {
-			if (!grouped.domains[domain].pages[note.url_pattern]) {
-				grouped.domains[domain].pages[note.url_pattern] = [];
-			}
-			grouped.domains[domain].pages[note.url_pattern].push(note);
-		}
-	}
-
-	return grouped;
-}
+import { NotesContainer } from "./_components/NotesContainer";
+import type { SearchParams } from "./types";
 
 export default async function Dashboard(props: {
 	searchParams: Promise<SearchParams>;
 }) {
 	const searchParams = await props.searchParams;
-	const { domain, exact } = searchParams;
-	const isNewNote = searchParams.new === "note";
 
 	const supabase = await createClient();
 
@@ -61,7 +19,7 @@ export default async function Dashboard(props: {
 		return redirect("/login");
 	}
 
-	// 追加: パラメータが何もない場合は Inbox へリダイレクト
+	// パラメータが何もない場合は Inbox へリダイレクト
 	if (
 		!searchParams.view &&
 		!searchParams.domain &&
@@ -72,104 +30,9 @@ export default async function Dashboard(props: {
 		redirect("/notes?domain=inbox");
 	}
 
-	const [notesRes, draftsRes] = await Promise.all([
-		supabase
-			.from("sitecue_notes")
-			.select("*")
-			.eq("user_id", user.id)
-			.order("is_pinned", { ascending: false })
-			.order("sort_order", { ascending: true })
-			.order("created_at", { ascending: false }),
-		supabase
-			.from("sitecue_drafts")
-			.select("*")
-			.eq("user_id", user.id)
-			.order("updated_at", { ascending: false }),
-	]);
-
-	const notes = (notesRes.data as Note[]) || [];
-	const drafts = (draftsRes.data as Draft[]) || [];
-	const groupedNotes = groupNotes(notes, drafts);
-
-	const effectiveView =
-		searchParams.view || (searchParams.domain ? "domains" : null);
-
-	// フィルタリングされた一覧の取得
-	let filteredItems: (Note | Draft)[] = [];
-	if (effectiveView === "drafts") {
-		filteredItems = groupedNotes.drafts;
-	} else if (exact) {
-		filteredItems = groupedNotes.domains[domain || ""]?.pages[exact] || [];
-	} else if (effectiveView === "inbox" || domain === "inbox") {
-		filteredItems = groupedNotes.inbox;
-	} else if (domain) {
-		const domainData = groupedNotes.domains[domain];
-		if (domainData) {
-			filteredItems = [
-				...domainData.domainNotes,
-				...Object.values(domainData.pages).flat(),
-			];
-			// 最後にピン留め → sort_order → 作成日時順にソートし直す
-			filteredItems.sort((a, b) => {
-				const noteA = a as Note;
-				const noteB = b as Note;
-
-				// 1. ピン留め (is_pinned) が true のものを優先
-				if (noteA.is_pinned !== noteB.is_pinned) {
-					return noteA.is_pinned ? -1 : 1;
-				}
-				// 2. sort_order が設定されている場合は小さい順（昇順）
-				if (noteA.sort_order !== noteB.sort_order) {
-					const orderA = noteA.sort_order ?? Number.MAX_SAFE_INTEGER;
-					const orderB = noteB.sort_order ?? Number.MAX_SAFE_INTEGER;
-					return orderA - orderB;
-				}
-				// 3. どちらも同じなら created_at の新しい順（降順）
-				return (
-					new Date(noteB.created_at).getTime() -
-					new Date(noteA.created_at).getTime()
-				);
-			});
-		}
-	}
-
-	// 選択されたノートまたはドラフトの取得
-	const selectedNote = searchParams.noteId
-		? notes.find((n) => n.id === searchParams.noteId)
-		: undefined;
-	const selectedDraft = searchParams.draftId
-		? drafts.find((d) => d.id === searchParams.draftId)
-		: undefined;
-
 	return (
-		<ResponsiveNotesLayout
-			selectedNoteId={searchParams.noteId ?? null}
-			selectedDraftId={searchParams.draftId ?? null}
-			leftNode={
-				<LeftPaneNavigation
-					groupedNotes={groupedNotes}
-					currentView={effectiveView}
-					currentDomain={domain ?? null}
-					currentExact={exact ?? null}
-				/>
-			}
-			middleNode={
-				<MiddlePaneList
-					items={filteredItems}
-					currentView={effectiveView}
-					currentDomain={domain ?? null}
-					currentExact={exact ?? null}
-					selectedNoteId={searchParams.noteId ?? null}
-					selectedDraftId={searchParams.draftId ?? null}
-				/>
-			}
-			rightNode={
-				<RightPaneDetail
-					note={selectedNote}
-					draft={selectedDraft}
-					isNewNote={isNewNote}
-				/>
-			}
-		/>
+		<Suspense fallback={null}>
+			<NotesContainer />
+		</Suspense>
 	);
 }

--- a/apps/app/src/app/notes/types.ts
+++ b/apps/app/src/app/notes/types.ts
@@ -1,6 +1,8 @@
 import type { Tables } from "../../../../../types/supabase";
 
-export type Note = Tables<"sitecue_notes">;
+export type Note = Omit<Tables<"sitecue_notes">, "content"> & {
+	content?: string;
+};
 export type Draft = Tables<"sitecue_drafts">;
 
 export interface DomainGroup {

--- a/apps/app/src/store/useNotesStore.ts
+++ b/apps/app/src/store/useNotesStore.ts
@@ -1,0 +1,115 @@
+import { create } from "zustand";
+import type { Draft, GroupedNotes, Note } from "@/app/notes/types";
+import { createClient } from "@/utils/supabase/client";
+import { normalizeUrlForGrouping } from "@/utils/url";
+
+interface NotesState {
+	notes: Note[];
+	drafts: Draft[];
+	groupedNotes: GroupedNotes | null;
+	isMetadataFetched: boolean;
+	fetchMetadata: () => Promise<void>;
+	fetchContentForIds: (ids: string[]) => Promise<void>;
+}
+
+function groupNotes(notes: Note[], drafts: Draft[]): GroupedNotes {
+	const grouped: GroupedNotes = {
+		inbox: [],
+		drafts: drafts,
+		domains: {},
+	};
+
+	for (const note of notes) {
+		// scope === 'draft' は一時的なコメントなので除外
+		if (note.scope === "draft") continue;
+
+		if (note.scope === "inbox") {
+			grouped.inbox.push(note);
+			continue;
+		}
+
+		// 正規化したドメイン名（基底ドメイン）をキーにする
+		const normalized = normalizeUrlForGrouping(note.url_pattern);
+		const domain = normalized.split("/")[0];
+
+		if (!grouped.domains[domain]) {
+			grouped.domains[domain] = { domainNotes: [], pages: {} };
+		}
+
+		if (note.scope === "domain") {
+			grouped.domains[domain].domainNotes.push(note);
+		} else if (note.scope === "exact") {
+			if (!grouped.domains[domain].pages[note.url_pattern]) {
+				grouped.domains[domain].pages[note.url_pattern] = [];
+			}
+			grouped.domains[domain].pages[note.url_pattern].push(note);
+		}
+	}
+
+	return grouped;
+}
+
+export const useNotesStore = create<NotesState>((set, get) => ({
+	notes: [],
+	drafts: [],
+	groupedNotes: null,
+	isMetadataFetched: false,
+
+	fetchMetadata: async () => {
+		if (get().isMetadataFetched) return;
+		const supabase = createClient();
+		const {
+			data: { user },
+		} = await supabase.auth.getUser();
+		if (!user) return;
+
+		const [notesRes, draftsRes] = await Promise.all([
+			// content を除外した Slim Fetching
+			supabase
+				.from("sitecue_notes")
+				.select(
+					"id, user_id, url_pattern, scope, note_type, is_pinned, is_resolved, is_favorite, is_expanded, sort_order, created_at, updated_at, draft_id",
+				)
+				.eq("user_id", user.id)
+				.order("is_pinned", { ascending: false })
+				.order("sort_order", { ascending: true })
+				.order("created_at", { ascending: false }),
+			supabase
+				.from("sitecue_drafts")
+				.select("*")
+				.eq("user_id", user.id)
+				.order("updated_at", { ascending: false }),
+		]);
+
+		const notes = (notesRes.data as Note[]) || [];
+		const drafts = (draftsRes.data as Draft[]) || [];
+		const groupedNotes = groupNotes(notes, drafts);
+
+		set({ notes, drafts, groupedNotes, isMetadataFetched: true });
+	},
+
+	fetchContentForIds: async (ids: string[]) => {
+		if (ids.length === 0) return;
+		const supabase = createClient();
+
+		const { data } = await supabase
+			.from("sitecue_notes")
+			.select("id, content")
+			.in("id", ids);
+
+		if (!data) return;
+
+		const contentMap = new Map(data.map((n) => [n.id, n.content]));
+
+		const updatedNotes = get().notes.map((note) =>
+			contentMap.has(note.id)
+				? { ...note, content: contentMap.get(note.id) as string }
+				: note,
+		);
+
+		set({
+			notes: updatedNotes,
+			groupedNotes: groupNotes(updatedNotes, get().drafts),
+		});
+	},
+}));


### PR DESCRIPTION
- Background: Eliminate legacy SSR overhead and reduce network/memory usage by shifting to a metadata-first retrieval approach, preparing for future layout consolidation.
- Implementation:
  - Update initial load to fetch only note metadata without `content` via Zustand.
  - Set domain accordions to be closed by default.
  - Implement background prefetching that triggers when a domain folder is opened.
  - Add fallback logic in `NotesContainer` to fetch content if missing during direct access.