### PR TITLE
refactor(layout): add suspense boundaries to AppShell and MobileBotto…

### DIFF
--- a/.agent/skills/basecamp-routing/SKILL.md
+++ b/.agent/skills/basecamp-routing/SKILL.md
@@ -27,6 +27,11 @@ App Basecamp（`apps/app/`）に新しい機能や画面を追加する場合、
 - **`useSearchParams` のラップ必須化**:
   Client Component (`"use client"`) 内で `useSearchParams()` フックを使用する場合、そのコンポーネントまたは呼び出し元を必ず React の `<Suspense fallback={...}>` でラップしてください。
   これを行わないと、OpenNext のビルドプロセス中の静的生成 (Prerendering) がクライアント側のパラメータに依存してしまい、ビルドが完全に失敗します。
+- **自己完結型Suspense境界の推奨**:
+  パフォーマンス向上のためSSR/SSGの恩恵を最大化しつつ、CSRへの強制フォールバックエラーを防ぐため、可能な限りコンポーネント単位で `<Suspense>` を配置してください。
+- **引き算の美学 (Fallback)**:
+  `.agent/rules/ui-rules.md` に従い、Suspense の `fallback` には原則として `null` を指定し、レンダリング時のチラつきを最小限に抑えてください。
+
 
 ## 5. Server Component Constraints (RSCの掟)
 - **イベントハンドラの禁止**: `page.tsx` や `layout.tsx` などの Server Component 内で、直接 `onClick` や `onChange` などのイベントハンドラを記述したり、`useState` などの React Hooks を呼び出したりすることは**厳禁**。

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "sitecue-api",
+	"name": "@sitecue/api",
 	"type": "module",
 	"scripts": {
 		"dev": "wrangler dev",

--- a/apps/app/src/components/layout/AppShell.tsx
+++ b/apps/app/src/components/layout/AppShell.tsx
@@ -28,6 +28,65 @@ import { useUserStore } from "@/store/useUserStore";
 import { GlobalSidebar } from "./GlobalSidebar";
 import { MobileBottomNav } from "./MobileBottomNav";
 
+function MobileFABInner() {
+	const searchParams = useSearchParams();
+
+	// FABの Shallow Routing
+	const handleOpenGlobalNew = (type: "note" | "draft") => {
+		const params = new URLSearchParams(searchParams.toString());
+		params.set("globalNew", type);
+		const newUrl = `${window.location.pathname}?${params.toString()}`;
+		window.history.pushState(null, "", newUrl);
+		// App Router環境で再レンダリングを促すため、popstateを発火させるかrouterを併用する場合があるが
+		// 設計図に従い pushState を使用
+		window.dispatchEvent(new PopStateEvent("popstate"));
+	};
+
+	return (
+		<div className="md:hidden fixed bottom-20 right-4 z-40">
+			<Popover>
+				<PopoverTrigger
+					render={
+						<Button
+							size="icon"
+							className="h-14 w-14 rounded-full shadow-xl bg-action text-action-text hover-safe:bg-action-hover cursor-pointer transition-transform active:scale-95"
+						>
+							<Plus className="w-6 h-6" aria-hidden="true" />
+						</Button>
+					}
+				/>
+				<PopoverContent
+					side="top"
+					align="end"
+					sideOffset={12}
+					className="w-48 p-2 flex flex-col gap-1 z-50"
+				>
+					<Button
+						type="button"
+						variant="ghost"
+						size="sm"
+						onClick={() => handleOpenGlobalNew("note")}
+						className="flex items-center justify-start gap-2 w-full cursor-pointer text-gray-600 hover:text-action"
+					>
+						<FileText className="w-4 h-4" aria-hidden="true" />
+						New Note
+					</Button>
+					<Button
+						type="button"
+						variant="ghost"
+						size="sm"
+						onClick={() => handleOpenGlobalNew("draft")}
+						className="flex items-center justify-start gap-2 w-full cursor-pointer text-gray-600 hover:text-action"
+					>
+						<PenSquare className="w-4 h-4" aria-hidden="true" />
+						New Draft
+					</Button>
+				</PopoverContent>
+			</Popover>
+		</div>
+	);
+}
+
 export function AppShell({ children }: { children: React.ReactNode }) {
 	const _pathname = usePathname();
 	const _isSidebarOpen = useLayoutStore((state) => state.isSidebarOpen);
@@ -40,7 +99,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 	);
 	const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 	const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
-	const searchParams = useSearchParams();
 	const { isPaywallOpen, paywallType, closePaywall, plan } = useUserStore();
 
 	// Global scroll monitoring (centralized)
@@ -89,17 +147,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 			window.removeEventListener("scroll", handleGlobalScroll, true);
 		};
 	}, [setIsMobileHeaderVisible]);
