### PR TITLE
fix(build): wrap search-params components in suspense for opennext

### DIFF
--- a/apps/app/src/app/(dashboard)/studio/[id]/page.tsx
+++ b/apps/app/src/app/(dashboard)/studio/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { createClient } from "@/utils/supabase/server";
 import type { Draft } from "../../../../../../../types/app.ts";
@@ -32,9 +33,11 @@ export default async function DraftEditPage({ params }: DraftPageProps) {
 	};
 
 	return (
-		<DraftEditor
-			initialDraft={formattedDraft}
-			template={formattedDraft.sitecue_templates}
-		/>
+		<Suspense fallback={null}>
+			<DraftEditor
+				initialDraft={formattedDraft}
+				template={formattedDraft.sitecue_templates}
+			/>
+		</Suspense>
 	);
 }

--- a/apps/app/src/app/(dashboard)/studio/new/page.tsx
+++ b/apps/app/src/app/(dashboard)/studio/new/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { createClient } from "@/utils/supabase/server";
 import DraftEditor from "../../_components/DraftEditor";
 
@@ -19,5 +20,9 @@ export default async function FocusModePage({
 		template = data;
 	}
 
-	return <DraftEditor template={template} />;
+	return (
+		<Suspense fallback={null}>
+			<DraftEditor template={template} />
+		</Suspense>
+	);
 }


### PR DESCRIPTION
- Resolve prerendering errors during Cloudflare/OpenNext deployment that cause missing middleware metadata.
- Wrap DraftEditor and GlobalNewNoteDialog in Suspense with null fallback to ensure build stability without UI noise.