### PR TITLE
fix(background): improve script stability and async handling

### DIFF
--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -73,19 +73,26 @@ export default defineBackground(() => {
 
 	// 1. Tab Activated (Switched)
 	chrome.tabs.onActivated.addListener(async (activeInfo) => {
-		const tab = await chrome.tabs.get(activeInfo.tabId);
-		if (tab.url) {
-			updateBadge(activeInfo.tabId, tab.url);
+		try {
+			const tab = await chrome.tabs.get(activeInfo.tabId);
+			if (tab.url) {
+				await updateBadge(activeInfo.tabId, tab.url);
+			}
+		} catch (error) {
+			console.debug(
+				"[SiteCue] Tab closed or unavailable before badge update:",
+				error,
+			);
 		}
 	});
 
 	// 2. Tab Updated (Navigated/Reloaded)
-	chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-		// We can update when status is 'loading' or 'complete'.
-		// 'status' change happens often. 'url' change happens on nav.
+	chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+		// リロード時は changeInfo.url が undefined になるが、
+		// Chromeがバッジをクリアしてしまうため status === "complete" で再描画する
 		if (changeInfo.url || changeInfo.status === "complete") {
 			if (tab.url) {
-				updateBadge(tabId, tab.url);
+				await updateBadge(tabId, tab.url);
 			}
 		}
 	});
@@ -93,20 +100,33 @@ export default defineBackground(() => {
 	// 3. Message from Side Panel (Note created/deleted)
 	chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 		if (message.type === "REFRESH_BADGE") {
-			// Refresh badge for the active tab (or all relevant tabs, but active is most important)
-			chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-				if (tabs.length > 0 && tabs[0].id && tabs[0].url) {
-					updateBadge(tabs[0].id, tabs[0].url);
+			// 非同期処理を即時実行関数（IIFE）でラップして実行
+			(async () => {
+				try {
+					const tabs = await chrome.tabs.query({
+						active: true,
+						currentWindow: true,
+					});
+					if (tabs.length > 0 && tabs[0].id && tabs[0].url) {
+						await updateBadge(tabs[0].id, tabs[0].url);
+					}
+					sendResponse({ status: "ok" });
+				} catch (error) {
+					console.error("[SiteCue] Failed to refresh badge:", error);
+					sendResponse({ status: "error", error });
 				}
-			});
+			})();
 
-			// Also handy to return something
-			sendResponse({ status: "ok" });
-		} else if (message.type === "TEST_SESSION_REFRESH") {
+			// 非同期で sendResponse を呼ぶために true を返す (Manifest V3 必須)
+			return true;
+		}
+
+		if (message.type === "TEST_SESSION_REFRESH") {
 			// Trigger manual session refresh test
 			// biome-ignore lint/suspicious/noExplicitAny: test hacking
 			(self as any).testSessionRefresh?.();
 			sendResponse({ status: "test_started" });
+			return false; // Sync response
 		}
 	});
 

--- a/apps/extension/tsconfig.json
+++ b/apps/extension/tsconfig.json
@@ -5,6 +5,7 @@
 	},
 	"include": [
 		"src/**/*",
+		"entrypoints/**/*",
 		".wxt/types/**/*",
 		"../../types/**/*",
 		"../../../types/**/*",


### PR DESCRIPTION
- Why:
  - Service Worker in Manifest V3 may sleep before fire-and-forget async calls complete, causing inconsistent badge updates.
  - Message ports close prematurely if the listener does not return true for asynchronous responses.
  - Rapid tab operations trigger exceptions in chrome.tabs.get, which can lead to Service Worker crashes.

- What:
  - Add try-catch block to chrome.tabs.onActivated listener to safely handle missing tabs.
  - Add await to all updateBadge calls in onActivated, onUpdated, and onMessage to ensure execution completes.
  - Return true in the chrome.runtime.onMessage listener for REFRESH_BADGE to maintain the asynchronous message channel.