### PR TITLE
feat(auth): implement requireUser guard and opt-out middleware

### DIFF
--- a/.agent/skills/basecamp-routing/SKILL.md
+++ b/.agent/skills/basecamp-routing/SKILL.md
@@ -31,3 +31,12 @@ App Basecamp（`apps/app/`）に新しい機能や画面を追加する場合、
 ## 5. Server Component Constraints (RSCの掟)
 - **イベントハンドラの禁止**: `page.tsx` や `layout.tsx` などの Server Component 内で、直接 `onClick` や `onChange` などのイベントハンドラを記述したり、`useState` などの React Hooks を呼び出したりすることは**厳禁**。
 - **解決策 (Expand & Contract)**: ボタンのクリックによるトースト通知や状態変更など、インタラクティブな処理が必要な場合は、そのボタン部分のみを純粋な Client Component (`"use client"`) として別ファイル（例: `_components/HogeButton.tsx`）に切り出し、Server Component にインポートして配置すること。
+
+## 6. Route Protection & Auth Constraints (多層防御の掟)
+- **オプトアウト方式の Middleware**:
+  Middleware（`middleware.ts`）でのルート保護は、ホワイトリスト（公開ルート）を定義し、「それ以外のルートはすべてデフォルトで保護対象（ログイン必須）」とするオプトアウト方式を維持すること。手動で保護ルートを列挙（オプトイン）してはならない。
+- **Data Access Layer (DAL) による二重チェック**:
+  Middlewareによる保護に加え、ログインが前提となるすべての Server Component（`page.tsx` 等）において、他のDBクエリを実行する前に必ず `requireUser()` などの共通認証ユーティリティを呼び出すこと。
+  未認証時は早期リターンで即座に `redirect('/login')` などを発火させ、RLSによる空データの描画（Ghost UI）を確実に防ぐ。
+- **`getUser()` の絶対使用**:
+  セッションの有効性をサーバー側で正確に検証するため、認証ユーティリティの内部では `getSession()` ではなく、必ず `supabase.auth.getUser()` を使用すること。

--- a/apps/app/src/app/(dashboard)/notes/page.tsx
+++ b/apps/app/src/app/(dashboard)/notes/page.tsx
@@ -1,21 +1,18 @@
-import { redirect } from "next/navigation";
 import { Suspense } from "react";
