### PR TITLE
feat(notes): update mobile notes detail to full-screen drawer UI

### DIFF
--- a/apps/app/src/app/(dashboard)/notes/_components/ResponsiveNotesLayout.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/ResponsiveNotesLayout.test.tsx
@@ -1,40 +1,49 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { ResponsiveNotesLayout } from "./ResponsiveNotesLayout";
 
-// next/navigation のモック
+// Mock hooks
 vi.mock("next/navigation", () => ({
-	useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
-	useSearchParams: vi.fn(() => new URLSearchParams("?new=note")),
+	useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+	useSearchParams: () => new URLSearchParams(),
 }));
 
-// MatchMedia のモック (Mobile環境をシミュレート)
-Object.defineProperty(window, "matchMedia", {
-	writable: true,
-	value: vi.fn().mockImplementation((query) => ({
-		matches: false, // モバイル (min-width: 768px -> false)
-		media: query,
-		onchange: null,
-		addListener: vi.fn(),
-		removeListener: vi.fn(),
-		addEventListener: vi.fn(),
-		removeEventListener: vi.fn(),
-		dispatchEvent: vi.fn(),
-	})),
-});
+vi.mock("@/hooks/use-media-query", () => ({
+	useMediaQuery: vi.fn(),
+}));
 
 describe("ResponsiveNotesLayout", () => {
-	it("URLに new=note が含まれる場合、モバイル環境で詳細ペイン(Dialog)が開くこと", () => {
+	it("renders both panes when isDesktop is true", () => {
+		vi.mocked(useMediaQuery).mockReturnValue(true);
+
 		render(
 			<ResponsiveNotesLayout
-				middleNode={<div>Middle Pane</div>}
-				rightNode={<div>Right Pane Detail</div>}
+				middleNode={<div data-testid="middle-node">Middle</div>}
+				rightNode={<div data-testid="right-node">Right</div>}
 				selectedNoteId={null}
 				selectedDraftId={null}
 			/>,
 		);
 
-		// Dialogが開いて、Right Pane Detail がレンダリングされていることを検証
-		expect(screen.getByText("Right Pane Detail")).toBeInTheDocument();
+		expect(screen.getByTestId("middle-node")).toBeInTheDocument();
+		expect(screen.getByTestId("right-node")).toBeInTheDocument();
+	});
+
+	it("renders only middle pane when isDesktop is false and no detail is selected", () => {
+		vi.mocked(useMediaQuery).mockReturnValue(false);
+
+		render(
+			<ResponsiveNotesLayout
+				middleNode={<div data-testid="middle-node">Middle</div>}
+				rightNode={<div data-testid="right-node">Right</div>}
+				selectedNoteId={null}
+				selectedDraftId={null}
+			/>,
+		);
+
+		expect(screen.getByTestId("middle-node")).toBeInTheDocument();
+		// Right node should not be in the document if Drawer is closed
+		expect(screen.queryByTestId("right-node")).not.toBeInTheDocument();
 	});
 });

--- a/apps/app/src/app/(dashboard)/notes/_components/ResponsiveNotesLayout.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/ResponsiveNotesLayout.tsx
@@ -1,14 +1,16 @@
 "use client";
 
+import { ArrowLeft } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Fragment, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
 import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
+	Drawer,
+	DrawerContent,
+	DrawerDescription,
+	DrawerHeader,
+	DrawerTitle,
+} from "@/components/ui/drawer";
 import { useMediaQuery } from "@/hooks/use-media-query";
 
 interface ResponsiveNotesLayoutProps {
@@ -58,18 +60,33 @@ export function ResponsiveNotesLayout({
 			{/* List Area */}
 			<main className="flex-1 overflow-hidden">{middleNode}</main>
 
-			{/* Detail Dialog */}
-			<Dialog open={isDetailOpen} onOpenChange={handleCloseDetail}>
-				<DialogContent className="p-0 sm:max-w-full h-[90vh] sm:h-screen sm:rounded-none flex flex-col overflow-hidden">
-					<DialogHeader className="sr-only">
-						<DialogTitle>Detail View</DialogTitle>
-						<DialogDescription>
+			{/* Detail Drawer (Mobile Only) */}
+			<Drawer onOpenChange={handleCloseDetail} open={isDetailOpen}>
+				<DrawerContent className="!mt-0 !h-[100dvh] !max-h-none rounded-t-2xl rounded-b-none p-0 flex flex-col overflow-hidden bg-base-bg border-none">
+					<DrawerHeader className="sr-only">
+						<DrawerTitle>Detail View</DrawerTitle>
+						<DrawerDescription>
 							View and edit note or draft details
-						</DialogDescription>
-					</DialogHeader>
-					<div className="flex-1 overflow-hidden">{rightNode}</div>
-				</DialogContent>
-			</Dialog>
+						</DrawerDescription>
+					</DrawerHeader>
+
+					{/* Mobile Header with Back Button (Placed under the drag handle) */}
+					<div className="shrink-0 flex items-center px-4 py-2 border-b border-base-border mt-2">
+						<Button
+							onClick={() => handleCloseDetail(false)}
+							type="button"
+							variant="ghost"
+							className="gap-2 px-2 -ml-2 text-action hover-safe:bg-base-surface cursor-pointer"
+						>
+							<ArrowLeft aria-hidden="true" className="w-5 h-5" />
+							Notes
+						</Button>
+					</div>
+
+					{/* Scrollable Content Area */}
+					<div className="flex-1 overflow-y-auto">{rightNode}</div>
+				</DrawerContent>
+			</Drawer>
 		</div>
 	);
 }

--- a/apps/app/src/app/(dashboard)/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/RightPaneDetail.tsx
@@ -390,7 +390,7 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 	return (
 		<div className="flex-1 flex flex-col h-full bg-base-bg overflow-hidden">
 			{/* 1. Header (Fixed) */}
-			<div className="shrink-0 z-10 bg-base-bg pt-12 md:pt-8 px-4 md:px-8">
+			<div className="shrink-0 z-10 bg-base-bg pt-6 md:pt-8 px-4 md:px-8">
 				<div className="max-w-3xl mx-auto w-full flex items-center justify-between pb-4 border-b border-base-border">
 					{/* Left: Badge and Date */}
 					<div className="flex flex-col gap-1">
@@ -658,7 +658,7 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 										note.url_pattern.startsWith("http")
 											? note.url_pattern
 											: note.url_pattern.includes("localhost") ||
-													note.url_pattern.includes("127.0.0.1")
+												note.url_pattern.includes("127.0.0.1")
 												? `http://${note.url_pattern}`
 												: `https://${note.url_pattern}`
 									}
@@ -699,17 +699,15 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 							<div className="text-[10px] font-bold text-neutral-400 uppercase tracking-widest">
 								{note ? "Note Content" : "Draft Content"}
 							</div>
-							{!note && draft && (
+							{content && (
 								<Button
 									type="button"
 									variant="ghost"
 									size="icon-sm"
 									className="text-neutral-400 hover:text-action cursor-pointer"
 									onClick={() => {
-										if (draft.content) {
-											navigator.clipboard.writeText(draft.content);
-											toast.success("Copied!");
-										}
+										navigator.clipboard.writeText(content);
+										toast.success("Copied!");
 									}}
 									title="Copy Content"
 								>


### PR DESCRIPTION
- Why:
  - Current Dialog-based mobile view suffers from background scroll noise, hindering immersion.
  - Users require a native-like swipe-to-close experience for better one-handed usability.
- What:
  - Replaced Dialog with vaul-based Drawer component for mobile (isDesktop === false) environments.
  - Implemented 100% full-screen layout to eliminate background visual noise.
  - Added swipe-to-close functionality and a dedicated back button in the header.
  - Maintained the existing side-by-side pane layout for desktop users.