### PR TITLE
feat(launchpad): refine component details and enhance visual affordance

### DIFF
--- a/apps/app/src/app/_components/PinnedSitesManager.tsx
+++ b/apps/app/src/app/_components/PinnedSitesManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ExternalLink, Pin, Plus, Trash2, X } from "lucide-react";
+import { Pin, Plus, Trash2, X } from "lucide-react";
 import { useOptimistic, useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import type { PinnedSite } from "../../../../../types/app";
@@ -153,9 +153,9 @@ export function PinnedSitesManager({ initialSites }: PinnedSitesManagerProps) {
 				</form>
 			)}
 
-			<div className="grid gap-4 grid-cols-2 sm:grid-cols-4 lg:grid-cols-5">
+			<div className="grid gap-3 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
 				{optimisticSites.length === 0 && !isAdding && (
-					<div className="col-span-full py-12 flex flex-col items-center justify-center rounded-2xl border-2 border-dashed border-base-border bg-base-surface/50">
+					<div className="col-span-full py-8 flex flex-col items-center justify-center rounded-xl border border-dashed border-base-border bg-base-surface/50">
 						<p className="text-sm text-gray-400 italic">
 							No pinned sites yet. Add your favorite tools or references here.
 						</p>
@@ -164,37 +164,43 @@ export function PinnedSitesManager({ initialSites }: PinnedSitesManagerProps) {
 				{optimisticSites.map((site) => (
 					<div
 						key={site.id}
-						className="group relative flex flex-col justify-between rounded-xl border border-base-border bg-base-surface p-4 transition-all hover:border-action hover:ring-1 hover:ring-action"
+						className="group relative flex items-center justify-between rounded-lg border border-base-border bg-base-surface p-2.5 transition-all hover:border-action hover:shadow-sm"
 					>
-						<div className="mb-3 flex items-start justify-between">
-							<div className="rounded-lg bg-base-bg p-2 group-hover:bg-base-surface transition-colors">
-								<ExternalLink className="w-4 h-4 text-gray-600" />
-							</div>
-							<Button
-								type="button"
-								variant="ghost"
-								size="icon-sm"
-								onClick={() => handleDelete(site.id)}
-								disabled={isPending}
-								className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-note-alert hover:bg-note-alert/10 cursor-pointer"
-								title="Delete"
-							>
-								<Trash2 className="w-4 h-4" />
-							</Button>
-						</div>
 						<a
 							href={site.url}
 							target="_blank"
 							rel="noopener noreferrer"
-							className="block cursor-pointer outline-none"
+							className="flex items-center gap-2.5 flex-1 min-w-0 outline-none cursor-pointer"
 						>
-							<h3 className="font-bold text-action line-clamp-1 group-hover:underline">
-								{site.title}
-							</h3>
-							<p className="mt-1 text-xs text-neutral-500 truncate">
-								{getHostname(site.url)}
-							</p>
+							<div className="shrink-0 rounded bg-base-bg p-1.5 group-hover:bg-white transition-colors">
+								{/* eslint-disable-next-line @next/next/no-img-element */}
+								<img
+									src={`https://www.google.com/s2/favicons?domain=${getHostname(site.url)}&sz=32`}
+									alt=""
+									className="w-4 h-4"
+									aria-hidden="true"
+								/>
+							</div>
+							<div className="min-w-0">
+								<h3 className="text-sm font-bold text-action line-clamp-1 group-hover:underline">
+									{site.title}
+								</h3>
+								<p className="text-[10px] text-neutral-500 truncate">
+									{getHostname(site.url)}
+								</p>
+							</div>
 						</a>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-xs"
+							onClick={() => handleDelete(site.id)}
+							disabled={isPending}
+							className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-note-alert hover:bg-note-alert/10 cursor-pointer ml-2 shrink-0"
+							title="Delete"
+						>
+							<Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+						</Button>
 					</div>
 				))}
 			</div>

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -1,4 +1,11 @@
-import { ArrowRight, Library, PenSquare } from "lucide-react";
+import {
+	Activity,
+	ArrowRight,
+	Clock,
+	Library,
+	PenSquare,
+	Plus,
+} from "lucide-react";
 import { CustomLink as Link } from "@/components/ui/custom-link";
 import { createClient } from "@/utils/supabase/server";
 import type { PinnedSite } from "../../../../types/app";
@@ -44,9 +51,15 @@ export default async function LaunchpadPage() {
 				<div className="mb-20 grid gap-12 md:grid-cols-[1fr_2fr] items-start">
 					{/* 左: Overview */}
 					<div>
-						<h1 className="text-2xl font-light tracking-tight text-neutral-600 mb-8">
-							Cultivate your thoughts right from here.
-						</h1>
+						<div className="mb-8 flex items-center gap-2">
+							<Activity
+								className="w-5 h-5 text-neutral-400"
+								aria-hidden="true"
+							/>
+							<h1 className="text-xl font-light tracking-tight text-neutral-800">
+								Overview
+							</h1>
+						</div>
 						<div className="flex flex-col gap-4 text-sm text-neutral-500">
 							<div className="flex items-center justify-between border-b border-base-border pb-2">
 								<span className="font-semibold text-neutral-400 uppercase tracking-widest text-[10px]">
@@ -70,9 +83,15 @@ export default async function LaunchpadPage() {
 					{/* 右: Recent Drafts */}
 					<div>
 						<div className="mb-6 flex items-center justify-between">
-							<h2 className="text-lg font-medium tracking-tight text-neutral-800">
-								Recent Drafts
-							</h2>
+							<div className="flex items-center gap-2">
+								<Clock
+									className="w-4 h-4 text-neutral-400"
+									aria-hidden="true"
+								/>
+								<h2 className="text-lg font-medium tracking-tight text-neutral-800">
+									Recent Drafts
+								</h2>
+							</div>
 							<Link
 								href="/notes?view=drafts"
 								className="text-xs font-medium text-neutral-400 hover:text-action transition-colors"
@@ -136,11 +155,14 @@ export default async function LaunchpadPage() {
 					<div className="grid gap-6 sm:grid-cols-3">
 						<Link
 							href="/studio/new"
-							className="group relative flex flex-col items-start rounded-xl border border-base-border bg-base-surface p-5 transition-all hover:border-neutral-400 cursor-pointer"
+							className="group relative flex flex-col items-start rounded-xl border-2 border-dashed border-base-border bg-transparent p-5 transition-all hover:border-neutral-400 hover:bg-base-surface/50 cursor-pointer"
 						>
-							<h3 className="mb-1 text-sm font-bold text-action group-hover:text-action-hover transition-colors">
-								Blank Canvas
-							</h3>
+							<div className="flex items-center gap-2 mb-1">
+								<Plus className="w-4 h-4 text-action" aria-hidden="true" />
+								<h3 className="text-sm font-bold text-action group-hover:text-action-hover transition-colors">
+									Blank Canvas
+								</h3>
+							</div>
 							<p className="text-xs text-neutral-500 line-clamp-2">
 								Free-form notes not limited to any specific template.
 							</p>


### PR DESCRIPTION
- Why:
  - Improve the UI sophistication and align with the "subtraction aesthetic" philosophy.
  - Optimize vertical space usage and improve information density at the component level.
  - Strengthen the visual affordance for primary user actions, such as starting a new draft.

- What:
  - Transform "Pinned Sites" into slim horizontal chips with favicons to reduce vertical footprint.
  - Replace the "Cultivate..." header text with a semantic H1 "Overview" accompanied by an Activity icon.
  - Add a Clock icon to the "Recent Drafts" heading to maintain visual consistency across sections.
  - Update the "Blank Canvas" card with a dashed border and Plus icon to clearly signal the creation action.