### PR TITLE
fix(templates): unify mobile layout and ux with notes page

### DIFF
--- a/apps/app/src/app/(dashboard)/_components/DraftEditor.test.tsx
+++ b/apps/app/src/app/(dashboard)/_components/DraftEditor.test.tsx
@@ -80,7 +80,10 @@ describe("DraftEditor - Error Handling", () => {
 
 		const renderWithProvider = (ui: React.ReactElement) => {
 			const queryClient = new QueryClient({
-				defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+				defaultOptions: {
+					queries: { retry: false },
+					mutations: { retry: false },
+				},
 			});
 			return render(
 				<QueryClientProvider client={queryClient}>
@@ -92,7 +95,9 @@ describe("DraftEditor - Error Handling", () => {
 
 		const user = userEvent.setup();
 
-		renderWithProvider(<DraftEditor initialDraft={mockDraft} template={null} />);
+		renderWithProvider(
+			<DraftEditor initialDraft={mockDraft} template={null} />,
+		);
 
 		// DraftEditor.tsx では、左サイドバーの「WEAVE」ボタン等があるか、
 		// StudioReviewPane.tsx 経由で呼び出されるのでそのボタンを探す。

--- a/apps/app/src/app/(dashboard)/_components/SaveAsTemplateDialog.test.tsx
+++ b/apps/app/src/app/(dashboard)/_components/SaveAsTemplateDialog.test.tsx
@@ -30,7 +30,10 @@ describe("SaveAsTemplateDialog", () => {
 		const user = userEvent.setup();
 
 		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
 		});
 
 		render(

--- a/apps/app/src/app/(dashboard)/notes/_components/ResponsiveNotesLayout.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/ResponsiveNotesLayout.test.tsx
@@ -95,7 +95,9 @@ describe("ResponsiveNotesLayout", () => {
 		});
 		// searchParams をモックし、view=drafts が存在している状態をシミュレート
 		vi.mocked(useSearchParams).mockReturnValue(
-			new URLSearchParams("view=drafts&draftId=draft-1") as any,
+			new URLSearchParams(
+				"view=drafts&draftId=draft-1",
+			) as unknown as ReturnType<typeof useSearchParams>,
 		);
 
 		render(

--- a/apps/app/src/app/(dashboard)/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/RightPaneDetail.tsx
@@ -645,7 +645,7 @@ export function RightPaneDetail({ note, draft, isNewNote }: Props) {
 									const formattedUrl = note.url_pattern.startsWith("http")
 										? note.url_pattern
 										: note.url_pattern.includes("localhost") ||
-											note.url_pattern.includes("127.0.0.1")
+												note.url_pattern.includes("127.0.0.1")
 											? `http://${note.url_pattern}`
 											: `https://${note.url_pattern}`;
 									return (

--- a/apps/app/src/app/(dashboard)/notes/_components/SearchModal.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/SearchModal.test.tsx
@@ -45,7 +45,10 @@ describe("SearchModal Context Jump", () => {
 		});
 
 		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
 		});
 		render(
 			<QueryClientProvider client={queryClient}>
@@ -99,7 +102,10 @@ describe("SearchModal Context Jump", () => {
 		});
 
 		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
 		});
 		render(
 			<QueryClientProvider client={queryClient}>
@@ -132,7 +138,10 @@ describe("SearchModal Context Jump", () => {
 		});
 
 		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
 		});
 		render(
 			<QueryClientProvider client={queryClient}>
@@ -179,7 +188,10 @@ describe("SearchModal Context Jump", () => {
 		});
 
 		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
 		});
 		render(
 			<QueryClientProvider client={queryClient}>
@@ -232,7 +244,10 @@ describe("SearchModal Context Jump", () => {
 		});
 
 		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
 		});
 		render(
 			<QueryClientProvider client={queryClient}>
@@ -280,7 +295,10 @@ describe("SearchModal Context Jump", () => {
 		});
 
 		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
 		});
 		render(
 			<QueryClientProvider client={queryClient}>

--- a/apps/app/src/app/(dashboard)/studio/_components/StudioReviewPane.test.tsx
+++ b/apps/app/src/app/(dashboard)/studio/_components/StudioReviewPane.test.tsx
@@ -10,7 +10,10 @@ describe("StudioReviewPane - AI Review", () => {
 		const mockGenerate = vi.fn().mockResolvedValue(undefined);
 
 		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
 		});
 
 		render(

--- a/apps/app/src/app/(dashboard)/templates/_components/TemplateManager.test.tsx
+++ b/apps/app/src/app/(dashboard)/templates/_components/TemplateManager.test.tsx
@@ -1,7 +1,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { TemplateManager } from "./TemplateManager";
+
+// useMediaQuery mock
+vi.mock("@/hooks/use-media-query", () => ({
+	useMediaQuery: vi.fn(),
+}));
 
 // next/navigation mock
 vi.mock("next/navigation", () => ({
@@ -49,55 +55,88 @@ const mockTemplates = [
 	},
 ];
 
+const renderWithQuery = (ui: React.ReactNode) => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+	);
+};
+
 describe("TemplateManager", () => {
-	it("renders list and allows selecting a template", async () => {
-		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-		});
-		render(
-			<QueryClientProvider client={queryClient}>
-				<TemplateManager initialTemplates={mockTemplates} selectedId="1" />
-			</QueryClientProvider>,
+	it("renders split pane on desktop and allows selecting a template", async () => {
+		vi.mocked(useMediaQuery).mockReturnValue(true);
+
+		renderWithQuery(
+			<TemplateManager initialTemplates={mockTemplates} selectedId="1" />,
 		);
 
 		// Check if list item exists
-		expect(screen.getByText("Mock Template")).toBeInTheDocument();
+		expect(await screen.findByText("Mock Template")).toBeInTheDocument();
 
-		// Check form fields
+		// Check form fields in the desktop pane
 		expect(screen.getByLabelText("Template Name")).toHaveValue("Mock Template");
 		expect(screen.getByLabelText("Max Length (Optional)")).toHaveValue(100);
-		expect(
-			screen.getByLabelText("Boilerplate / Initial Text (Optional)"),
-		).toHaveValue("Hello");
-		expect(
-			screen.getByLabelText("Weave Prompt (System Prompt for AI) (Optional)"),
-		).toHaveValue("Focus on X");
+
+		// Drawer should NOT be present (searching for dialog role)
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 	});
 
-	it("shows empty state when no template is selected", () => {
-		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-		});
-		render(
-			<QueryClientProvider client={queryClient}>
-				<TemplateManager initialTemplates={mockTemplates} selectedId={null} />
-			</QueryClientProvider>,
+	it("renders Drawer on mobile when a template is selected", async () => {
+		vi.mocked(useMediaQuery).mockReturnValue(false);
+
+		renderWithQuery(
+			<TemplateManager initialTemplates={mockTemplates} selectedId="1" />,
+		);
+
+		// List item should still be there
+		expect(await screen.findByText("Mock Template")).toBeInTheDocument();
+
+		// Drawer should be open (contains dialog role)
+		expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+		// Drawer内の戻るボタンがレンダリングされていることを確認
+		const backButton = screen.getByRole("button", { name: /Templates/i });
+		expect(backButton).toBeInTheDocument();
+
+		const headings = screen.getAllByText(/Edit Template/i);
+		expect(headings.length).toBeGreaterThan(0);
+	});
+
+	it("shows empty state when no template is selected (Desktop)", () => {
+		vi.mocked(useMediaQuery).mockReturnValue(true);
+
+		renderWithQuery(
+			<TemplateManager initialTemplates={mockTemplates} selectedId={null} />,
 		);
 		expect(
 			screen.getByText("Select a template to edit or create a new one."),
 		).toBeInTheDocument();
 	});
 
-	it("shows creation form when id is 'new'", () => {
-		const queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-		});
-		render(
-			<QueryClientProvider client={queryClient}>
-				<TemplateManager initialTemplates={mockTemplates} selectedId="new" />
-			</QueryClientProvider>,
+	it("shows creation form on mobile via Drawer", async () => {
+		vi.mocked(useMediaQuery).mockReturnValue(false);
+
+		renderWithQuery(
+			<TemplateManager initialTemplates={mockTemplates} selectedId="new" />,
 		);
-		expect(screen.getByText("Create Template")).toBeInTheDocument();
+
+		expect(await screen.findByRole("dialog")).toBeInTheDocument();
+		const headings = screen.getAllByText(/Create Template/i);
+		expect(headings.length).toBeGreaterThan(0);
 		expect(screen.getByLabelText("Template Name")).toHaveValue("");
+	});
+
+	it("has a new template button in the header", () => {
+		vi.mocked(useMediaQuery).mockReturnValue(true);
+
+		renderWithQuery(
+			<TemplateManager initialTemplates={mockTemplates} selectedId={null} />,
+		);
+
+		const newBtn = screen.getByLabelText("New Template");
+		expect(newBtn).toBeInTheDocument();
+		expect(newBtn.closest("a")).toHaveAttribute("href", "/templates?id=new");
 	});
 });

--- a/apps/app/src/app/(dashboard)/templates/_components/TemplateManager.tsx
+++ b/apps/app/src/app/(dashboard)/templates/_components/TemplateManager.tsx
@@ -6,9 +6,17 @@ import { useEffect, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { Button } from "@/components/ui/button";
 import { CustomLink as Link } from "@/components/ui/custom-link";
+import {
+	Drawer,
+	DrawerContent,
+	DrawerDescription,
+	DrawerHeader,
+	DrawerTitle,
+} from "@/components/ui/drawer";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { APP_LIMITS } from "@/constants/limits";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import {
 	useCreateTemplate,
 	useDeleteTemplate,
@@ -29,6 +37,8 @@ export function TemplateManager({
 }) {
 	const isSidebarOpen = useLayoutStore((state) => state.isSidebarOpen);
 	const router = useRouter();
+	const isDesktop = useMediaQuery("(min-width: 768px)");
+
 	const { data: templates = [], isLoading } =
 		useFetchTemplates(initialTemplates);
 
@@ -39,6 +49,7 @@ export function TemplateManager({
 	// Form State
 	const activeTemplate = templates.find((t) => t.id === selectedId);
 	const isNew = selectedId === "new";
+	const isDrawerOpen = !isDesktop && (!!activeTemplate || isNew);
 
 	const [name, setName] = useState("");
 	const [maxLength, setMaxLength] = useState<string>("");
@@ -133,41 +144,141 @@ export function TemplateManager({
 		}
 	};
 
+	const handleOpenChange = (open: boolean) => {
+		if (!open) router.push("/templates");
+	};
+
+	const EditorContent = (
+		<div className="max-w-2xl w-full mx-auto space-y-6">
+			<div className="flex items-center justify-between mb-8">
+				<h2 className="text-2xl font-bold">
+					{isNew ? "Create Template" : "Edit Template"}
+				</h2>
+				<Button
+					onClick={handleSave}
+					disabled={isSaving || !name.trim() || isOverLimit}
+					type="button"
+				>
+					{isSaving ? "Saving..." : "Save Template"}
+				</Button>
+			</div>
+
+			<div className="space-y-4">
+				<div className="space-y-2">
+					<Label htmlFor="template-name">Template Name</Label>
+					<Input
+						id="template-name"
+						value={name}
+						onChange={(e) => setName(e.target.value)}
+						placeholder="e.g. X Thread, Daily Report"
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<Label htmlFor="max-length">Max Length (Optional)</Label>
+					<Input
+						id="max-length"
+						type="number"
+						value={maxLength}
+						onChange={(e) => setMaxLength(e.target.value)}
+						placeholder="e.g. 140"
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<Label htmlFor="boilerplate">
+						Boilerplate / Initial Text (Optional)
+					</Label>
+					<TextareaAutosize
+						id="boilerplate"
+						minRows={4}
+						value={boilerplate}
+						onChange={(e) => setBoilerplate(e.target.value)}
+						className="w-full rounded-lg border border-base-border bg-transparent p-3 text-sm focus:outline-none focus:ring-2 focus:ring-base-border"
+						placeholder="# Target Audience&#10;&#10;# Key Message"
+					/>
+					{isBoilerplateNearLimit && (
+						<div className="flex justify-end">
+							<span
+								className={cn(
+									"text-[10px] font-bold",
+									isBoilerplateOverLimit ? "text-note-alert" : "text-note-idea",
+								)}
+							>
+								{boilerplateCharCount.toLocaleString()} /{" "}
+								{APP_LIMITS.MAX_TEMPLATE_LENGTH.toLocaleString()}
+							</span>
+						</div>
+					)}
+				</div>
+
+				<div className="space-y-2">
+					<Label htmlFor="weave-prompt">
+						Weave Prompt (System Prompt for AI) (Optional)
+					</Label>
+					<TextareaAutosize
+						id="weave-prompt"
+						minRows={3}
+						value={weavePrompt}
+						onChange={(e) => setWeavePrompt(e.target.value)}
+						className="w-full rounded-lg border border-base-border bg-base-surface p-3 text-sm focus:outline-none font-mono text-xs"
+						placeholder="Provide context for the AI when generating from this template."
+					/>
+					{isWeavePromptNearLimit && (
+						<div className="flex justify-end">
+							<span
+								className={cn(
+									"text-[10px] font-bold",
+									isWeavePromptOverLimit ? "text-note-alert" : "text-note-idea",
+								)}
+							>
+								{weavePromptCharCount.toLocaleString()} /{" "}
+								{APP_LIMITS.MAX_TEMPLATE_LENGTH.toLocaleString()}
+							</span>
+						</div>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+
 	if (isLoading) return null;
 
 	return (
 		<div className="flex h-screen overflow-hidden bg-base-bg text-action">
-			{/* Left Pane: List */}
-			<div className="w-80 flex flex-col border-r border-base-border bg-base-surface">
+			{/* List Pane */}
+			<div className="w-full md:w-80 flex flex-col border-r border-base-border bg-base-surface">
 				<div className="flex-1 overflow-y-auto pb-28 md:pb-0">
 					<div
 						className={cn(
-							"p-4 border-b border-base-border flex items-center gap-2 sticky top-0 bg-base-surface z-20 transition-all duration-300",
+							"p-4 border-b border-base-border flex items-center justify-between sticky top-0 bg-base-surface z-20 transition-all duration-300",
 							!isSidebarOpen && "md:pl-16",
 						)}
 					>
-						<Link
-							href="/"
-							className="inline-flex items-center justify-center h-7 w-7 rounded-[min(var(--radius-md),12px)] hover:bg-muted hover:text-foreground transition-colors"
-							aria-label="Go back to Launchpad"
-						>
-							<ArrowLeft className="w-4 h-4 text-action" aria-hidden="true" />
-						</Link>
-						<h1 className="font-bold text-lg">Templates</h1>
-					</div>
-					<div className="p-4">
+						<div className="flex items-center gap-2">
+							<Link
+								href="/"
+								className="inline-flex items-center justify-center h-7 w-7 rounded-[min(var(--radius-md),12px)] hover-safe:bg-muted hover-safe:text-foreground transition-colors"
+								aria-label="Go back to Launchpad"
+							>
+								<ArrowLeft className="w-4 h-4 text-action" aria-hidden="true" />
+							</Link>
+							<h1 className="font-bold text-lg">Templates</h1>
+						</div>
 						<Link
 							href="/templates?id=new"
-							className="flex items-center justify-center gap-2 w-full border border-dashed border-base-border bg-transparent text-neutral-500 py-2 rounded-lg text-sm font-bold hover:text-action hover:border-action transition-colors"
+							className="inline-flex items-center justify-center h-7 w-7 rounded-[min(var(--radius-md),12px)] hover-safe:bg-muted transition-colors text-action"
+							aria-label="New Template"
 						>
-							<Plus className="w-4 h-4" aria-hidden="true" /> New Template
+							<Plus className="w-4 h-4" aria-hidden="true" />
 						</Link>
 					</div>
-					<div className="px-2 space-y-1">
+
+					<div className="px-2 py-4 space-y-1">
 						{templates.map((t) => (
 							<div
 								key={t.id}
-								className={`flex items-center justify-between px-3 py-2 rounded-lg group ${selectedId === t.id ? "bg-base-bg shadow-sm" : "hover:bg-base-bg/50"}`}
+								className={`flex items-center justify-between px-3 py-2 rounded-lg group ${selectedId === t.id ? "bg-base-bg shadow-sm" : "hover-safe:bg-base-bg/50"}`}
 							>
 								<Link
 									href={`/templates?id=${t.id}`}
@@ -179,8 +290,9 @@ export function TemplateManager({
 									variant="ghost"
 									size="icon-sm"
 									onClick={() => handleDelete(t.id)}
-									className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-note-alert transition-opacity"
+									className="opacity-100 pointer-fine:opacity-0 group-hover-safe:opacity-100 text-gray-400 hover-safe:text-note-alert transition-opacity"
 									type="button"
+									aria-label={`Delete ${t.name}`}
 								>
 									<Trash2 className="w-3 h-3" aria-hidden="true" />
 								</Button>
@@ -190,110 +302,50 @@ export function TemplateManager({
 				</div>
 			</div>
 
-			{/* Right Pane: Form */}
-			<div className="flex-1 flex flex-col overflow-y-auto p-8 pb-28 md:pb-8">
-				{activeTemplate || isNew ? (
-					<div className="max-w-2xl w-full mx-auto space-y-6">
-						<div className="flex items-center justify-between mb-8">
-							<h2 className="text-2xl font-bold">
+			{/* Desktop Editor Pane */}
+			{isDesktop && (
+				<div className="flex-1 flex flex-col overflow-y-auto p-8 pb-28 md:pb-8">
+					{activeTemplate || isNew ? (
+						EditorContent
+					) : (
+						<div className="flex-1 flex items-center justify-center text-gray-400">
+							Select a template to edit or create a new one.
+						</div>
+					)}
+				</div>
+			)}
+
+			{/* Mobile Editor Drawer */}
+			{!isDesktop && (
+				<Drawer open={isDrawerOpen} onOpenChange={handleOpenChange}>
+					<DrawerContent className="!mt-0 !h-[100dvh] !max-h-none rounded-t-2xl rounded-b-none p-0 flex flex-col overflow-hidden bg-base-bg border-none">
+						<DrawerHeader className="sr-only">
+							<DrawerTitle>
 								{isNew ? "Create Template" : "Edit Template"}
-							</h2>
+							</DrawerTitle>
+							<DrawerDescription>Edit the template details</DrawerDescription>
+						</DrawerHeader>
+
+						{/* Mobile Header with Back Button */}
+						<div className="shrink-0 flex items-center px-4 py-2 border-b border-base-border mt-2">
 							<Button
-								onClick={handleSave}
-								disabled={isSaving || !name.trim() || isOverLimit}
+								onClick={() => handleOpenChange(false)}
 								type="button"
+								variant="ghost"
+								className="gap-2 px-2 -ml-2 text-action hover-safe:bg-base-surface cursor-pointer"
 							>
-								{isSaving ? "Saving..." : "Save Template"}
+								<ArrowLeft aria-hidden="true" className="w-5 h-5" />
+								Templates
 							</Button>
 						</div>
 
-						<div className="space-y-4">
-							<div className="space-y-2">
-								<Label htmlFor="template-name">Template Name</Label>
-								<Input
-									id="template-name"
-									value={name}
-									onChange={(e) => setName(e.target.value)}
-									placeholder="e.g. X Thread, Daily Report"
-								/>
-							</div>
-
-							<div className="space-y-2">
-								<Label htmlFor="max-length">Max Length (Optional)</Label>
-								<Input
-									id="max-length"
-									type="number"
-									value={maxLength}
-									onChange={(e) => setMaxLength(e.target.value)}
-									placeholder="e.g. 140"
-								/>
-							</div>
-
-							<div className="space-y-2">
-								<Label htmlFor="boilerplate">
-									Boilerplate / Initial Text (Optional)
-								</Label>
-								<TextareaAutosize
-									id="boilerplate"
-									minRows={4}
-									value={boilerplate}
-									onChange={(e) => setBoilerplate(e.target.value)}
-									className="w-full rounded-lg border border-base-border bg-transparent p-3 text-sm focus:outline-none focus:ring-2 focus:ring-base-border"
-									placeholder="# Target Audience&#10;&#10;# Key Message"
-								/>
-								{isBoilerplateNearLimit && (
-									<div className="flex justify-end">
-										<span
-											className={cn(
-												"text-[10px] font-bold",
-												isBoilerplateOverLimit
-													? "text-note-alert"
-													: "text-note-idea",
-											)}
-										>
-											{boilerplateCharCount.toLocaleString()} /{" "}
-											{APP_LIMITS.MAX_TEMPLATE_LENGTH.toLocaleString()}
-										</span>
-									</div>
-								)}
-							</div>
-
-							<div className="space-y-2">
-								<Label htmlFor="weave-prompt">
-									Weave Prompt (System Prompt for AI) (Optional)
-								</Label>
-								<TextareaAutosize
-									id="weave-prompt"
-									minRows={3}
-									value={weavePrompt}
-									onChange={(e) => setWeavePrompt(e.target.value)}
-									className="w-full rounded-lg border border-base-border bg-base-surface p-3 text-sm focus:outline-none font-mono text-xs"
-									placeholder="Provide context for the AI when generating from this template."
-								/>
-								{isWeavePromptNearLimit && (
-									<div className="flex justify-end">
-										<span
-											className={cn(
-												"text-[10px] font-bold",
-												isWeavePromptOverLimit
-													? "text-note-alert"
-													: "text-note-idea",
-											)}
-										>
-											{weavePromptCharCount.toLocaleString()} /{" "}
-											{APP_LIMITS.MAX_TEMPLATE_LENGTH.toLocaleString()}
-										</span>
-									</div>
-								)}
-							</div>
+						{/* Scrollable Content Area */}
+						<div className="flex-1 overflow-y-auto p-4 pb-28">
+							{EditorContent}
 						</div>
-					</div>
-				) : (
-					<div className="flex-1 flex items-center justify-center text-gray-400">
-						Select a template to edit or create a new one.
-					</div>
-				)}
-			</div>
+					</DrawerContent>
+				</Drawer>
+			)}
 		</div>
 	);
 }

--- a/apps/app/vitest.setup.ts
+++ b/apps/app/vitest.setup.ts
@@ -15,9 +15,10 @@ class ResizeObserver {
 	unobserve() {}
 	disconnect() {}
 }
-
-// biome-ignore lint/suspicious/noExplicitAny: Global mock
-(window as any).ResizeObserver = ResizeObserver;
+Object.defineProperty(window, "ResizeObserver", {
+	writable: true,
+	value: ResizeObserver,
+});
 
 // PointerEvent mock (for jsdom)
 if (!window.PointerEvent) {
@@ -26,7 +27,10 @@ if (!window.PointerEvent) {
 			super(type, params);
 		}
 	}
-	(window as any).PointerEvent = PointerEvent;
+	Object.defineProperty(window, "PointerEvent", {
+		writable: true,
+		value: PointerEvent,
+	});
 }
 
 // matchMedia mock


### PR DESCRIPTION
- fix layout collapse on mobile devices in TemplateManager.tsx by implementing a responsive layout
- switch to drawer-based editing on mobile (< md) while maintaining 2-pane view on desktop (>= md)
- ensure url id parameter is removed when closing the drawer to sync state with the list view
- relocate "new template" button to a header "+" icon to optimize screen space
- apply pointer-fine variants to delete icons to improve visibility and accessibility on touch devices