### PR TITLE
feat(tags): implement automatic extraction and in-memory filtering

### DIFF
--- a/apps/extension/src/SidePanel.tsx
+++ b/apps/extension/src/SidePanel.tsx
@@ -81,6 +81,8 @@ function NotesUI({
 		"exact",
 	);
 	const [searchQuery, setSearchQuery] = useState("");
+	const [selectedTag, setSelectedTag] = useState<string | null>(null);
+
 
 	const filteredNotesByScope = notes.filter((n) => {
 		if (viewScope === "inbox") {
@@ -97,6 +99,21 @@ function NotesUI({
 
 		return true;
 	});
+
+	const availableTags = Array.from(
+		new Set(
+			filteredNotesByScope.flatMap((n) => (n as { tags?: string[] }).tags || []),
+		),
+	).sort();
+
+	const finalFilteredNotes = filteredNotesByScope.filter((n) => {
+		const noteTags = (n as { tags?: string[] }).tags || [];
+		if (selectedTag && !noteTags.includes(selectedTag)) {
+			return false;
+		}
+		return true;
+	});
+
 
 	return (
 		<div className="w-full h-screen bg-base-surface flex flex-col font-sans">
@@ -136,11 +153,16 @@ function NotesUI({
 				searchQuery={searchQuery}
 				setSearchQuery={setSearchQuery}
 				filteredNotes={filteredNotesByScope}
+				selectedTag={selectedTag}
+				setSelectedTag={setSelectedTag}
+				availableTags={availableTags}
 			/>
+
 
 			<div className="flex-1 overflow-y-auto p-4 space-y-6">
 				<NoteList
-					notes={filteredNotesByScope}
+					notes={finalFilteredNotes}
+
 					loading={loading}
 					filterType={filterType}
 					showResolved={showResolved}

--- a/apps/extension/src/components/FilterBar.tsx
+++ b/apps/extension/src/components/FilterBar.tsx
@@ -21,6 +21,9 @@ interface FilterBarProps {
 	searchQuery: string;
 	setSearchQuery: (query: string) => void;
 	filteredNotes: Note[];
+	selectedTag: string | null;
+	setSelectedTag: (tag: string | null) => void;
+	availableTags: string[];
 }
 
 export default function FilterBar({
@@ -33,6 +36,9 @@ export default function FilterBar({
 	searchQuery,
 	setSearchQuery,
 	filteredNotes,
+	selectedTag,
+	setSelectedTag,
+	availableTags,
 }: FilterBarProps) {
 	const [isSearchOpen, setIsSearchOpen] = useState(false);
 	const [isCopied, setIsCopied] = useState(false);
@@ -300,6 +306,26 @@ export default function FilterBar({
 					</button>
 				</div>
 			</div>
+
+			{/* Tag Pills */}
+			{availableTags.length > 0 && (
+				<div className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-hide">
+					{availableTags.map((tag) => (
+						<button
+							key={tag}
+							type="button"
+							onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
+							className={`cursor-pointer whitespace-nowrap px-2 py-0.5 rounded-full text-[10px] font-medium border transition-colors ${
+								selectedTag === tag
+									? "bg-action text-action-text border-action"
+									: "bg-base-surface text-muted-foreground border-base-border hover:border-action hover:text-action"
+							}`}
+						>
+							#{tag}
+						</button>
+					))}
+				</div>
+			)}
 		</div>
 	);
 }

--- a/apps/extension/src/hooks/useNotes.ts
+++ b/apps/extension/src/hooks/useNotes.ts
@@ -4,6 +4,7 @@ import toast from "react-hot-toast";
 import type { Note, NoteScope } from "../../../../types/app";
 import { supabase } from "../supabaseClient";
 import { getScopeUrls } from "../utils/url";
+import { extractTags } from "../utils/tags";
 
 export type NoteType = Note["note_type"];
 export type { Note, NoteScope };
@@ -78,6 +79,7 @@ export function useNotes(
 			is_favorite: false,
 			is_pinned: false,
 			is_resolved: false,
+			tags: extractTags(content),
 		} as Note;
 
 		// UI（ステート）には全スコープ追加する
@@ -91,6 +93,7 @@ export function useNotes(
 				scope: selectedScope,
 				note_type: selectedType,
 				sort_order: newSortOrder,
+				tags: extractTags(content),
 			};
 
 			const { data, error } = await supabase
@@ -140,9 +143,11 @@ export function useNotes(
 				note_type: NoteType;
 				scope?: NoteScope;
 				url_pattern?: string;
+				tags?: string[];
 			} = {
 				content: editContent,
 				note_type: editType,
+				tags: extractTags(editContent),
 			};
 
 			if (editScope && editScope !== currentNote?.scope) {

--- a/apps/extension/src/utils/tags.test.ts
+++ b/apps/extension/src/utils/tags.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { extractTags } from "./tags";
+
+describe("extractTags", () => {
+	it("通常のハッシュタグを抽出できること", () => {
+		expect(extractTags("これは #test と #アイデア のメモです")).toEqual([
+			"test",
+			"アイデア",
+		]);
+	});
+
+	it("コードブロック内のハッシュタグを除外すること", () => {
+		const content = `
+通常の #valid タグ
+\`\`\`css
+#invalid-id { color: red; }
+\`\`\`
+インラインの \`#invalid_inline\` も除外。
+ただし最後は #valid2
+          `;
+		expect(extractTags(content)).toEqual(["valid", "valid2"]);
+	});
+
+	it("重複したタグを一つにまとめること", () => {
+		expect(extractTags("#test some text #test")).toEqual(["test"]);
+	});
+
+	it("空文字やタグなしの場合は空配列を返すこと", () => {
+		expect(extractTags("タグのないただのテキスト")).toEqual([]);
+		expect(extractTags("")).toEqual([]);
+		expect(extractTags(null as unknown as string)).toEqual([]);
+		expect(extractTags(undefined as unknown as string)).toEqual([]);
+	});
+});

--- a/apps/extension/src/utils/tags.ts
+++ b/apps/extension/src/utils/tags.ts
@@ -1,0 +1,22 @@
+/**
+ * Markdownテキストからハッシュタグを抽出する純粋な関数。
+ * コードブロック (```...```) およびインラインコード (`...`) 内の文字列は無視する。
+ */
+export function extractTags(content: string | undefined | null): string[] {
+	if (!content) return [];
+
+	// 1. 複数行のコードブロックを削除 (```code```)
+	let text = content.replace(/```[\s\S]*?```/g, "");
+
+	// 2. インラインコードを削除 (`code`)
+	text = text.replace(/`[^`]*`/g, "");
+
+	// 3. ハッシュタグを抽出 (行頭または空白の直後にある # から始まり、空白や#以外の文字が続く)
+	const matches = text.match(/(^|\s)#([^\s#]+)/g);
+
+	if (!matches) return [];
+
+	// 4. '#' や空白を除去し、重複を排除
+	const tags = matches.map((m) => m.trim().substring(1));
+	return Array.from(new Set(tags));
+}

--- a/supabase/migrations/20260420024500_add_tags_to_notes.sql
+++ b/supabase/migrations/20260420024500_add_tags_to_notes.sql
@@ -1,0 +1,3 @@
+-- Up
+ALTER TABLE public.sitecue_notes ADD COLUMN IF NOT EXISTS tags text[] DEFAULT '{}';
+ALTER TABLE public.sitecue_drafts ADD COLUMN IF NOT EXISTS tags text[] DEFAULT '{}';

--- a/types/app.ts
+++ b/types/app.ts
@@ -7,6 +7,7 @@ export type Note = Omit<
 	"scope"
 > & {
 	scope: NoteScope;
+	tags?: string[];
 };
 
 export type Template = Database["public"]["Tables"]["sitecue_templates"]["Row"];
@@ -17,6 +18,7 @@ export type Draft = Database["public"]["Tables"]["sitecue_drafts"]["Row"] & {
 		[key: string]: unknown;
 	} | null;
 	sitecue_templates?: Template | null;
+	tags?: string[];
 };
 
 export type PinnedSite =


### PR DESCRIPTION
- Why:
  - Enable seamless information retrieval without manual tag management overhead for the user.
- What:
  - Extract `#tags` from Markdown content while strictly excluding those within code blocks.
  - Store extracted tags into a database array column during note save and update operations.
  - Add a horizontal scrolling UI component displaying tag pill buttons.
  - Implement client-side in-memory filtering to provide instant list updates upon tag selection.