-import { createClient } from "@/utils/supabase/server";
+import { requireUser } from "@/utils/supabase/server";
 import { NotesContainer } from "./_components/NotesContainer";
 import type { SearchParams } from "./types";
 
 export default async function Dashboard(_props: {
 	searchParams: Promise<SearchParams>;
 }) {
-	const supabase = await createClient();
+	const resolvedParams = await _props.searchParams;
+	const query = new URLSearchParams(
+		resolvedParams as Record<string, string>,
+	).toString();
+	const currentPath = `/notes${query ? `?${query}` : ""}`;
 
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
-
-	if (!user) {
-		return redirect("/login");
-	}
+	await requireUser(currentPath);
 
 	return (
 		<Suspense fallback={null}>

--- a/apps/app/src/app/(dashboard)/page.tsx
+++ b/apps/app/src/app/(dashboard)/page.tsx
@@ -8,13 +8,13 @@ import {
 } from "lucide-react";
 import { CustomLink as Link } from "@/components/ui/custom-link";
 import { NOTES_LIMIT } from "@/constants/limits";
-import { createClient } from "@/utils/supabase/server";
+import { requireUser } from "@/utils/supabase/server";
 import type { PinnedSite } from "../../../../../types/app";
 import { ComingSoonButton } from "./_components/ComingSoonButton";
 import { PinnedSitesManager } from "./_components/PinnedSitesManager";
 
 export default async function LaunchpadPage() {
-	const supabase = await createClient();
+	const { supabase } = await requireUser("/");
 	const [
 		{ count: notesCount },
 		{ count: draftsCount },

--- a/apps/app/src/app/(dashboard)/studio/[id]/page.tsx
+++ b/apps/app/src/app/(dashboard)/studio/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
-import { createClient } from "@/utils/supabase/server";
+import { requireUser } from "@/utils/supabase/server";
 import type { Draft } from "../../../../../../../types/app.ts";
 import DraftEditor from "../../_components/DraftEditor";
 
@@ -12,7 +12,7 @@ interface DraftPageProps {
 
 export default async function DraftEditPage({ params }: DraftPageProps) {
 	const { id } = await params;
-	const supabase = await createClient();
+	const { supabase } = await requireUser(`/studio/${id}`);
 
 	const { data: draft, error } = await supabase
 		.from("sitecue_drafts")

--- a/apps/app/src/app/(dashboard)/studio/new/page.tsx
+++ b/apps/app/src/app/(dashboard)/studio/new/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { createClient } from "@/utils/supabase/server";
+import { requireUser } from "@/utils/supabase/server";
 import DraftEditor from "../../_components/DraftEditor";
 
 export default async function FocusModePage({
@@ -8,14 +8,19 @@ export default async function FocusModePage({
 	searchParams: Promise<{ template_id?: string }>;
 }) {
 	const resolvedParams = await searchParams;
-	let template = null;
+	const templateId = resolvedParams.template_id;
+	const currentPath = templateId
+		? `/studio/new?template_id=${templateId}`
+		: "/studio/new";
 
-	if (resolvedParams.template_id) {
-		const supabase = await createClient();
+	const { supabase } = await requireUser(currentPath);
+
+	let template = null;
+	if (templateId) {
 		const { data } = await supabase
 			.from("sitecue_templates")
 			.select("*")
-			.eq("id", resolvedParams.template_id)
+			.eq("id", templateId)
 			.single();
 		template = data;
 	}

--- a/apps/app/src/app/(dashboard)/templates/page.tsx
+++ b/apps/app/src/app/(dashboard)/templates/page.tsx
@@ -1,5 +1,4 @@
-import { redirect } from "next/navigation";
-import { createClient } from "@/utils/supabase/server";
+import { requireUser } from "@/utils/supabase/server";
 import type { Template } from "../../../../../../types/app";
 import { TemplateManager } from "./_components/TemplateManager";
 
@@ -9,14 +8,11 @@ export default async function TemplatesPage({
 	searchParams: Promise<{ id?: string }>;
 }) {
 	const resolvedParams = await searchParams;
-	const supabase = await createClient();
-	const {
-		data: { user },
-	} = await supabase.auth.getUser();
+	const currentPath = resolvedParams.id
+		? `/templates?id=${resolvedParams.id}`
+		: "/templates";
 
-	if (!user) {
-		return redirect("/login?next=/templates");
-	}
+	const { supabase } = await requireUser(currentPath);
 
 	const { data: templates } = await supabase
 		.from("sitecue_templates")

--- a/apps/app/src/utils/supabase/middleware.ts
+++ b/apps/app/src/utils/supabase/middleware.ts
@@ -35,12 +35,13 @@ export async function updateSession(request: NextRequest) {
 		data: { user },
 	} = await supabase.auth.getUser();
 
-	const protectedRoutes = ["/", "/notes", "/studio"];
-	const isProtectedRoute =
-		protectedRoutes.includes(request.nextUrl.pathname) ||
-		request.nextUrl.pathname.startsWith("/studio/");
+	// オプトアウト方式: 認証不要な公開ルートをホワイトリストとして定義
+	const publicRoutes = ["/login", "/auth/callback", "/pricing"];
+	const isPublicRoute =
+		publicRoutes.includes(request.nextUrl.pathname) ||
+		request.nextUrl.pathname.startsWith("/api/");
 
-	if (!user && isProtectedRoute) {
+	if (!user && !isPublicRoute) {
 		// no user, potentially respond by redirecting the user to the login page
 		let baseUrl = request.url;
 		const host =
@@ -61,3 +62,10 @@ export async function updateSession(request: NextRequest) {
 
 	return supabaseResponse;
 }
+
+// 静的アセット等の除外設定
+export const config = {
+	matcher: [
+		"/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+	],
+};

--- a/apps/app/src/utils/supabase/server.test.ts
+++ b/apps/app/src/utils/supabase/server.test.ts
@@ -1,0 +1,39 @@
+import { redirect } from "next/navigation";
+import { describe, expect, it, vi } from "vitest";
+import { requireUser } from "./server";
+
+// next/navigation のモック
+vi.mock("next/navigation", () => ({
+	redirect: vi.fn(),
+}));
+
+// next/headers のモック
+vi.mock("next/headers", () => ({
+	cookies: vi.fn().mockResolvedValue({
+		getAll: vi.fn().mockReturnValue([]),
+		set: vi.fn(),
+	}),
+}));
+
+// @supabase/ssr のモック
+vi.mock("@supabase/ssr", () => ({
+	createServerClient: vi.fn().mockReturnValue({
+		auth: {
+			getUser: vi.fn().mockResolvedValue({
+				data: { user: null },
+				error: { message: "No user" },
+			}),
+		},
+	}),
+}));
+
+describe("requireUser DAL", () => {
+	it("未認証ユーザーの場合、指定した currentPath をエンコードしてリダイレクトする", async () => {
+		await requireUser("/studio/new?template_id=xyz");
+
+		// EncodeURIComponent でエンコードされた値が渡されるかを検証
+		expect(redirect).toHaveBeenCalledWith(
+			"/login?next=%2Fstudio%2Fnew%3Ftemplate_id%3Dxyz",
+		);
+	});
+});

--- a/apps/app/src/utils/supabase/server.ts
+++ b/apps/app/src/utils/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 
 export async function createClient() {
 	const cookieStore = await cookies();
@@ -26,4 +27,22 @@ export async function createClient() {
 			},
 		},
 	);
+}
+
+/**
+ * 認証済みユーザーを要求するData Access Layer (DAL)。
+ * 未認証時は指定された currentPath を next パラメータに付与して /login へリダイレクトする。
+ */
+export async function requireUser(currentPath: string) {
+	const supabase = await createClient();
+	const {
+		data: { user },
+		error,
+	} = await supabase.auth.getUser();
+
+	if (error || !user) {
+		redirect(`/login?next=${encodeURIComponent(currentPath)}`);
+	}
+
+	return { supabase, user };
 }


### PR DESCRIPTION
- Why
  - Prevent "Ghost UI" rendering in Server Components when Middleware is bypassed during client-side navigation.
  - Enhance system security by adopting a "secure by default" (whitelist-based) access control to prevent protection leaks.

- What
  - Introduce `requireUser()` function as a robust Data Access Layer (DAL) utility for Server Component-level authentication.
  - Refactor Middleware logic to protect all routes by default, requiring explicit opt-out for public access.