### PR TITLE
feat(ext): enhance ui/ux and streamline permissions

### DIFF
--- a/apps/extension/src/SidePanel.tsx
+++ b/apps/extension/src/SidePanel.tsx
@@ -15,7 +15,7 @@ import { useUserStats } from "./hooks/useUserStats";
 
 import { getScopeUrls } from "./utils/url";
 
-const MAX_FREE_NOTES = 200;
+const MAX_FREE_NOTES = 500;
 
 export default function SidePanel() {
 	const {
@@ -30,7 +30,7 @@ export default function SidePanel() {
 	if (sessionLoading) {
 		return (
 			<div className="w-full h-screen bg-base-surface flex flex-col items-center justify-center font-sans">
-				<Loader2 className="w-8 h-8 animate-spin text-gray-500" />
+				<Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
 			</div>
 		);
 	}
@@ -159,7 +159,7 @@ function NotesUI({
 			{userStatsLoading ? (
 				<div className="p-4 bg-base-surface border-t border-base-border space-y-3">
 					<div className="flex items-center justify-center py-4">
-						<Loader2 className="w-5 h-5 animate-spin text-gray-300" />
+						<Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
 					</div>
 				</div>
 			) : (

--- a/apps/extension/src/components/FilterBar.tsx
+++ b/apps/extension/src/components/FilterBar.tsx
@@ -109,7 +109,7 @@ export default function FilterBar({
 					className={`cursor-pointer pb-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
 						viewScope === "exact"
 							? "border-action text-action"
-							: "border-transparent text-gray-400 hover:text-action hover:border-base-border"
+							: "border-transparent text-muted-foreground hover:text-action hover:border-base-border"
 					}`}
 				>
 					Page
@@ -120,7 +120,7 @@ export default function FilterBar({
 					className={`cursor-pointer pb-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
 						viewScope === "domain"
 							? "border-action text-action"
-							: "border-transparent text-gray-400 hover:text-action hover:border-base-border"
+							: "border-transparent text-muted-foreground hover:text-action hover:border-base-border"
 					}`}
 				>
 					Domain
@@ -131,7 +131,7 @@ export default function FilterBar({
 					className={`cursor-pointer pb-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
 						viewScope === "inbox"
 							? "border-action text-action"
-							: "border-transparent text-gray-400 hover:text-action hover:border-base-border"
+							: "border-transparent text-muted-foreground hover:text-action hover:border-base-border"
 					}`}
 				>
 					Inbox
@@ -147,7 +147,7 @@ export default function FilterBar({
 						className={`cursor-pointer py-1 px-2 rounded text-xs font-medium transition-colors ${
 							filterType === "all"
 								? "bg-base-surface text-action shadow-sm"
-								: "text-gray-400 hover:text-white"
+								: "text-muted-foreground hover:text-white"
 						}`}
 					>
 						All
@@ -158,7 +158,7 @@ export default function FilterBar({
 						className={`cursor-pointer py-1 px-2 rounded transition-colors ${
 							filterType === "info"
 								? "bg-base-surface text-action shadow-sm"
-								: "text-gray-400 hover:text-white"
+								: "text-muted-foreground hover:text-white"
 						}`}
 						title="Info"
 					>
@@ -170,7 +170,7 @@ export default function FilterBar({
 						className={`cursor-pointer py-1 px-2 rounded transition-colors ${
 							filterType === "alert"
 								? "bg-base-surface text-action shadow-sm"
-								: "text-gray-400 hover:text-white"
+								: "text-muted-foreground hover:text-white"
 						}`}
 						title="Alert"
 					>
@@ -182,7 +182,7 @@ export default function FilterBar({
 						className={`cursor-pointer py-1 px-2 rounded transition-colors ${
 							filterType === "idea"
 								? "bg-base-surface text-action shadow-sm"
-								: "text-gray-400 hover:text-white"
+								: "text-muted-foreground hover:text-white"
 						}`}
 						title="Idea"
 					>
@@ -199,7 +199,7 @@ export default function FilterBar({
 							className={`cursor-pointer p-1.5 rounded transition-colors shrink-0 ${
 								isSearchOpen || searchQuery
 									? "bg-base-bg text-action"
-									: "text-gray-400 hover:text-action hover:bg-base-bg"
+									: "text-muted-foreground hover:text-action hover:bg-base-bg"
 							}`}
 						>
 							<Search className="w-3.5 h-3.5" />
@@ -219,7 +219,7 @@ export default function FilterBar({
 									onBlur={() => {
 										if (!searchQuery) setIsSearchOpen(false);
 									}}
-									className="w-full min-w-0 text-xs pl-2 pr-6 py-1 bg-base-bg border-none rounded focus:outline-none focus:ring-1 focus:ring-action/30 placeholder:text-gray-400"
+									className="w-full min-w-0 text-xs pl-2 pr-6 py-1 bg-base-bg border-none rounded focus:outline-none focus:ring-1 focus:ring-action/30 placeholder:text-muted-foreground"
 								/>
 								{searchQuery && (
 									<button
@@ -232,7 +232,7 @@ export default function FilterBar({
 											setSearchQuery("");
 											inputRef.current?.focus();
 										}}
-										className="absolute right-1 cursor-pointer p-0.5 text-gray-400 hover:text-action transition-colors shrink-0"
+										className="absolute right-1 cursor-pointer p-0.5 text-muted-foreground hover:text-action transition-colors shrink-0"
 										title="Clear search"
 									>
 										<X className="w-3 h-3" />
@@ -252,7 +252,7 @@ export default function FilterBar({
 									? "text-note-info bg-note-info/10"
 									: isCopyMenuOpen
 										? "text-action bg-base-bg"
-										: "text-gray-400 hover:text-action hover:bg-base-bg"
+										: "text-muted-foreground hover:text-action hover:bg-base-bg"
 							}`}
 							title={isCopied ? "Copied!" : "Copy options"}
 							aria-label={isCopied ? "Copied!" : "Open copy options menu"}
@@ -269,14 +269,14 @@ export default function FilterBar({
 								<button
 									type="button"
 									onClick={handleCopyText}
-									className="w-full text-left px-3 py-1.5 text-xs text-gray-600 hover:bg-base-bg transition-colors"
+									className="w-full text-left px-3 py-1.5 text-xs text-muted-foreground hover:bg-base-bg transition-colors"
 								>
 									Copy as Text
 								</button>
 								<button
 									type="button"
 									onClick={handleCopyJson}
-									className="w-full text-left px-3 py-1.5 text-xs text-gray-600 hover:bg-base-bg transition-colors"
+									className="w-full text-left px-3 py-1.5 text-xs text-muted-foreground hover:bg-base-bg transition-colors"
 								>
 									Copy as JSON
 								</button>

--- a/apps/extension/src/components/Header.tsx
+++ b/apps/extension/src/components/Header.tsx
@@ -127,7 +127,7 @@ export default function Header({
 							</span>
 						)}
 					</h1>
-					<p className="text-xs text-gray-400 truncate" title={url}>
+					<p className="text-xs text-muted-foreground truncate" title={url}>
 						{url || "Waiting..."}
 					</p>
 				</div>
@@ -135,14 +135,14 @@ export default function Header({
 					<button
 						type="button"
 						onClick={() => setIsSettingsOpen(!isSettingsOpen)}
-						className={`cursor-pointer p-1.5 rounded-full transition-colors ${isSettingsOpen ? "bg-action text-action-text" : "text-gray-400 hover:text-action"}`}
+						className={`cursor-pointer p-1.5 rounded-full transition-colors ${isSettingsOpen ? "bg-action text-action-text" : "text-muted-foreground hover:text-action"}`}
 					>
 						<Settings className="w-4 h-4" />
 					</button>
 					<button
 						type="button"
 						onClick={onLogout}
-						className="cursor-pointer p-1.5 text-gray-400 hover:text-action shrink-0"
+						className="cursor-pointer p-1.5 text-muted-foreground hover:text-action shrink-0"
 					>
 						<LogOut className="w-4 h-4" />
 					</button>
@@ -156,7 +156,7 @@ export default function Header({
 						<div>
 							<label
 								htmlFor="label-input"
-								className="text-xs font-medium text-neutral-500 mb-1.5 block"
+								className="text-xs font-medium text-muted-foreground mb-1.5 block"
 							>
 								Label
 							</label>
@@ -166,13 +166,13 @@ export default function Header({
 								value={editLabel}
 								onChange={(e) => setEditLabel(e.target.value.slice(0, 10))}
 								placeholder="e.g. PROD, DEV"
-								className="w-full text-xs text-action border border-base-border rounded p-1.5 focus:outline-none focus:ring-1 focus:ring-action placeholder-gray-400"
+								className="w-full text-xs text-action border border-base-border rounded p-1.5 focus:outline-none focus:ring-1 focus:ring-action placeholder-muted-foreground"
 							/>
 						</div>
 						<div>
 							<label
 								htmlFor="color-button"
-								className="text-xs font-medium text-gray-500 mb-1.5 block"
+								className="text-xs font-medium text-muted-foreground mb-1.5 block"
 							>
 								Color
 							</label>
@@ -181,7 +181,7 @@ export default function Header({
 									id="color-button"
 									type="button"
 									onClick={() => setEditColor("")}
-									className={`cursor-pointer w-4 h-4 rounded-full transition-all flex items-center justify-center border border-transparent text-gray-400 hover:text-action ${editColor === "" ? "text-action bg-base-bg" : ""}`}
+									className={`cursor-pointer w-4 h-4 rounded-full transition-all flex items-center justify-center border border-transparent text-muted-foreground hover:text-action ${editColor === "" ? "text-action bg-base-bg" : ""}`}
 									title="Clear Settings"
 								>
 									<CircleOff className="w-3.5 h-3.5" />
@@ -202,7 +202,7 @@ export default function Header({
 							<button
 								type="button"
 								onClick={() => setIsSettingsOpen(false)}
-								className="cursor-pointer px-3 py-1 text-xs text-gray-500 hover:text-action"
+								className="cursor-pointer px-3 py-1 text-xs text-muted-foreground hover:text-action"
 							>
 								Cancel
 							</button>

--- a/apps/extension/src/components/LoginScreen.tsx
+++ b/apps/extension/src/components/LoginScreen.tsx
@@ -15,7 +15,7 @@ export default function LoginScreen({
 				<h1 className="text-xl font-bold text-center mb-2 text-action">
 					Welcome to SiteCue
 				</h1>
-				<p className="text-xs text-center text-gray-500 mb-6">
+				<p className="text-xs text-center text-muted-foreground mb-6">
 					Sign in to sync your notes across devices
 				</p>
 
@@ -73,13 +73,13 @@ export default function LoginScreen({
 					</button>
 				</div>
 
-				<p className="text-xs text-gray-500 mt-4 text-center">
+				<p className="text-xs text-muted-foreground mt-4 text-center">
 					By signing in, you agree to our{" "}
 					<a
 						href="https://grey-throat-c6a.notion.site/Privacy-Policy-for-sitecue-30eee95bb40780f396f0e27e417db8bf"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="underline hover:text-gray-700"
+						className="underline hover:text-action"
 					>
 						Privacy Policy
 					</a>

--- a/apps/extension/src/components/MarkdownRenderer.tsx
+++ b/apps/extension/src/components/MarkdownRenderer.tsx
@@ -130,10 +130,10 @@ export default function MarkdownRenderer({
 						<strong className="font-semibold text-action">{children}</strong>
 					),
 					em: ({ children }) => (
-						<em className="italic text-neutral-600">{children}</em>
+						<em className="italic text-muted-foreground">{children}</em>
 					),
 					blockquote: ({ children }) => (
-						<blockquote className="border-l-4 border-base-border pl-4 py-1 my-2 bg-base-bg italic text-gray-600 rounded-r">
+						<blockquote className="border-l-4 border-base-border pl-4 py-1 my-2 bg-base-bg italic text-muted-foreground rounded-r">
 							{children}
 						</blockquote>
 					),
@@ -180,7 +180,7 @@ export default function MarkdownRenderer({
 									<button
 										type="button"
 										onClick={() => handleCopyCode(codeString, uniqueId)}
-										className="p-1.5 text-gray-500 hover:text-action flex items-center justify-center transition-colors cursor-pointer"
+										className="p-1.5 text-muted-foreground hover:text-action flex items-center justify-center transition-colors cursor-pointer"
 										title="Copy code"
 									>
 										{isCopied ? (
@@ -231,7 +231,7 @@ export default function MarkdownRenderer({
 					),
 					tr: ({ children }) => <tr>{children}</tr>,
 					th: ({ children }) => (
-						<th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+						<th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
 							{children}
 						</th>
 					),

--- a/apps/extension/src/components/NoteInput.tsx
+++ b/apps/extension/src/components/NoteInput.tsx
@@ -27,6 +27,9 @@ export default function NoteInput({
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const handleAutoIndent = useAutoIndent();
 
+	const isNearLimit = totalNoteCount >= maxFreeNotes * 0.9;
+	const isLimitReached = totalNoteCount >= maxFreeNotes;
+
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
 		const content = newNote.trim();
@@ -79,50 +82,71 @@ export default function NoteInput({
 				</div>
 
 				<div className="flex items-center gap-3">
-					{userPlan === "free" && (
-						<span className="text-[10px] text-gray-400 font-medium">
-							{totalNoteCount} / {maxFreeNotes}
-						</span>
+					{/* カウンターは引き算の美学に基づき非表示化。将来の参考のためコメントアウトで残す */}
+					{/* {userPlan === "free" && (
+						<div className="flex items-center gap-2">
+							{isNearLimit && (
+								<span className="text-[9px] text-note-alert opacity-90 hidden sm:inline">
+									To manage or upgrade, visit the App.
+								</span>
+							)}
+							<span
+								className={`text-[10px] font-medium ${isNearLimit ? "text-note-alert" : "text-muted-foreground"}`}
+							>
+								{totalNoteCount}
+							</span>
+						</div>
 					)}
+					*/}
 
 					<div className="flex bg-base-surface p-0.5 rounded-md">
 						<button
 							type="button"
 							onClick={() => setSelectedType("info")}
-							className={`cursor-pointer p-1 rounded ${selectedType === "info" ? "bg-action shadow-sm text-action-text" : "text-gray-400 hover:text-action"}`}
+							className={`cursor-pointer p-1 rounded ${selectedType === "info" ? "bg-action shadow-sm text-action-text" : "text-muted-foreground hover:text-action"}`}
 							title="Info"
 						>
-							<Info className="w-4 h-4" strokeWidth={2} />
+							<Info className="w-4 h-4" />
 						</button>
 						<button
 							type="button"
 							onClick={() => setSelectedType("alert")}
-							className={`cursor-pointer p-1 rounded ${selectedType === "alert" ? "bg-action shadow-sm text-action-text" : "text-gray-400 hover:text-action"}`}
+							className={`cursor-pointer p-1 rounded ${selectedType === "alert" ? "bg-action shadow-sm text-action-text" : "text-muted-foreground hover:text-action"}`}
 							title="Alert"
 						>
-							<AlertTriangle className="w-4 h-4" strokeWidth={2} />
+							<AlertTriangle className="w-4 h-4" />
 						</button>
 						<button
 							type="button"
 							onClick={() => setSelectedType("idea")}
-							className={`cursor-pointer p-1 rounded ${selectedType === "idea" ? "bg-action shadow-sm text-action-text" : "text-gray-400 hover:text-action"}`}
+							className={`cursor-pointer p-1 rounded ${selectedType === "idea" ? "bg-action shadow-sm text-action-text" : "text-muted-foreground hover:text-action"}`}
 							title="Idea"
 						>
-							<Lightbulb className="w-4 h-4" strokeWidth={2} />
+							<Lightbulb className="w-4 h-4" />
 						</button>
 					</div>
 				</div>
 			</div>
 
+			{userPlan === "free" && isNearLimit && !isLimitReached && (
+				<div className="flex items-start gap-2 p-2 mb-2 text-xs text-note-alert bg-note-alert/10 border border-note-alert/20 rounded">
+					<AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+					<p>
+						Approaching limit ({totalNoteCount}/{maxFreeNotes}). Please visit
+						Basecamp to free up space or unlock unlimited notes.
+					</p>
+				</div>
+			)}
+
 			<form onSubmit={handleSubmit} className="flex gap-2 items-center">
-				{userPlan === "free" && totalNoteCount >= maxFreeNotes ? (
+				{userPlan === "free" && isLimitReached ? (
 					<div className="w-full bg-note-idea/10 border border-note-idea/20 rounded-lg p-3 text-sm text-note-idea flex items-start gap-3">
 						<AlertTriangle className="w-5 h-5 shrink-0 mt-0.5" />
 						<div>
-							<div className="font-bold mb-1">FREE Plan Limit Reached</div>
+							<div className="font-bold mb-1">Note Limit Reached</div>
 							<p className="text-xs opacity-90">
-								You have reached the {maxFreeNotes} note limit. Please delete
-								some existing notes to create new ones.
+								You have reached the {maxFreeNotes}-note limit. Please visit
+								Basecamp to free up space or upgrade for unlimited access.
 							</p>
 						</div>
 					</div>

--- a/apps/extension/src/components/NoteItem.tsx
+++ b/apps/extension/src/components/NoteItem.tsx
@@ -186,7 +186,7 @@ export default function NoteItem({
 							<button
 								type="button"
 								onClick={() => setEditType("info")}
-								className={`cursor-pointer p-1 rounded ${editType === "info" ? "bg-note-info shadow-sm text-action-text" : "text-gray-400 hover:text-note-info"}`}
+								className={`cursor-pointer p-1 rounded ${editType === "info" ? "bg-note-info shadow-sm text-action-text" : "text-muted-foreground hover:text-note-info"}`}
 								title="Info"
 							>
 								<Info className="w-3.5 h-3.5" />
@@ -194,7 +194,7 @@ export default function NoteItem({
 							<button
 								type="button"
 								onClick={() => setEditType("alert")}
-								className={`cursor-pointer p-1 rounded ${editType === "alert" ? "bg-note-alert shadow-sm text-action-text" : "text-gray-400 hover:text-note-alert"}`}
+								className={`cursor-pointer p-1 rounded ${editType === "alert" ? "bg-note-alert shadow-sm text-action-text" : "text-muted-foreground hover:text-note-alert"}`}
 								title="Alert"
 							>
 								<AlertTriangle className="w-3.5 h-3.5" />
@@ -202,7 +202,7 @@ export default function NoteItem({
 							<button
 								type="button"
 								onClick={() => setEditType("idea")}
-								className={`cursor-pointer p-1 rounded ${editType === "idea" ? "bg-note-idea shadow-sm text-action-text" : "text-gray-400 hover:text-note-idea"}`}
+								className={`cursor-pointer p-1 rounded ${editType === "idea" ? "bg-note-idea shadow-sm text-action-text" : "text-muted-foreground hover:text-note-idea"}`}
 								title="Idea"
 							>
 								<Lightbulb className="w-3.5 h-3.5" />
@@ -228,7 +228,7 @@ export default function NoteItem({
 						<button
 							type="button"
 							onClick={cancelEditing}
-							className="cursor-pointer p-1 text-gray-400 hover:text-gray-600 rounded"
+							className="cursor-pointer p-1 text-muted-foreground hover:text-gray-600 rounded"
 						>
 							<X className="w-4 h-4" />
 						</button>
@@ -300,13 +300,13 @@ export default function NoteItem({
 								className="flex items-center mr-0.5 outline-none cursor-default"
 								title={`Scope: ${note.scope === "exact" ? "Page" : note.scope === "inbox" ? "Inbox" : "Domain"}\nCreated: ${Intl.DateTimeFormat("sv-SE").format(new Date(note.created_at))}`}
 							>
-								<Info className="w-3.5 h-3.5 text-gray-400 hover:text-action" />
+								<Info className="w-3.5 h-3.5 text-muted-foreground hover:text-action" />
 							</div>
 
 							<button
 								type="button"
 								onClick={() => onToggleFavorite(note)}
-								className={`cursor-pointer hover:scale-110 transition-transform ${note.is_favorite ? "text-action fill-current" : "text-gray-400 hover:text-action"}`}
+								className={`cursor-pointer hover:scale-110 transition-transform ${note.is_favorite ? "text-action fill-current" : "text-muted-foreground hover:text-action"}`}
 								title={
 									note.is_favorite
 										? "Remove from favorites"
@@ -320,7 +320,7 @@ export default function NoteItem({
 							<button
 								type="button"
 								onClick={() => onTogglePinned(note)}
-								className={`cursor-pointer hover:scale-110 transition-transform ${note.is_pinned ? "text-action fill-current" : "text-gray-400 hover:text-action"}`}
+								className={`cursor-pointer hover:scale-110 transition-transform ${note.is_pinned ? "text-action fill-current" : "text-muted-foreground hover:text-action"}`}
 								title={note.is_pinned ? "Unpin note" : "Pin note"}
 							>
 								<Pin
@@ -337,21 +337,26 @@ export default function NoteItem({
 						>
 							<div
 								ref={contentRef}
-								className={`text-sm mb-0 pt-2 pl-2 ${note.is_resolved ? "line-through text-gray-400" : "text-action"}`}
+								className={`text-sm mb-0 pt-2 pl-2 ${note.is_resolved ? "line-through text-muted-foreground" : "text-action"}`}
 							>
 								<MarkdownRenderer content={note.content} />
 							</div>
+
+							{/* 縮小時に下部を背景色へフェードアウトさせるグラデーション */}
+							{isCollapsed && (
+								<div className="absolute bottom-0 left-0 w-full h-12 bg-gradient-to-t from-base-bg to-transparent pointer-events-none" />
+							)}
 						</div>
 
 						{/* 展開ボタン */}
 						{(isCollapsed || (note.is_expanded && isOverflowing)) && (
-							<div className="mt-1 flex justify-center">
+							<div className="mt-1 flex justify-center relative z-10">
 								<button
 									type="button"
 									onClick={() =>
 										onToggleExpansion(note.id, note.is_expanded ?? false)
 									}
-									className="cursor-pointer text-[10px] text-gray-400 hover:text-action transition-colors bg-base-surface hover:bg-base-border px-2 py-0.5 rounded"
+									className="cursor-pointer text-[10px] text-muted-foreground hover:text-action transition-colors bg-base-surface hover:bg-base-border px-2 py-0.5 rounded"
 								>
 									{isCollapsed ? "Read more" : "Show less"}
 								</button>
@@ -361,9 +366,9 @@ export default function NoteItem({
 
 					{/* Favoriteリスト時のみのメタデータ（必要なら引き続き表示） */}
 					{isFavoriteList && note.scope !== "inbox" && (
-						<div className="text-[10px] text-gray-400 flex items-center gap-2 mt-1">
+						<div className="text-[10px] text-muted-foreground flex items-center gap-2 mt-1">
 							<span
-								className={`px-1 rounded border ${note.scope === "exact" ? "bg-base-bg border-base-border text-gray-500" : "bg-base-surface border-base-border text-gray-400"}`}
+								className={`px-1 rounded border ${note.scope === "exact" ? "bg-base-bg border-base-border text-gray-500" : "bg-base-surface border-base-border text-muted-foreground"}`}
 							>
 								{note.scope === "exact" ? "Page" : "Domain"}
 							</span>
@@ -396,7 +401,7 @@ export default function NoteItem({
 										type="button"
 										onClick={handleMoveUp}
 										disabled={!onMoveUp || isSwapping || isFirst || isSorting}
-										className={`transition-colors ${!onMoveUp || isSwapping || isFirst || isSorting ? "text-base-border cursor-not-allowed" : "text-gray-400 hover:text-action cursor-pointer"}`}
+										className={`transition-colors ${!onMoveUp || isSwapping || isFirst || isSorting ? "text-base-border cursor-not-allowed" : "text-muted-foreground hover:text-action cursor-pointer"}`}
 										title="Move up"
 									>
 										<ChevronUp className="w-4 h-4" />
@@ -405,14 +410,16 @@ export default function NoteItem({
 										type="button"
 										onClick={handleMoveDown}
 										disabled={!onMoveDown || isSwapping || isLast || isSorting}
-										className={`transition-colors ${!onMoveDown || isSwapping || isLast || isSorting ? "text-base-border cursor-not-allowed" : "text-gray-400 hover:text-action cursor-pointer"}`}
+										className={`transition-colors ${!onMoveDown || isSwapping || isLast || isSorting ? "text-base-border cursor-not-allowed" : "text-muted-foreground hover:text-action cursor-pointer"}`}
 										title="Move down"
 									>
 										<ChevronDown className="w-4 h-4" />
 									</button>
 								</>
 							) : (
-								<span className="text-[10px] text-gray-400 ml-1">Pinned</span>
+								<span className="text-[10px] text-muted-foreground ml-1">
+									Pinned
+								</span>
 							)}
 						</div>
 
@@ -421,7 +428,7 @@ export default function NoteItem({
 							<button
 								type="button"
 								onClick={handleCopyNote}
-								className="cursor-pointer text-gray-400 hover:text-action transition-colors"
+								className="cursor-pointer text-muted-foreground hover:text-action transition-colors"
 								title="Copy note"
 							>
 								{copiedNoteId === note.id ? (
@@ -433,7 +440,7 @@ export default function NoteItem({
 							<button
 								type="button"
 								onClick={startEditing}
-								className="cursor-pointer text-gray-400 hover:text-action transition-colors"
+								className="cursor-pointer text-muted-foreground hover:text-action transition-colors"
 								title="Edit"
 							>
 								<Edit2 className="w-3.5 h-3.5" />
@@ -441,7 +448,7 @@ export default function NoteItem({
 							<button
 								type="button"
 								onClick={() => onDelete(note.id)}
-								className="cursor-pointer text-gray-400 hover:text-note-alert transition-colors"
+								className="cursor-pointer text-muted-foreground hover:text-note-alert transition-colors"
 								title="Delete"
 							>
 								<Trash2 className="w-3.5 h-3.5" />

--- a/apps/extension/src/components/NoteList.tsx
+++ b/apps/extension/src/components/NoteList.tsx
@@ -90,7 +90,7 @@ export default function NoteList({
 	if (loading && notes.length === 0) {
 		return (
 			<div className="flex justify-center p-8">
-				<Loader2 className="w-6 h-6 animate-spin text-gray-400" />
+				<Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
 			</div>
 		);
 	}
@@ -99,12 +99,12 @@ export default function NoteList({
 		return (
 			<div className="flex flex-col items-center justify-center py-10 text-center">
 				<div className="bg-base-bg p-4 rounded-full mb-4">
-					<Ghost className="w-8 h-8 text-gray-400" />
+					<Ghost className="w-8 h-8 text-muted-foreground" />
 				</div>
 				<h3 className="text-sm font-medium text-action mb-1">
 					No notes for this page yet
 				</h3>
-				<p className="text-xs text-gray-500 mb-4 max-w-50">
+				<p className="text-xs text-muted-foreground mb-4 max-w-50">
 					Capture your thoughts for this page.
 				</p>
 			</div>
@@ -191,7 +191,7 @@ export default function NoteList({
 					<button
 						type="button"
 						onClick={() => setIsFavoritesOpen(!isFavoritesOpen)}
-						className="flex items-center gap-1 text-xs font-semibold text-gray-500 uppercase tracking-wider px-1 hover:text-action transition-colors cursor-pointer"
+						className="flex items-center gap-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider px-1 hover:text-action transition-colors cursor-pointer"
 					>
 						{isFavoritesOpen ? (
 							<ChevronDown className="w-3 h-3" />
@@ -214,7 +214,7 @@ export default function NoteList({
 			{currentScopeNotes.length > 0 && (
 				<div className="space-y-3">
 					{favoriteNotes.length > 0 && (
-						<div className="flex items-center gap-2 text-xs font-semibold text-gray-500 uppercase tracking-wider px-1">
+						<div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground uppercase tracking-wider px-1">
 							<span>Current Page</span>
 						</div>
 					)}

--- a/apps/extension/src/components/QuickLinks.tsx
+++ b/apps/extension/src/components/QuickLinks.tsx
@@ -134,9 +134,11 @@ export default function QuickLinks({ currentDomain }: QuickLinksProps) {
 			>
 				<div className="flex items-center gap-1.5">
 					<LinkIcon className="w-3.5 h-3.5" />
-					<span className="text-gray-500 font-semibold">Quick Links</span>
+					<span className="text-muted-foreground font-semibold">
+						Quick Links
+					</span>
 					{links.length > 0 && (
-						<span className="bg-base-bg text-gray-500 px-1.5 rounded-full text-[10px]">
+						<span className="bg-base-bg text-muted-foreground px-1.5 rounded-full text-[10px]">
 							{links.length}
 						</span>
 					)}
@@ -167,11 +169,11 @@ export default function QuickLinks({ currentDomain }: QuickLinksProps) {
 					<div className="space-y-1">
 						{loading ? (
 							<div className="flex justify-center py-2">
-								<Loader2 className="w-4 h-4 animate-spin text-gray-400" />
+								<Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
 							</div>
 						) : links.length === 0 ? (
 							!isAdding && (
-								<div className="text-center text-gray-400 text-xs py-2 italic">
+								<div className="text-center text-muted-foreground text-xs py-2 italic">
 									No links added yet.
 								</div>
 							)
@@ -207,12 +209,12 @@ export default function QuickLinks({ currentDomain }: QuickLinksProps) {
 											<span className="truncate text-action">{link.label}</span>
 
 											{link.type === "related" && (
-												<ExternalLink className="w-3 h-3 text-gray-400 shrink-0" />
+												<ExternalLink className="w-3 h-3 text-muted-foreground shrink-0" />
 											)}
 
 											<div className="flex items-center gap-1">
 												{link.type === "env" && (
-													<span className="flex items-center gap-0.5 text-[10px] text-gray-400 ml-1 shrink-0 border border-base-border px-1 rounded">
+													<span className="flex items-center gap-0.5 text-[10px] text-muted-foreground ml-1 shrink-0 border border-base-border px-1 rounded">
 														ENV
 														{isIncoming && <Lock className="w-3 h-3" />}
 													</span>
@@ -225,14 +227,14 @@ export default function QuickLinks({ currentDomain }: QuickLinksProps) {
 												<button
 													type="button"
 													onClick={() => startEditing(link)}
-													className="cursor-pointer p-1 text-gray-400 hover:text-action hover:bg-base-bg rounded transition-all"
+													className="cursor-pointer p-1 text-muted-foreground hover:text-action hover:bg-base-bg rounded transition-all"
 												>
 													<Pencil className="w-3.5 h-3.5" />
 												</button>
 												<button
 													type="button"
 													onClick={() => deleteLink(link.id)}
-													className="cursor-pointer p-1 text-gray-400 hover:text-note-alert hover:bg-note-alert/10 rounded transition-all"
+													className="cursor-pointer p-1 text-muted-foreground hover:text-note-alert hover:bg-note-alert/10 rounded transition-all"
 												>
 													<Trash2 className="w-3.5 h-3.5" />
 												</button>
@@ -293,7 +295,7 @@ export default function QuickLinks({ currentDomain }: QuickLinksProps) {
 										<button
 											type="button"
 											onClick={cancelForm}
-											className="cursor-pointer px-2 py-1 text-gray-500 hover:text-action"
+											className="cursor-pointer px-2 py-1 text-muted-foreground hover:text-action"
 										>
 											Cancel
 										</button>
@@ -315,7 +317,7 @@ export default function QuickLinks({ currentDomain }: QuickLinksProps) {
 							<button
 								type="button"
 								onClick={startAdding}
-								className="cursor-pointer w-full text-left p-2 text-xs text-gray-400 hover:text-action hover:bg-base-bg rounded flex items-center gap-1 transition-colors"
+								className="cursor-pointer w-full text-left p-2 text-xs text-muted-foreground hover:text-action hover:bg-base-bg rounded flex items-center gap-1 transition-colors"
 							>
 								<Plus className="w-3.5 h-3.5" />
 								Add Link

--- a/apps/extension/src/index.css
+++ b/apps/extension/src/index.css
@@ -10,4 +10,6 @@
   --color-note-info: #3b82f6;
   --color-note-alert: #ef4444;
   --color-note-idea: #eab308;
+  --color-muted: #f3f4f6;
+  --color-muted-foreground: #9ca3af;
 }

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
 						"128": "sitecue_icon128.png",
 					},
 		permissions: ["sidePanel", "activeTab", "storage", "tabs", "identity"],
-		optional_host_permissions: ["<all_urls>"],
+		optional_host_permissions: [],
 		// 開発時のみローカル API 通信を許可
 		host_permissions:
 			command === "serve"


### PR DESCRIPTION
- Why:
  - Improve Chrome Web Store review success rate by removing redundant permissions.
  - Enhance user experience by increasing free limits and simplifying the UI.
  - Ensure visual consistency with the main App by standardizing color tokens.

- What:
  - Remove isolated `<all_urls>` permission from manifest.
  - Increase free memo limit to 500.
  - Hide total capacity denominator and implement smart alerts at 90% usage.
  - Add gradient fade effect to "Read more" truncation for long memos.
  - Refactor hardcoded grays to Tailwind v4 semantic theme variables.