### PR TITLE
refactor(notes): migrate notes data management to tanstack query

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -22,6 +22,7 @@
 		"@supabase/ssr": "^0.8.0",
 		"@supabase/supabase-js": "^2.93.1",
 		"@tailwindcss/typography": "^0.5.19",
+		"@tanstack/react-query": "^5.99.2",
 		"@uiw/react-codemirror": "^4.25.9",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/apps/app/src/app/_components/GlobalNewNoteDialog.tsx
+++ b/apps/app/src/app/_components/GlobalNewNoteDialog.tsx
@@ -21,8 +21,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
-import { useNotesStore } from "@/store/useNotesStore";
-import { createClient } from "@/utils/supabase/client";
+import { useCreateNote } from "@/hooks/useNotesQuery";
 import { normalizeUrlForGrouping } from "@/utils/url";
 import type { Note, NoteScope } from "../../../../../types/app";
 
@@ -36,7 +35,7 @@ export default function GlobalNewNoteDialog() {
 	const [scope, setScope] = useState<NoteScope>("inbox");
 	const [isSaving, setIsSaving] = useState(false);
 	const [noteType, setNoteType] = useState<Note["note_type"]>("info");
-	const addNote = useNotesStore((state) => state.addNote);
+	const createNoteMutation = useCreateNote();
 
 	// Load initial state from URL parameters
 	useEffect(() => {
@@ -89,13 +88,6 @@ export default function GlobalNewNoteDialog() {
 
 		setIsSaving(true);
 		try {
-			const supabase = createClient();
-			const {
-				data: { user },
-			} = await supabase.auth.getUser();
-
-			if (!user) throw new Error("User not authenticated");
-
 			let finalUrl = urlPattern.trim();
 			if (scope === "inbox") {
 				finalUrl = "";
@@ -110,26 +102,12 @@ export default function GlobalNewNoteDialog() {
 				}
 			}
 
-			const { data, error } = await supabase
-				.from("sitecue_notes")
-				.insert({
-					content: content.trim(),
-					scope: scope,
-					url_pattern: finalUrl,
-					note_type: noteType,
-					user_id: user.id,
-					is_expanded: false,
-					is_favorite: false,
-					is_pinned: false,
-					is_resolved: false,
-					sort_order: 0,
-				})
-				.select()
-				.single();
-
-			if (error) throw error;
-
-			addNote(data as Note);
+			const data = await createNoteMutation.mutateAsync({
+				content: content.trim(),
+				scope: scope,
+				url_pattern: finalUrl,
+				note_type: noteType,
+			});
 
 			const params = new URLSearchParams(searchParams.toString());
 			params.delete("globalNew");
@@ -151,7 +129,6 @@ export default function GlobalNewNoteDialog() {
 			}
 
 			router.push(`/notes?${params.toString()}`);
-			router.refresh();
 		} catch (err) {
 			console.error("Failed to save note:", err);
 			alert("Failed to save the note.");

--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -20,6 +20,7 @@ export const metadata: Metadata = {
 import { Suspense } from "react";
 import { Toaster } from "react-hot-toast";
 import { AppShell } from "@/components/layout/AppShell";
+import { QueryProvider } from "@/providers/QueryProvider";
 import GlobalNewNoteDialog from "./_components/GlobalNewNoteDialog";
 
 export default function RootLayout({
@@ -32,16 +33,18 @@ export default function RootLayout({
 			<body
 				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
 			>
-				<Toaster
-					position="top-center"
-					toastOptions={{ duration: 4000, style: { fontSize: "14px" } }}
-				/>
-				<Suspense fallback={null}>
-					<GlobalNewNoteDialog />
-				</Suspense>
-				<Suspense fallback={null}>
-					<AppShell>{children}</AppShell>
-				</Suspense>
+				<QueryProvider>
+					<Toaster
+						position="top-center"
+						toastOptions={{ duration: 4000, style: { fontSize: "14px" } }}
+					/>
+					<Suspense fallback={null}>
+						<GlobalNewNoteDialog />
+					</Suspense>
+					<Suspense fallback={null}>
+						<AppShell>{children}</AppShell>
+					</Suspense>
+				</QueryProvider>
 			</body>
 		</html>
 	);

--- a/apps/app/src/app/notes/_components/NotesContainer.tsx
+++ b/apps/app/src/app/notes/_components/NotesContainer.tsx
@@ -2,7 +2,8 @@
 
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import { useNotesStore } from "@/store/useNotesStore";
+import { useFetchNoteContents, useFetchNotes } from "@/hooks/useNotesQuery";
+import { groupNotes, useNotesStore } from "@/store/useNotesStore";
 import { createClient } from "@/utils/supabase/client";
 import type { Draft, Note, SearchParams } from "../types";
 import { MiddlePaneList } from "./MiddlePaneList";
@@ -11,15 +12,21 @@ import { RightPaneDetail } from "./RightPaneDetail";
 
 export function NotesContainer() {
 	const searchParams = useSearchParams();
+	const { data: notes = [], isLoading: isNotesLoading } = useFetchNotes();
+	const { mutate: fetchContentForIds } = useFetchNoteContents();
 	const {
-		notes,
 		drafts,
-		groupedNotes,
-		isMetadataFetched,
-		fetchContentForIds,
+		isMetadataFetched: isDraftsFetched,
 		searchResults,
 		setSearchResults,
 	} = useNotesStore();
+
+	const groupedNotes = useMemo(() => {
+		if (isNotesLoading) return null;
+		return groupNotes(notes, drafts);
+	}, [notes, drafts, isNotesLoading]);
+
+	const isDataReady = !isNotesLoading && isDraftsFetched;
 
 	// Convert searchParams to our SearchParams type
 	const params: SearchParams = useMemo(() => {
@@ -130,7 +137,7 @@ export function NotesContainer() {
 
 	// フォールバック: 表示されているリストの中に本文(content)がないものがあれば自動取得
 	useEffect(() => {
-		if (!isMetadataFetched || filteredItems.length === 0) return;
+		if (!isDataReady || filteredItems.length === 0) return;
 
 		const missingIds = filteredItems
 			.filter(
@@ -142,12 +149,12 @@ export function NotesContainer() {
 		if (missingIds.length > 0) {
 			fetchContentForIds(missingIds);
 		}
-	}, [filteredItems, isMetadataFetched, fetchContentForIds]);
+	}, [filteredItems, isDataReady, fetchContentForIds]);
 
 	// 選択されたノートまたはドラフトの取得
 	const selectedNote = useMemo(() => {
 		if (!params.noteId) return undefined;
-		// まず全体ストアから探す
+		// まず全体データから探す
 		const foundInNotes = notes.find((n) => n.id === params.noteId);
 		if (foundInNotes) return foundInNotes;
 		// なければ検索結果（ローカル状態）から探す
@@ -162,7 +169,7 @@ export function NotesContainer() {
 		[drafts, params.draftId],
 	);
 
-	if (!isMetadataFetched || !groupedNotes) {
+	if (!isDataReady || !groupedNotes) {
 		return null; // Initial loading state (handled by Suspense if we want a better fallback)
 	}
 

--- a/apps/app/src/app/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/notes/_components/RightPaneDetail.tsx
@@ -53,9 +53,12 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import {
+	useCreateNote,
+	useDeleteNote,
+	useUpdateNote,
+} from "@/hooks/useNotesQuery";
 import { cn } from "@/lib/utils";
-import { useNotesStore } from "@/store/useNotesStore";
-import { createClient } from "@/utils/supabase/client";
 import { extractTags } from "@/utils/tags";
 import type { Draft, Note } from "../types";
 
@@ -66,8 +69,9 @@ type Props = {
 };
 
 export function RightPaneDetail({ note, draft, isNewNote }: Props) {
-	const addNote = useNotesStore((state) => state.addNote);
-	const removeNote = useNotesStore((state) => state.removeNote);
+	const createNoteMutation = useCreateNote();
+	const updateNoteMutation = useUpdateNote();
+	const deleteNoteMutation = useDeleteNote();
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const [isEditing, setIsEditing] = useState(false);
@@ -219,14 +223,7 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 		setIsEditing(false);
 
 		try {
-			const supabase = createClient();
-
 			if (isNewNote) {
-				const {
-					data: { user },
-				} = await supabase.auth.getUser();
-				if (!user) throw new Error("User not authenticated");
-
 				const exactParam = searchParams.get("exact");
 				const domainParam = searchParams.get("domain");
 
@@ -243,47 +240,28 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 
 				const extractedTags = extractTags(newContent);
 
-				const { data, error } = await supabase
-					.from("sitecue_notes")
-					.insert({
-						content: newContent,
-						scope: targetScope,
-						url_pattern: targetUrlPattern,
-						note_type: noteType,
-						user_id: user.id,
-						is_expanded: false,
-						is_favorite: false,
-						is_pinned: false,
-						is_resolved: false,
-						sort_order: 0,
-						tags: extractedTags,
-					})
-					.select()
-					.single();
-
-				if (error) throw error;
-
-				// 【追加】新規作成されたノートを Zustand ストアに即時反映する
-				addNote(data as Note);
+				const data = await createNoteMutation.mutateAsync({
+					content: newContent,
+					scope: targetScope,
+					url_pattern: targetUrlPattern,
+					note_type: noteType,
+					tags: extractedTags,
+				});
 
 				setOptimisticContent(newContent);
 				const params = new URLSearchParams(searchParams.toString());
 				params.delete("new");
 				params.set("noteId", data.id);
 				router.replace(`/notes?${params.toString()}`);
-				router.refresh();
 			} else if (note) {
 				const extractedTags = extractTags(newContent);
-				const { error } = await supabase
-					.from("sitecue_notes")
-					.update({
+				await updateNoteMutation.mutateAsync({
+					id: note.id,
+					updates: {
 						content: newContent,
 						tags: extractedTags,
-					})
-					.eq("id", note.id);
-
-				if (error) throw error;
-				router.refresh();
+					},
+				});
 			}
 		} catch (err) {
 			console.error("Failed to save note:", err);
@@ -309,14 +287,10 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 			setOptimisticFavorite(updates.is_favorite);
 
 		try {
-			const supabase = createClient();
-			const { error } = await supabase
-				.from("sitecue_notes")
-				.update(updates)
-				.eq("id", note.id);
-
-			if (error) throw error;
-			router.refresh();
+			await updateNoteMutation.mutateAsync({
+				id: note.id,
+				updates,
+			});
 		} catch (err) {
 			console.error("Failed to update note property:", err);
 			// Reset optimistic state on error
@@ -332,20 +306,12 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 		if (!note) return;
 		setIsSaving(true);
 		try {
-			const supabase = createClient();
-			const { error } = await supabase
-				.from("sitecue_notes")
-				.delete()
-				.eq("id", note.id);
-			if (error) throw error;
-
-			removeNote(note.id);
+			await deleteNoteMutation.mutateAsync(note.id);
 			setIsDeleteDialogOpen(false);
 
 			const params = new URLSearchParams(searchParams.toString());
 			params.delete("noteId");
 			router.replace(`/notes?${params.toString()}`);
-			router.refresh();
 		} catch (err) {
 			console.error("Failed to delete note:", err);
 			alert("Failed to delete the note.");
@@ -372,17 +338,14 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 				}
 			}
 
-			const supabase = createClient();
-			const { error } = await supabase
-				.from("sitecue_notes")
-				.update({
+			await updateNoteMutation.mutateAsync({
+				id: note.id,
+				updates: {
 					url_pattern: finalUrl,
 					scope: editScope,
-				})
-				.eq("id", note.id);
-			if (error) throw error;
+				},
+			});
 			setIsEditMetaDialogOpen(false);
-			router.refresh();
 		} catch (err) {
 			console.error("Failed to save metadata:", err);
 			alert("Failed to save metadata.");

--- a/apps/app/src/app/notes/types.ts
+++ b/apps/app/src/app/notes/types.ts
@@ -1,6 +1,7 @@
+import type { Note as AppNote } from "../../../../../types/app";
 import type { Tables } from "../../../../../types/supabase";
 
-export type Note = Omit<Tables<"sitecue_notes">, "content"> & {
+export type Note = Omit<AppNote, "content"> & {
 	content?: string;
 };
 export type Draft = Tables<"sitecue_drafts">;

--- a/apps/app/src/components/layout/GlobalSidebar.tsx
+++ b/apps/app/src/components/layout/GlobalSidebar.tsx
@@ -20,7 +20,8 @@ import SearchInput from "@/app/notes/_components/SearchInput";
 import type { DomainGroup, Note } from "@/app/notes/types";
 import { Button } from "@/components/ui/button";
 import { CustomLink as Link } from "@/components/ui/custom-link";
-import { useNotesStore } from "@/store/useNotesStore";
+import { useFetchNoteContents, useFetchNotes } from "@/hooks/useNotesQuery";
+import { groupNotes, useNotesStore } from "@/store/useNotesStore";
 import { getSafeUrl, normalizeUrlForGrouping } from "@/utils/url";
 
 interface GlobalSidebarProps {
@@ -31,7 +32,19 @@ export function GlobalSidebar({ onClose }: GlobalSidebarProps) {
 	const pathname = usePathname();
 	const router = useRouter();
 	const searchParams = useSearchParams();
-	const { groupedNotes, searchResults } = useNotesStore();
+	const { data: notes = [], isLoading: isNotesLoading } = useFetchNotes();
+	const {
+		drafts,
+		isMetadataFetched: isDraftsFetched,
+		searchResults,
+	} = useNotesStore();
+
+	const groupedNotes = useMemo(() => {
+		if (isNotesLoading) return null;
+		return groupNotes(notes, drafts);
+	}, [notes, drafts, isNotesLoading]);
+
+	const isDataReady = !isNotesLoading && isDraftsFetched;
 
 	const qParam = searchParams.get("q") || "";
 	const tagsParam = searchParams.get("tags") || "";
@@ -111,7 +124,7 @@ export function GlobalSidebar({ onClose }: GlobalSidebarProps) {
 	);
 	const effectiveIsDomainsOpen = isDomainsOpen || shouldForceOpenDomains;
 
-	if (!groupedNotes) return null;
+	if (!isDataReady || !groupedNotes) return null;
 
 	return (
 		<div className="flex flex-col h-full bg-base-surface w-full overflow-hidden border-r border-base-border">
@@ -285,7 +298,7 @@ function DomainAccordionItem({
 }) {
 	const isUnderThisDomain = currentDomain === domainName;
 	const [isOpen, setIsOpen] = useState(false);
-	const fetchContentForIds = useNotesStore((state) => state.fetchContentForIds);
+	const { mutate: fetchContentForIds } = useFetchNoteContents();
 
 	const handleOpenChange = (open: boolean) => {
 		setIsOpen(open);

--- a/apps/app/src/hooks/useNotesQuery.ts
+++ b/apps/app/src/hooks/useNotesQuery.ts
@@ -1,0 +1,160 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { Note } from "@/app/notes/types";
+import { createClient } from "@/utils/supabase/client";
+
+export const NOTES_QUERY_KEY = ["notes"];
+
+export function useFetchNotes() {
+	return useQuery({
+		queryKey: NOTES_QUERY_KEY,
+		queryFn: async () => {
+			const supabase = createClient();
+			const {
+				data: { user },
+			} = await supabase.auth.getUser();
+			if (!user) throw new Error("User not authenticated");
+
+			const { data, error } = await supabase
+				.from("sitecue_notes")
+				.select(
+					"id, user_id, url_pattern, scope, note_type, is_pinned, is_resolved, is_favorite, is_expanded, sort_order, created_at, updated_at, draft_id, tags",
+				)
+				.eq("user_id", user.id)
+				.order("is_pinned", { ascending: false })
+				.order("sort_order", { ascending: true })
+				.order("created_at", { ascending: false });
+
+			if (error) throw error;
+			return (data as Note[]) || [];
+		},
+	});
+}
+
+export function useCreateNote() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async (newNote: Partial<Note>) => {
+			const supabase = createClient();
+			const {
+				data: { user },
+			} = await supabase.auth.getUser();
+			if (!user) throw new Error("User not authenticated");
+
+			const { data, error } = await supabase
+				.from("sitecue_notes")
+				.insert({
+					...newNote,
+					user_id: user.id,
+					is_expanded: false,
+					is_favorite: false,
+					is_pinned: false,
+					is_resolved: false,
+					sort_order: 0,
+				})
+				.select()
+				.single();
+
+			if (error) throw error;
+			return data as Note;
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: NOTES_QUERY_KEY });
+		},
+	});
+}
+
+export function useUpdateNote() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async ({
+			id,
+			updates,
+		}: {
+			id: string;
+			updates: Partial<Note>;
+		}) => {
+			const supabase = createClient();
+			const { data, error } = await supabase
+				.from("sitecue_notes")
+				.update(updates)
+				.eq("id", id)
+				.select()
+				.single();
+
+			if (error) throw error;
+			return data as Note;
+		},
+		onSuccess: (updatedNote) => {
+			// Optimistically update the list if needed, or just invalidate
+			queryClient.setQueryData<Note[]>(NOTES_QUERY_KEY, (old) => {
+				if (!old) return old;
+				return old.map((note) =>
+					note.id === updatedNote.id ? updatedNote : note,
+				);
+			});
+		},
+	});
+}
+
+export function useDeleteNote() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async (id: string) => {
+			const supabase = createClient();
+			const { error } = await supabase
+				.from("sitecue_notes")
+				.delete()
+				.eq("id", id);
+
+			if (error) throw error;
+			return id;
+		},
+		onSuccess: (deletedId) => {
+			queryClient.setQueryData<Note[]>(NOTES_QUERY_KEY, (old) => {
+				if (!old) return old;
+				return old.filter((note) => note.id !== deletedId);
+			});
+		},
+	});
+}
+
+/**
+ * Lazily fetch content for multiple notes and update the query cache.
+ */
+export function useFetchNoteContents() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async (ids: string[]) => {
+			if (ids.length === 0) return [];
+			const supabase = createClient();
+
+			const { data, error } = await supabase
+				.from("sitecue_notes")
+				.select("id, content")
+				.in("id", ids);
+
+			if (error) throw error;
+			return data || [];
+		},
+		onSuccess: (contents) => {
+			if (contents.length === 0) return;
+
+			const contentMap = new Map(contents.map((n) => [n.id, n.content]));
+
+			queryClient.setQueryData<Note[]>(NOTES_QUERY_KEY, (old) => {
+				if (!old) return old;
+				return old.map((note) =>
+					contentMap.has(note.id)
+						? { ...note, content: contentMap.get(note.id) as string }
+						: note,
+				);
+			});
+		},
+	});
+}

--- a/apps/app/src/providers/QueryProvider.tsx
+++ b/apps/app/src/providers/QueryProvider.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+	const [queryClient] = useState(
+		() =>
+			new QueryClient({
+				defaultOptions: {
+					queries: {
+						// Set default stale time to 5 minutes to reduce unnecessary refetches
+						staleTime: 1000 * 60 * 5,
+					},
+				},
+			}),
+	);
+
+	return (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+}

--- a/apps/app/src/store/useNotesStore.ts
+++ b/apps/app/src/store/useNotesStore.ts
@@ -4,19 +4,14 @@ import { createClient } from "@/utils/supabase/client";
 import { normalizeUrlForGrouping } from "@/utils/url";
 
 interface NotesState {
-	notes: Note[];
 	drafts: Draft[];
-	groupedNotes: GroupedNotes | null;
-	isMetadataFetched: boolean;
+	isMetadataFetched: boolean; // Note: Still used for drafts for now
 	fetchMetadata: () => Promise<void>;
-	fetchContentForIds: (ids: string[]) => Promise<void>;
 	searchResults: Note[] | null;
 	setSearchResults: (results: Note[] | null) => void;
-	addNote: (note: Note) => void;
-	removeNote: (id: string) => void;
 }
 
-function groupNotes(notes: Note[], drafts: Draft[]): GroupedNotes {
+export function groupNotes(notes: Note[], drafts: Draft[]): GroupedNotes {
 	const grouped: GroupedNotes = {
 		inbox: [],
 		drafts: drafts,
@@ -54,30 +49,11 @@ function groupNotes(notes: Note[], drafts: Draft[]): GroupedNotes {
 }
 
 export const useNotesStore = create<NotesState>((set, get) => ({
-	notes: [],
 	drafts: [],
-	groupedNotes: null,
 	isMetadataFetched: false,
 	searchResults: null,
 
 	setSearchResults: (results) => set({ searchResults: results }),
-
-	addNote: (note) => {
-		const newNotes = [note, ...get().notes];
-		set({
-			notes: newNotes,
-			groupedNotes: groupNotes(newNotes, get().drafts),
-		});
-	},
-
-	removeNote: (id) => {
-		const currentNotes = get().notes;
-		const updatedNotes = currentNotes.filter((note) => note.id !== id);
-		set({
-			notes: updatedNotes,
-			groupedNotes: groupNotes(updatedNotes, get().drafts),
-		});
-	},
 
 	fetchMetadata: async () => {
 		if (get().isMetadataFetched) return;
@@ -87,53 +63,14 @@ export const useNotesStore = create<NotesState>((set, get) => ({
 		} = await supabase.auth.getUser();
 		if (!user) return;
 
-		const [notesRes, draftsRes] = await Promise.all([
-			// content を除外した Slim Fetching
-			supabase
-				.from("sitecue_notes")
-				.select(
-					"id, user_id, url_pattern, scope, note_type, is_pinned, is_resolved, is_favorite, is_expanded, sort_order, created_at, updated_at, draft_id, tags",
-				)
-				.eq("user_id", user.id)
-				.order("is_pinned", { ascending: false })
-				.order("sort_order", { ascending: true })
-				.order("created_at", { ascending: false }),
-			supabase
-				.from("sitecue_drafts")
-				.select("*")
-				.eq("user_id", user.id)
-				.order("updated_at", { ascending: false }),
-		]);
+		const { data: draftsData } = await supabase
+			.from("sitecue_drafts")
+			.select("*")
+			.eq("user_id", user.id)
+			.order("updated_at", { ascending: false });
 
-		const notes = (notesRes.data as Note[]) || [];
-		const drafts = (draftsRes.data as Draft[]) || [];
-		const groupedNotes = groupNotes(notes, drafts);
+		const drafts = (draftsData as Draft[]) || [];
 
-		set({ notes, drafts, groupedNotes, isMetadataFetched: true });
-	},
-
-	fetchContentForIds: async (ids: string[]) => {
-		if (ids.length === 0) return;
-		const supabase = createClient();
-
-		const { data } = await supabase
-			.from("sitecue_notes")
-			.select("id, content")
-			.in("id", ids);
-
-		if (!data) return;
-
-		const contentMap = new Map(data.map((n) => [n.id, n.content]));
-
-		const updatedNotes = get().notes.map((note) =>
-			contentMap.has(note.id)
-				? { ...note, content: contentMap.get(note.id) as string }
-				: note,
-		);
-
-		set({
-			notes: updatedNotes,
-			groupedNotes: groupNotes(updatedNotes, get().drafts),
-		});
+		set({ drafts, isMetadataFetched: true });
 	},
 }));

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.93.1",
         "@tailwindcss/typography": "^0.5.19",
+        "@tanstack/react-query": "^5.99.2",
         "@uiw/react-codemirror": "^4.25.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -941,6 +942,10 @@
     "@tailwindcss/typography": ["@tailwindcss/typography@0.5.19", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1" } }, "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.2", "", { "dependencies": { "@tailwindcss/node": "4.2.2", "@tailwindcss/oxide": "4.2.2", "tailwindcss": "4.2.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.99.2", "", {}, "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.99.2", "", { "dependencies": { "@tanstack/query-core": "5.99.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 


### PR DESCRIPTION
- Why:
  - Address the limitations of manual synchronization with Zustand (In-Memory First Pattern) which leads to potential data inconsistency.
  - Decouple UI state from remote state to ensure automated data synchronization and a more robust architecture.

- What:
  - Install @tanstack/react-query and configure the QueryClientProvider.
  - Remove server-related state (notes, groupedNotes) and actions (addNote, removeNote) from useNotesStore.ts.
  - Implement useNotesQuery custom hooks for fetching and mutating notes data.
  - Refactor RightPaneDetail, GlobalNewNoteDialog, and NotesContainer to consume the new query hooks.