-
-	// FABの Shallow Routing
-	const handleOpenGlobalNew = (type: "note" | "draft") => {
-		const params = new URLSearchParams(searchParams.toString());
-		params.set("globalNew", type);
-		const newUrl = `${window.location.pathname}?${params.toString()}`;
-		window.history.pushState(null, "", newUrl);
-		// App Router環境で再レンダリングを促すため、popstateを発火させるかrouterを併用する場合があるが
-		// 設計図に従い pushState を使用
-		window.dispatchEvent(new PopStateEvent("popstate"));
-	};
 
 	return (
 		<div className="flex h-screen w-full overflow-hidden bg-base-bg text-action">
@@ -160,47 +207,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 			/>
 
 			{/* FAB (Mobile Only) */}
-			<div className="md:hidden fixed bottom-20 right-4 z-40">
-				<Popover>
-					<PopoverTrigger
-						render={
-							<Button
-								size="icon"
-								className="h-14 w-14 rounded-full shadow-xl bg-action text-action-text hover-safe:bg-action-hover cursor-pointer transition-transform active:scale-95"
-							>
-								<Plus className="w-6 h-6" aria-hidden="true" />
-							</Button>
-						}
-					/>
-					<PopoverContent
-						side="top"
-						align="end"
-						sideOffset={12}
-						className="w-48 p-2 flex flex-col gap-1 z-50"
-					>
-						<Button
-							type="button"
-							variant="ghost"
-							size="sm"
-							onClick={() => handleOpenGlobalNew("note")}
-							className="flex items-center justify-start gap-2 w-full cursor-pointer text-gray-600 hover:text-action"
-						>
-							<FileText className="w-4 h-4" aria-hidden="true" />
-							New Note
-						</Button>
-						<Button
-							type="button"
-							variant="ghost"
-							size="sm"
-							onClick={() => handleOpenGlobalNew("draft")}
-							className="flex items-center justify-start gap-2 w-full cursor-pointer text-gray-600 hover:text-action"
-						>
-							<PenSquare className="w-4 h-4" aria-hidden="true" />
-							New Draft
-						</Button>
-					</PopoverContent>
-				</Popover>
-			</div>
+			<Suspense fallback={null}>
+				<MobileFABInner />
+			</Suspense>
 
 			<MobileBottomNav onSearchOpen={() => setIsSearchModalOpen(true)} />
 

--- a/apps/app/src/components/layout/MobileBottomNav.test.tsx
+++ b/apps/app/src/components/layout/MobileBottomNav.test.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MobileBottomNav } from "./MobileBottomNav";
+
+// next/navigationのモック
+vi.mock("next/navigation", () => ({
+	useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("MobileBottomNav", () => {
+	it("renders correctly within Suspense boundary without crashing", () => {
+		const { container } = render(
+			<MobileBottomNav onSearchOpen={vi.fn()} />
+		);
+		// DOMの取得検証
+		expect(container.querySelector("nav")).toBeInTheDocument();
+	});
+});

--- a/apps/app/src/components/layout/MobileBottomNav.tsx
+++ b/apps/app/src/components/layout/MobileBottomNav.tsx
@@ -2,13 +2,14 @@
 
 import { Globe, Inbox, PenSquare, Search } from "lucide-react";
 import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import { CustomLink as Link } from "@/components/ui/custom-link";
 
 interface MobileBottomNavProps {
 	onSearchOpen: () => void;
 }
 
-export function MobileBottomNav({ onSearchOpen }: MobileBottomNavProps) {
+function MobileBottomNavInner({ onSearchOpen }: MobileBottomNavProps) {
 	const searchParams = useSearchParams();
 	const isDetailOpen = !!(
 		searchParams.get("noteId") || searchParams.get("draftId")
@@ -51,5 +52,13 @@ export function MobileBottomNav({ onSearchOpen }: MobileBottomNavProps) {
 				</button>
 			</div>
 		</nav>
+	);
+}
+
+export function MobileBottomNav(props: MobileBottomNavProps) {
+	return (
+		<Suspense fallback={null}>
+			<MobileBottomNavInner {...props} />
+		</Suspense>
 	);
 }

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "sitecue-extension",
+	"name": "@sitecue/extension",
 	"private": true,
 	"version": "1.2.0",
 	"type": "module",


### PR DESCRIPTION
…mNav

- Why: resolve `missing-suspense-with-csr-bailout` error during Next.js (OpenNext) static generation triggered by `useSearchParams()`
- What: extract logic using `useSearchParams` into `Inner` components and wrap them with `<Suspense fallback={null}>` in `AppShell.tsx` and `MobileBottomNav.tsx` to prevent forced CSR fallback