### PR TITLE
fix(notes): ensure note content is displayed when selected from searc…

### DIFF
--- a/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { NotesContainer } from "./NotesContainer";
+import { useNotesStore } from "@/store/useNotesStore";
+import { useFetchNotes } from "@/hooks/useNotesQuery";
+
+vi.mock("@/store/useNotesStore", () => ({
+	useNotesStore: vi.fn(),
+	groupNotes: vi.fn(() => ({
+		inbox: [],
+		drafts: [],
+		domains: {},
+	})),
+}));
+
+// モックのセットアップ
+vi.mock("next/navigation", () => ({
+	useSearchParams: () => new URLSearchParams("?noteId=note-1&q=test"),
+	useRouter: () => ({
+		push: vi.fn(),
+		replace: vi.fn(),
+		prefetch: vi.fn(),
+	}),
+}));
+
+vi.mock("@/hooks/useNotesQuery", () => ({
+	useFetchNotes: vi.fn(),
+	useFetchNoteContents: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useDraftsQuery", () => ({
+	useFetchDrafts: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("@/utils/supabase/client", () => ({
+	createClient: () => ({
+		from: () => ({
+			select: () => ({
+				ilike: () => ({
+					order: () => ({
+						order: () => Promise.resolve({ data: [], error: null }),
+					}),
+				}),
+			}),
+		}),
+	}),
+}));
+
+vi.mock("./MiddlePaneList", () => ({
+	MiddlePaneList: () => <div data-testid="middle-pane" />,
+}));
+
+vi.mock("./RightPaneDetail", () => ({
+	RightPaneDetail: ({ note }: { note: any }) => (
+		<div data-testid="right-pane">{note?.content || "No Content"}</div>
+	),
+}));
+
+// window.matchMedia のモック
+Object.defineProperty(window, "matchMedia", {
+	writable: true,
+	value: vi.fn().mockImplementation((query) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addListener: vi.fn(), // 互換性のため
+		removeListener: vi.fn(), // 互換性のため
+		addEventListener: vi.fn(),
+		removeEventListener: vi.fn(),
+		dispatchEvent: vi.fn(),
+	})),
+});
+
+describe("NotesContainer selectedNote resolution", () => {
+	it("should prioritize searchResults over cached notes when noteId matches", async () => {
+		// キャッシュされたノート（本文なし）
+		const mockNotes = [{ id: "note-1", url_pattern: "example.com" }];
+		(useFetchNotes as any).mockReturnValue({
+			data: mockNotes,
+			isLoading: false,
+		});
+
+		// 検索結果（本文あり）をモック
+		(useNotesStore as any).mockReturnValue({
+			searchResults: [{ id: "note-1", url_pattern: "example.com", content: "Full text content" }],
+			setSearchResults: vi.fn(),
+		});
+
+		render(<NotesContainer/>);
+
+		// 検索結果のコンテンツが右ペインに表示されることを確認（findByTextで非同期待機）
+		const detailContent = await screen.findByTestId("right-pane");
+		expect(detailContent.textContent).toBe("Full text content");
+	});
+});

--- a/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.tsx
@@ -151,14 +151,15 @@ export function NotesContainer() {
 	// 選択されたノートまたはドラフトの取得
 	const selectedNote = useMemo(() => {
 		if (!params.noteId) return undefined;
-		// まず全体データから探す
-		const foundInNotes = notes.find((n) => n.id === params.noteId);
-		if (foundInNotes) return foundInNotes;
-		// なければ検索結果（ローカル状態）から探す
+
+		// 1. 検索結果（ローカル状態・完全なデータ）を先に評価する
 		if (searchResults) {
-			return searchResults.find((n) => n.id === params.noteId);
+			const foundInSearch = searchResults.find((n) => n.id === params.noteId);
+			if (foundInSearch) return foundInSearch;
 		}
-		return undefined;
+
+		// 2. なければ全体データ（Slim Fetchingキャッシュ等）から探す
+		return notes.find((n) => n.id === params.noteId);
 	}, [notes, searchResults, params.noteId]);
 	const selectedDraft = useMemo(
 		() =>


### PR DESCRIPTION
…h results

- Why: The `useMemo` logic in `NotesContainer.tsx` prioritized slim-fetched cached notes (which lack content) over search results.
- What: Update evaluation order to prioritize `searchResults` during active searches to ensure full content is rendered.