### PR TITLE
fix(extension): overhaul fractional indexing to prevent collisions an…

### DIFF
--- a/apps/extension/src/SidePanel.tsx
+++ b/apps/extension/src/SidePanel.tsx
@@ -18,276 +18,278 @@ import { useUserStats } from "./hooks/useUserStats";
 const MAX_FREE_NOTES = 500;
 
 export default function SidePanel() {
-  const {
-    session,
-    authLoading,
-    authError,
-    sessionLoading,
-    handleLogout,
-    handleSocialLogin,
-  } = useAuth();
+	const {
+		session,
+		authLoading,
+		authError,
+		sessionLoading,
+		handleLogout,
+		handleSocialLogin,
+	} = useAuth();
 
-  if (sessionLoading) {
-    return (
-      <div className="w-full h-screen bg-base-surface flex flex-col items-center justify-center font-sans">
-        <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
-      </div>
-    );
-  }
+	if (sessionLoading) {
+		return (
+			<div className="w-full h-screen bg-base-surface flex flex-col items-center justify-center font-sans">
+				<Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+			</div>
+		);
+	}
 
-  if (!session) {
-    return (
-      <LoginScreen
-        authError={authError}
-        authLoading={authLoading}
-        handleSocialLogin={handleSocialLogin}
-      />
-    );
-  }
+	if (!session) {
+		return (
+			<LoginScreen
+				authError={authError}
+				authLoading={authLoading}
+				handleSocialLogin={handleSocialLogin}
+			/>
+		);
+	}
 
-  return <NotesUI session={session} onLogout={handleLogout} />;
+	return <NotesUI session={session} onLogout={handleLogout} />;
 }
 
 function NotesUI({
-  session,
-  onLogout,
+	session,
+	onLogout,
 }: {
-  session: Session;
-  onLogout: () => void;
+	session: Session;
+	onLogout: () => void;
 }) {
-  const { currentFullUrl, url, title } = useCurrentTab();
-  const { userPlan, totalNoteCount, setTotalNoteCount, userStatsLoading } =
-    useUserStats(session);
+	const { currentFullUrl, url, title } = useCurrentTab();
+	const { userPlan, totalNoteCount, setTotalNoteCount, userStatsLoading } =
+		useUserStats(session);
 
-  // 🔍 フィルタリング用ステート
-  const [filterType, setFilterType] = useState<
-    "all" | "info" | "alert" | "idea"
-  >("all");
-  const [showResolved, setShowResolved] = useState(false);
-  const [viewScope, setViewScope] = useState<"exact" | "domain" | "inbox">(
-    "exact",
-  );
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+	// 🔍 フィルタリング用ステート
+	const [filterType, setFilterType] = useState<
+		"all" | "info" | "alert" | "idea"
+	>("all");
+	const [showResolved, setShowResolved] = useState(false);
+	const [viewScope, setViewScope] = useState<"exact" | "domain" | "inbox">(
+		"exact",
+	);
+	const [searchQuery, setSearchQuery] = useState("");
+	const [selectedTag, setSelectedTag] = useState<string | null>(null);
 
-  const [isInputModeOpen, setIsInputModeOpen] = useState(false);
-  const listContainerRef = useRef<HTMLDivElement>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const [isInputModeOpen, setIsInputModeOpen] = useState(false);
+	const listContainerRef = useRef<HTMLDivElement>(null);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const {
-    notes,
-    loading,
-    addNote: originalAddNote,
-    updateNote,
-    deleteNote,
-    toggleResolved,
-    toggleFavorite,
-    togglePinned,
-    updateNoteOrder,
-    toggleNoteExpansion,
-  } = useNotes(session, currentFullUrl, setTotalNoteCount, viewScope);
+	const {
+		notes,
+		loading,
+		addNote: originalAddNote,
+		updateNote,
+		deleteNote,
+		toggleResolved,
+		toggleFavorite,
+		togglePinned,
+		updateNoteOrder,
+		toggleNoteExpansion,
+	} = useNotes(session, currentFullUrl, setTotalNoteCount, viewScope);
 
-  // スクロールバック付きのラッパー関数
-  const handleAddNote = async (
-    content: string,
-    scope: NoteScope,
-    type: NoteType,
-  ) => {
-    const success = await originalAddNote(content, scope, type);
-    if (success) {
-      // 新規ノート追加時、背後のノートリストを最上部へ自動でスクロールバック
-      setTimeout(() => {
-        if (listContainerRef.current) {
-          listContainerRef.current.scrollTo({
-            top: 0,
-            behavior: "smooth",
-          });
-        }
-      }, 100);
-    }
-    return success;
-  };
+	// スクロールバック付きのラッパー関数
+	const handleAddNote = async (
+		content: string,
+		scope: NoteScope,
+		type: NoteType,
+	) => {
+		const success = await originalAddNote(content, scope, type);
+		if (success) {
+			// 新規ノート追加時、背後のノートリストを最上部へ自動でスクロールバック
+			setTimeout(() => {
+				if (listContainerRef.current) {
+					listContainerRef.current.scrollTo({
+						top: 0,
+						behavior: "smooth",
+					});
+				}
+			}, 100);
+		}
+		return success;
+	};
 
-  // 🔍 フィルタリングロジックの集約 (SSOT)
-  const scopeUrls = currentFullUrl
-    ? getScopeUrls(currentFullUrl)
-    : { domain: "", exact: "" };
+	// 🔍 フィルタリングロジックの集約 (SSOT)
+	const scopeUrls = currentFullUrl
+		? getScopeUrls(currentFullUrl)
+		: { domain: "", exact: "" };
 
-  const filteredNotesForTags = notes.filter((n) => {
-    // 1. スコープ（タブ）フィルターの適用
-    // 原則: 「現在お気に入りである」か「現在のURL/スコープに一致する」かのいずれかが必要
-    const isCurrentScope =
-      (viewScope === "inbox" && n.scope === "inbox") ||
-      (viewScope === "domain" &&
-        n.scope === "domain" &&
-        n.url_pattern === scopeUrls.domain) ||
-      (viewScope === "exact" &&
-        n.scope === "exact" &&
-        n.url_pattern === scopeUrls.exact);
+	const filteredNotesForTags = notes.filter((n) => {
+		// 1. スコープ（タブ）フィルターの適用
+		// 原則: 「現在お気に入りである」か「現在のURL/スコープに一致する」かのいずれかが必要
+		const isCurrentScope =
+			(viewScope === "inbox" && n.scope === "inbox") ||
+			(viewScope === "domain" &&
+				n.scope === "domain" &&
+				n.url_pattern === scopeUrls.domain) ||
+			(viewScope === "exact" &&
+				n.scope === "exact" &&
+				n.url_pattern === scopeUrls.exact);
 
-    // 🚨 お気に入りを解除した瞬間、isCurrentScopeがfalseならリストから除外される
-    if (!n.is_favorite && !isCurrentScope) {
-      return false;
-    }
+		// 🚨 お気に入りを解除した瞬間、isCurrentScopeがfalseならリストから除外される
+		if (!n.is_favorite && !isCurrentScope) {
+			return false;
+		}
 
-    // 他のタブの「お気に入り」は表示するが、現在のタブの「お気に入りではないノート」も表示する
-    // ただし、現在選択中のタブ(viewScope)とノートのscopeが不一致なものは落とす（InboxタブにDomainノートを出さない等）
-    if (viewScope === "inbox" && n.scope !== "inbox") return false;
-    if (viewScope !== "inbox" && n.scope === "inbox") return false;
-    if (viewScope !== "inbox" && !n.is_favorite && n.scope !== viewScope)
-      return false;
+		// 他のタブの「お気に入り」は表示するが、現在のタブの「お気に入りではないノート」も表示する
+		// ただし、現在選択中のタブ(viewScope)とノートのscopeが不一致なものは落とす（InboxタブにDomainノートを出さない等）
+		if (viewScope === "inbox" && n.scope !== "inbox") return false;
+		if (viewScope !== "inbox" && n.scope === "inbox") return false;
+		if (viewScope !== "inbox" && !n.is_favorite && n.scope !== viewScope)
+			return false;
 
-    // 2. Note Type フィルター
-    if (filterType !== "all" && (n.note_type || "info") !== filterType) {
-      return false;
-    }
+		// 2. Note Type フィルター
+		if (filterType !== "all" && (n.note_type || "info") !== filterType) {
+			return false;
+		}
 
-    // 3. 解決済みフィルター
-    if (!showResolved && n.is_resolved) {
-      return false;
-    }
+		// 3. 解決済みフィルター
+		if (!showResolved && n.is_resolved) {
+			return false;
+		}
 
-    // 4. 検索クエリフィルター
-    if (searchQuery) {
-      const searchLower = searchQuery.toLowerCase();
-      const matchesContent = n.content?.toLowerCase().includes(searchLower);
-      const matchesTags = n.tags?.some((tag) =>
-        tag.toLowerCase().includes(searchLower),
-      );
-      const matchesUrl = n.url_pattern?.toLowerCase().includes(searchLower);
+		// 4. 検索クエリフィルター
+		if (searchQuery) {
+			const searchLower = searchQuery.toLowerCase();
+			const matchesContent = n.content?.toLowerCase().includes(searchLower);
+			const matchesTags = n.tags?.some((tag) =>
+				tag.toLowerCase().includes(searchLower),
+			);
+			const matchesUrl = n.url_pattern?.toLowerCase().includes(searchLower);
 
-      if (!matchesContent && !matchesTags && !matchesUrl) {
-        return false;
-      }
-    }
+			if (!matchesContent && !matchesTags && !matchesUrl) {
+				return false;
+			}
+		}
 
-    return true;
-  });
+		return true;
+	});
 
-  const availableTags = Array.from(
-    new Set(
-      filteredNotesForTags.flatMap(
-        (n) => (n as { tags?: string[] }).tags || [],
-      ),
-    ),
-  ).sort();
+	const availableTags = Array.from(
+		new Set(
+			filteredNotesForTags.flatMap(
+				(n) => (n as { tags?: string[] }).tags || [],
+			),
+		),
+	).sort();
 
-  const finalFilteredNotes = filteredNotesForTags.filter((n) => {
-    const noteTags = (n as { tags?: string[] }).tags || [];
-    if (selectedTag && !noteTags.includes(selectedTag)) {
-      return false;
-    }
-    return true;
-  });
+	const finalFilteredNotes = filteredNotesForTags.filter((n) => {
+		const noteTags = (n as { tags?: string[] }).tags || [];
+		if (selectedTag && !noteTags.includes(selectedTag)) {
+			return false;
+		}
+		return true;
+	});
 
-  return (
-    <div className="w-full h-screen bg-base-surface grid grid-rows-[auto_auto_auto_auto_1fr] relative font-sans">
-      <Toaster
-        position="bottom-center"
-        toastOptions={{
-          style: {
-            fontSize: "12px",
-            padding: "8px 12px",
-            borderRadius: "8px",
-            background: "#262626", // action
-            color: "#ffffff", // action-text
-          },
-        }}
-      />
-      <Header
-        url={url}
-        title={title}
-        domain={currentFullUrl ? getScopeUrls(currentFullUrl).domain : ""}
-        session={session}
-        onLogout={onLogout}
-      />
+	return (
+		<div className="w-full h-screen bg-base-surface grid grid-rows-[auto_auto_auto_auto_1fr] relative font-sans">
+			<Toaster
+				position="bottom-center"
+				toastOptions={{
+					style: {
+						fontSize: "12px",
+						padding: "8px 12px",
+						borderRadius: "8px",
+						background: "#262626", // action
+						color: "#ffffff", // action-text
+					},
+				}}
+			/>
+			<Header
+				url={url}
+				title={title}
+				domain={currentFullUrl ? getScopeUrls(currentFullUrl).domain : ""}
+				session={session}
+				onLogout={onLogout}
+			/>
 
-      <QuickLinks
-        currentDomain={
-          currentFullUrl ? getScopeUrls(currentFullUrl).domain : null
-        }
-      />
+			<QuickLinks
+				currentDomain={
+					currentFullUrl ? getScopeUrls(currentFullUrl).domain : null
+				}
+			/>
 
-      <FilterBar
-        filterType={filterType}
-        setFilterType={setFilterType}
-        showResolved={showResolved}
-        setShowResolved={setShowResolved}
-        viewScope={viewScope}
-        setViewScope={setViewScope}
-        searchQuery={searchQuery}
-        setSearchQuery={setSearchQuery}
-        filteredNotes={finalFilteredNotes} // コピー対象はタグ絞り込み後の最終リスト
-        selectedTag={selectedTag}
-        setSelectedTag={setSelectedTag}
-        availableTags={availableTags}
-      />
+			<FilterBar
+				filterType={filterType}
+				setFilterType={setFilterType}
+				showResolved={showResolved}
+				setShowResolved={setShowResolved}
+				viewScope={viewScope}
+				setViewScope={setViewScope}
+				searchQuery={searchQuery}
+				setSearchQuery={setSearchQuery}
+				filteredNotes={finalFilteredNotes} // コピー対象はタグ絞り込み後の最終リスト
+				selectedTag={selectedTag}
+				setSelectedTag={setSelectedTag}
+				availableTags={availableTags}
+			/>
 
-      <div className="grid grid-cols-3 items-center px-4 py-1.5 bg-base-surface shrink-0 border-b border-base-border shadow-xs">
-        {/* 左カラム（将来の拡張アクションボタン用スペース） */}
-        <div className="flex justify-start" />
+			<div className="grid grid-cols-3 items-center px-4 py-1.5 bg-base-surface shrink-0 border-b border-base-border shadow-xs">
+				{/* 左カラム（将来の拡張アクションボタン用スペース） */}
+				<div className="flex justify-start" />
 
-        {/* 中央カラム（「＋」ボタンを物理的中心に完全ロック） */}
-        <div className="flex justify-center">
-          <button
-            type="button"
-            onClick={() => {
-              setIsInputModeOpen(true);
-              setTimeout(() => textareaRef.current?.focus(), 50);
-            }}
-            className="cursor-pointer w-9 h-9 rounded-full bg-action text-action-text shadow-md hover:bg-action-hover transition-all transform hover:scale-105 active:scale-95 flex items-center justify-center border border-action-hover/10"
-            title="Create new note"
-          >
-            <Plus aria-hidden="true" className="w-4 h-4" />
-          </button>
-        </div>
+				{/* 中央カラム（「＋」ボタンを物理的中心に完全ロック） */}
+				<div className="flex justify-center">
+					<button
+						type="button"
+						onClick={() => {
+							setIsInputModeOpen(true);
+							setTimeout(() => textareaRef.current?.focus(), 50);
+						}}
+						className="cursor-pointer w-9 h-9 rounded-full bg-action text-action-text shadow-md hover:bg-action-hover transition-all transform hover:scale-105 active:scale-95 flex items-center justify-center border border-action-hover/10"
+						title="Create new note"
+					>
+						<Plus aria-hidden="true" className="w-4 h-4" />
+					</button>
+				</div>
 
-        {/* 右カラム（将来の拡張アクションボタン用スペース） */}
-        <div className="flex justify-end" />
-      </div>
+				{/* 右カラム（将来の拡張アクションボタン用スペース） */}
+				<div className="flex justify-end" />
+			</div>
 
-      <div ref={listContainerRef} className="overflow-y-auto p-4 relative">
-        <NoteList
-          notes={finalFilteredNotes}
-          loading={loading}
-          currentFullUrl={currentFullUrl}
-          onUpdate={updateNote}
-          onDelete={deleteNote}
-          onToggleResolved={toggleResolved}
-          onToggleFavorite={toggleFavorite}
-          onTogglePinned={togglePinned}
-          onUpdateNoteOrder={updateNoteOrder}
-          onToggleExpansion={toggleNoteExpansion}
-        />
-      </div>
+			<div ref={listContainerRef} className="overflow-y-auto p-4 relative">
+				<NoteList
+					notes={finalFilteredNotes}
+					loading={loading}
+					currentFullUrl={currentFullUrl}
+					onUpdate={updateNote}
+					onDelete={deleteNote}
+					onToggleResolved={toggleResolved}
+					onToggleFavorite={toggleFavorite}
+					onTogglePinned={togglePinned}
+					onUpdateNoteOrder={(id, direction) =>
+						updateNoteOrder(id, direction, finalFilteredNotes)
+					}
+					onToggleExpansion={toggleNoteExpansion}
+				/>
+			</div>
 
-      {isInputModeOpen && (
-        <>
-          {/* 背景の遮断レイヤー（領域外クリックで閉じる） */}
-          <button
-            type="button"
-            className="absolute inset-0 bg-black/20 backdrop-blur-[1px] z-40 transition-opacity duration-200 cursor-default"
-            onClick={() => setIsInputModeOpen(false)}
-            aria-label="Close input overlay"
-          />
-          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[92%] max-w-sm z-50 animate-in fade-in zoom-in-95 duration-200">
-            {userStatsLoading ? (
-              <div className="p-4 bg-base-surface border border-base-border/50 rounded-2xl shadow-2xl flex items-center justify-center">
-                <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
-              </div>
-            ) : (
-              <NoteInput
-                userPlan={userPlan}
-                totalNoteCount={totalNoteCount}
-                maxFreeNotes={MAX_FREE_NOTES}
-                onAddNote={handleAddNote}
-                onClose={() => setIsInputModeOpen(false)}
-                textareaRef={textareaRef}
-              />
-            )}
-          </div>
-        </>
-      )}
-    </div>
-  );
+			{isInputModeOpen && (
+				<>
+					{/* 背景の遮断レイヤー（領域外クリックで閉じる） */}
+					<button
+						type="button"
+						className="absolute inset-0 bg-black/20 backdrop-blur-[1px] z-40 transition-opacity duration-200 cursor-default"
+						onClick={() => setIsInputModeOpen(false)}
+						aria-label="Close input overlay"
+					/>
+					<div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[92%] max-w-sm z-50 animate-in fade-in zoom-in-95 duration-200">
+						{userStatsLoading ? (
+							<div className="p-4 bg-base-surface border border-base-border/50 rounded-2xl shadow-2xl flex items-center justify-center">
+								<Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+							</div>
+						) : (
+							<NoteInput
+								userPlan={userPlan}
+								totalNoteCount={totalNoteCount}
+								maxFreeNotes={MAX_FREE_NOTES}
+								onAddNote={handleAddNote}
+								onClose={() => setIsInputModeOpen(false)}
+								textareaRef={textareaRef}
+							/>
+						)}
+					</div>
+				</>
+			)}
+		</div>
+	);
 }

--- a/apps/extension/src/components/FilterBar.tsx
+++ b/apps/extension/src/components/FilterBar.tsx
@@ -1,329 +1,342 @@
 import {
-  AlertTriangle,
-  Check,
-  CheckSquare,
-  Copy,
-  Info,
-  Lightbulb,
-  Search,
-  X,
+	AlertTriangle,
+	Check,
+	CheckSquare,
+	Copy,
+	Info,
+	Lightbulb,
+	Search,
+	X,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { Note } from "../hooks/useNotes";
 
 interface FilterBarProps {
-  filterType: "all" | "info" | "alert" | "idea";
-  setFilterType: (type: "all" | "info" | "alert" | "idea") => void;
-  showResolved: boolean;
-  setShowResolved: (show: boolean) => void;
-  viewScope: "exact" | "domain" | "inbox";
-  setViewScope: (scope: "exact" | "domain" | "inbox") => void;
-  searchQuery: string;
-  setSearchQuery: (query: string) => void;
-  filteredNotes: Note[];
-  selectedTag: string | null;
-  setSelectedTag: (tag: string | null) => void;
-  availableTags: string[];
+	filterType: "all" | "info" | "alert" | "idea";
+	setFilterType: (type: "all" | "info" | "alert" | "idea") => void;
+	showResolved: boolean;
+	setShowResolved: (show: boolean) => void;
+	viewScope: "exact" | "domain" | "inbox";
+	setViewScope: (scope: "exact" | "domain" | "inbox") => void;
+	searchQuery: string;
+	setSearchQuery: (query: string) => void;
+	filteredNotes: Note[];
+	selectedTag: string | null;
+	setSelectedTag: (tag: string | null) => void;
+	availableTags: string[];
 }
 
 export default function FilterBar({
-  filterType,
-  setFilterType,
-  showResolved,
-  setShowResolved,
-  viewScope,
-  setViewScope,
-  searchQuery,
-  setSearchQuery,
-  filteredNotes,
-  selectedTag,
-  setSelectedTag,
-  availableTags,
+	filterType,
+	setFilterType,
+	showResolved,
+	setShowResolved,
+	viewScope,
+	setViewScope,
+	searchQuery,
+	setSearchQuery,
+	filteredNotes,
+	selectedTag,
+	setSelectedTag,
+	availableTags,
 }: FilterBarProps) {
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [isCopied, setIsCopied] = useState(false);
-  const [isCopyMenuOpen, setIsCopyMenuOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
+	const [isSearchOpen, setIsSearchOpen] = useState(false);
+	const [isCopied, setIsCopied] = useState(false);
+	const [isCopyMenuOpen, setIsCopyMenuOpen] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const menuRef = useRef<HTMLDivElement>(null);
 
-  const copyToClipboard = async (text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setIsCopied(true);
-      setTimeout(() => setIsCopied(false), 2000);
-    } catch {
-      // clipboard write failed silently
-    }
-  };
+	const copyToClipboard = async (text: string) => {
+		try {
+			await navigator.clipboard.writeText(text);
+			setIsCopied(true);
+			setTimeout(() => setIsCopied(false), 2000);
+		} catch {
+			// clipboard write failed silently
+		}
+	};
 
-  const handleCopyText = async () => {
-    const text = filteredNotes.map((n) => n.content ?? "").join("\n\n");
-    await copyToClipboard(text);
-    setIsCopyMenuOpen(false);
-  };
+	const handleCopyText = async () => {
+		const text = filteredNotes.map((n) => n.content ?? "").join("\n\n");
+		await copyToClipboard(text);
+		setIsCopyMenuOpen(false);
+	};
 
-  const handleCopyJson = async () => {
-    const json = filteredNotes.map((n) => ({
-      type: n.note_type || "info",
-      content: n.content,
-    }));
-    await copyToClipboard(JSON.stringify(json, null, 2));
-    setIsCopyMenuOpen(false);
-  };
+	const handleCopyJson = async () => {
+		const json = filteredNotes.map((n) => ({
+			type: n.note_type || "info",
+			content: n.content,
+		}));
+		await copyToClipboard(JSON.stringify(json, null, 2));
+		setIsCopyMenuOpen(false);
+	};
 
-  // Close search and menu when pressing Escape
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        if (!searchQuery) setIsSearchOpen(false);
-        inputRef.current?.blur();
-        setIsCopyMenuOpen(false);
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [searchQuery]);
+	// Close search and menu when pressing Escape
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				if (!searchQuery) setIsSearchOpen(false);
+				inputRef.current?.blur();
+				setIsCopyMenuOpen(false);
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [searchQuery]);
 
-  // Close menu when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        setIsCopyMenuOpen(false);
-      }
-    };
-    if (isCopyMenuOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isCopyMenuOpen]);
+	// Close menu when clicking outside
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+				setIsCopyMenuOpen(false);
+			}
+		};
+		if (isCopyMenuOpen) {
+			document.addEventListener("mousedown", handleClickOutside);
+		}
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside);
+		};
+	}, [isCopyMenuOpen]);
 
-  useEffect(() => {
-    if (isSearchOpen && inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [isSearchOpen]);
+	useEffect(() => {
+		if (isSearchOpen && inputRef.current) {
+			inputRef.current.focus();
+		}
+	}, [isSearchOpen]);
 
-  return (
-    <div className="bg-base-surface border-b border-base-border px-2 py-2 flex flex-col gap-3 z-10 w-full min-w-0">
-      {/* Scope Tabs */}
-      <div className="flex space-x-4 border-b border-base-border">
-        <button
-          type="button"
-          onClick={() => setViewScope("exact")}
-          className={`cursor-pointer pb-2 text-sm font-medium border-b-2 -mb-px transition-colors ${viewScope === "exact"
-            ? "border-action text-action"
-            : "border-transparent text-muted-foreground hover:text-action hover:border-base-border"
-            }`}
-        >
-          Page
-        </button>
-        <button
-          type="button"
-          onClick={() => setViewScope("domain")}
-          className={`cursor-pointer pb-2 text-sm font-medium border-b-2 -mb-px transition-colors ${viewScope === "domain"
-            ? "border-action text-action"
-            : "border-transparent text-muted-foreground hover:text-action hover:border-base-border"
-            }`}
-        >
-          Domain
-        </button>
-        <button
-          type="button"
-          onClick={() => setViewScope("inbox")}
-          className={`cursor-pointer pb-2 text-sm font-medium border-b-2 -mb-px transition-colors ${viewScope === "inbox"
-            ? "border-action text-action"
-            : "border-transparent text-muted-foreground hover:text-action hover:border-base-border"
-            }`}
-        >
-          Inbox
-        </button>
-      </div>
+	return (
+		<div className="bg-base-surface border-b border-base-border px-2 py-2 flex flex-col gap-3 z-10 w-full min-w-0">
+			{/* Scope Tabs */}
+			<div className="flex space-x-4 border-b border-base-border">
+				<button
+					type="button"
+					onClick={() => setViewScope("exact")}
+					className={`cursor-pointer pb-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+						viewScope === "exact"
+							? "border-action text-action"
+							: "border-transparent text-muted-foreground hover:text-action hover:border-base-border"
+					}`}
+				>
+					Page
+				</button>
+				<button
+					type="button"
+					onClick={() => setViewScope("domain")}
+					className={`cursor-pointer pb-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+						viewScope === "domain"
+							? "border-action text-action"
+							: "border-transparent text-muted-foreground hover:text-action hover:border-base-border"
+					}`}
+				>
+					Domain
+				</button>
+				<button
+					type="button"
+					onClick={() => setViewScope("inbox")}
+					className={`cursor-pointer pb-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+						viewScope === "inbox"
+							? "border-action text-action"
+							: "border-transparent text-muted-foreground hover:text-action hover:border-base-border"
+					}`}
+				>
+					Inbox
+				</button>
+			</div>
 
-      <div className="flex items-center justify-between gap-2 w-full">
-        {/* Note Type Filter */}
-        <div className="flex bg-action p-1 rounded-lg shrink-0">
-          <button
-            type="button"
-            onClick={() => setFilterType("all")}
-            className={`cursor-pointer py-1 px-2 rounded text-xs font-medium transition-colors ${filterType === "all"
-              ? "bg-base-surface text-action shadow-sm"
-              : "text-muted-foreground hover:text-white"
-              }`}
-          >
-            All
-          </button>
-          <button
-            type="button"
-            onClick={() => setFilterType("info")}
-            className={`cursor-pointer py-1 px-2 rounded transition-colors ${filterType === "info"
-              ? "bg-base-surface text-action shadow-sm"
-              : "text-muted-foreground hover:text-white"
-              }`}
-            title="Filter by Info"
-          >
-            <Info className="w-3.5 h-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={() => setFilterType("alert")}
-            className={`cursor-pointer py-1 px-2 rounded transition-colors ${filterType === "alert"
-              ? "bg-base-surface text-action shadow-sm"
-              : "text-muted-foreground hover:text-white"
-              }`}
-            title="Filter by Alert"
-          >
-            <AlertTriangle className="w-3.5 h-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={() => setFilterType("idea")}
-            className={`cursor-pointer py-1 px-2 rounded transition-colors ${filterType === "idea"
-              ? "bg-base-surface text-action shadow-sm"
-              : "text-muted-foreground hover:text-white"
-              }`}
-            title="Filter by Idea"
-          >
-            <Lightbulb className="w-3.5 h-3.5" />
-          </button>
-        </div>
+			<div className="flex items-center justify-between gap-2 w-full">
+				{/* Note Type Filter */}
+				<div className="flex bg-action p-1 rounded-lg shrink-0">
+					<button
+						type="button"
+						onClick={() => setFilterType("all")}
+						className={`cursor-pointer py-1 px-2 rounded text-xs font-medium transition-colors ${
+							filterType === "all"
+								? "bg-base-surface text-action shadow-sm"
+								: "text-muted-foreground hover:text-white"
+						}`}
+					>
+						All
+					</button>
+					<button
+						type="button"
+						onClick={() => setFilterType("info")}
+						className={`cursor-pointer py-1 px-2 rounded transition-colors ${
+							filterType === "info"
+								? "bg-base-surface text-action shadow-sm"
+								: "text-muted-foreground hover:text-white"
+						}`}
+						title="Filter by Info"
+					>
+						<Info className="w-3.5 h-3.5" />
+					</button>
+					<button
+						type="button"
+						onClick={() => setFilterType("alert")}
+						className={`cursor-pointer py-1 px-2 rounded transition-colors ${
+							filterType === "alert"
+								? "bg-base-surface text-action shadow-sm"
+								: "text-muted-foreground hover:text-white"
+						}`}
+						title="Filter by Alert"
+					>
+						<AlertTriangle className="w-3.5 h-3.5" />
+					</button>
+					<button
+						type="button"
+						onClick={() => setFilterType("idea")}
+						className={`cursor-pointer py-1 px-2 rounded transition-colors ${
+							filterType === "idea"
+								? "bg-base-surface text-action shadow-sm"
+								: "text-muted-foreground hover:text-white"
+						}`}
+						title="Filter by Idea"
+					>
+						<Lightbulb className="w-3.5 h-3.5" />
+					</button>
+				</div>
 
-        <div className="flex items-center gap-1.5 flex-1 justify-end min-w-0">
-          {/* Search Bar */}
-          <div
-            className={`relative flex items-center shrink min-w-0 rounded transition-colors ${isSearchOpen || searchQuery ? "bg-base-bg" : ""
-              }`}
-          >
-            <button
-              type="button"
-              onClick={() => setIsSearchOpen(true)}
-              className={`cursor-pointer p-1.5 rounded transition-colors shrink-0 ${isSearchOpen || searchQuery
-                ? "text-action" // 背景色は親コンテナが持つため一元化
-                : "text-muted-foreground hover:text-action hover:bg-base-bg"
-                }`}
-            >
-              <Search className="w-3.5 h-3.5" />
-            </button>
-            <div
-              className={`overflow-hidden transition-all duration-200 ease-in-out shrink min-w-0 ${isSearchOpen || searchQuery ? "w-32" : "w-0" // ml-1 を削除しボタンと完璧に隙間なく連結
-                }`}
-            >
-              <div className="relative flex items-center w-full min-w-0">
-                <input
-                  ref={inputRef}
-                  type="text"
-                  placeholder="Search..."
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  onBlur={() => {
-                    if (!searchQuery) setIsSearchOpen(false);
-                  }}
-                  // bg-base-bg と rounded を廃止し、bg-transparent を指定して下地と一体化
-                  className="w-full min-w-0 text-xs pl-1 pr-6 py-1 bg-transparent border-none focus:outline-none placeholder:text-muted-foreground"
-                />
-                {searchQuery && (
-                  <button
-                    type="button"
-                    onMouseDown={(e) => {
-                      // Prevent input from losing focus when clicking the clear button
-                      e.preventDefault();
-                    }}
-                    onClick={() => {
-                      setSearchQuery("");
-                      inputRef.current?.focus();
-                    }}
-                    className="absolute right-1 cursor-pointer p-0.5 text-muted-foreground hover:text-action transition-colors shrink-0"
-                    title="Clear search"
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
-          {/* Copy All Dropdown */}
-          <div className="relative" ref={menuRef}>
-            <button
-              type="button"
-              onClick={() => setIsCopyMenuOpen(!isCopyMenuOpen)}
-              className={`cursor-pointer p-1.5 rounded transition-colors shrink-0 ${isCopied
-                ? "text-note-info bg-note-info/10"
-                : isCopyMenuOpen
-                  ? "text-action bg-base-bg"
-                  : "text-muted-foreground hover:text-action hover:bg-base-bg"
-                }`}
-              title={isCopied ? "Copied!" : "Copy options"}
-              aria-label={isCopied ? "Copied!" : "Open copy options menu"}
-            >
-              {isCopied ? (
-                <Check className="w-3.5 h-3.5" />
-              ) : (
-                <Copy className="w-3.5 h-3.5" />
-              )}
-            </button>
+				<div className="flex items-center gap-1.5 flex-1 justify-end min-w-0">
+					{/* Search Bar */}
+					<div
+						className={`relative flex items-center shrink min-w-0 rounded transition-colors ${
+							isSearchOpen || searchQuery ? "bg-base-bg" : ""
+						}`}
+					>
+						<button
+							type="button"
+							onClick={() => setIsSearchOpen(true)}
+							className={`cursor-pointer p-1.5 rounded transition-colors shrink-0 ${
+								isSearchOpen || searchQuery
+									? "text-action" // 背景色は親コンテナが持つため一元化
+									: "text-muted-foreground hover:text-action hover:bg-base-bg"
+							}`}
+						>
+							<Search className="w-3.5 h-3.5" />
+						</button>
+						<div
+							className={`overflow-hidden transition-all duration-200 ease-in-out shrink min-w-0 ${
+								isSearchOpen || searchQuery ? "w-32" : "w-0" // ml-1 を削除しボタンと完璧に隙間なく連結
+							}`}
+						>
+							<div className="relative flex items-center w-full min-w-0">
+								<input
+									ref={inputRef}
+									type="text"
+									placeholder="Search..."
+									value={searchQuery}
+									onChange={(e) => setSearchQuery(e.target.value)}
+									onBlur={() => {
+										if (!searchQuery) setIsSearchOpen(false);
+									}}
+									// bg-base-bg と rounded を廃止し、bg-transparent を指定して下地と一体化
+									className="w-full min-w-0 text-xs pl-1 pr-6 py-1 bg-transparent border-none focus:outline-none placeholder:text-muted-foreground"
+								/>
+								{searchQuery && (
+									<button
+										type="button"
+										onMouseDown={(e) => {
+											// Prevent input from losing focus when clicking the clear button
+											e.preventDefault();
+										}}
+										onClick={() => {
+											setSearchQuery("");
+											inputRef.current?.focus();
+										}}
+										className="absolute right-1 cursor-pointer p-0.5 text-muted-foreground hover:text-action transition-colors shrink-0"
+										title="Clear search"
+									>
+										<X className="w-3 h-3" />
+									</button>
+								)}
+							</div>
+						</div>
+					</div>
+					{/* Copy All Dropdown */}
+					<div className="relative" ref={menuRef}>
+						<button
+							type="button"
+							onClick={() => setIsCopyMenuOpen(!isCopyMenuOpen)}
+							className={`cursor-pointer p-1.5 rounded transition-colors shrink-0 ${
+								isCopied
+									? "text-note-info bg-note-info/10"
+									: isCopyMenuOpen
+										? "text-action bg-base-bg"
+										: "text-muted-foreground hover:text-action hover:bg-base-bg"
+							}`}
+							title={isCopied ? "Copied!" : "Copy options"}
+							aria-label={isCopied ? "Copied!" : "Open copy options menu"}
+						>
+							{isCopied ? (
+								<Check className="w-3.5 h-3.5" />
+							) : (
+								<Copy className="w-3.5 h-3.5" />
+							)}
+						</button>
 
-            {isCopyMenuOpen && (
-              <div className="absolute right-0 top-full mt-1 bg-base-surface border border-base-border rounded shadow-md z-20 py-1 min-w-[120px]">
-                <button
-                  type="button"
-                  onClick={handleCopyText}
-                  className="w-full text-left px-3 py-1.5 text-xs text-muted-foreground hover:bg-base-bg transition-colors"
-                >
-                  Copy as Text
-                </button>
-                <button
-                  type="button"
-                  onClick={handleCopyJson}
-                  className="w-full text-left px-3 py-1.5 text-xs text-muted-foreground hover:bg-base-bg transition-colors"
-                >
-                  Copy as JSON
-                </button>
-              </div>
-            )}
-          </div>
+						{isCopyMenuOpen && (
+							<div className="absolute right-0 top-full mt-1 bg-base-surface border border-base-border rounded shadow-md z-20 py-1 min-w-[120px]">
+								<button
+									type="button"
+									onClick={handleCopyText}
+									className="w-full text-left px-3 py-1.5 text-xs text-muted-foreground hover:bg-base-bg transition-colors"
+								>
+									Copy as Text
+								</button>
+								<button
+									type="button"
+									onClick={handleCopyJson}
+									className="w-full text-left px-3 py-1.5 text-xs text-muted-foreground hover:bg-base-bg transition-colors"
+								>
+									Copy as JSON
+								</button>
+							</div>
+						)}
+					</div>
 
-          {/* Resolved Toggle */}
-          <button
-            type="button"
-            onClick={() => setShowResolved(!showResolved)}
-            className={`cursor-pointer flex items-center gap-1.5 px-2 py-1 rounded text-xs border transition-colors shrink-0 ${showResolved
-              ? "bg-action border-action text-action-text"
-              : "bg-base-surface border-dashed border-action text-action hover:text-action-text hover:border-action hover:bg-action"
-              }`}
-            title="Show/Hide Resolved Notes"
-          >
-            <CheckSquare className="w-3.5 h-3.5" />
-            <span className="hidden sm:inline">Resolved</span>
-          </button>
-        </div>
-      </div>
+					{/* Resolved Toggle */}
+					<button
+						type="button"
+						onClick={() => setShowResolved(!showResolved)}
+						className={`cursor-pointer flex items-center gap-1.5 px-2 py-1 rounded text-xs border transition-colors shrink-0 ${
+							showResolved
+								? "bg-action border-action text-action-text"
+								: "bg-base-surface border-dashed border-action text-action hover:text-action-text hover:border-action hover:bg-action"
+						}`}
+						title="Show/Hide Resolved Notes"
+					>
+						<CheckSquare className="w-3.5 h-3.5" />
+						<span className="hidden sm:inline">Resolved</span>
+					</button>
+				</div>
+			</div>
 
-      {/* Tag Pills */}
-      {availableTags.length > 0 && (
-        <div className="relative w-full min-w-0 shrink-0 overflow-hidden">
-          <div className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-hide pr-12">
-            {availableTags.map((tag) => (
-              <button
-                key={tag}
-                type="button"
-                onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
-                className={`cursor-pointer whitespace-nowrap px-2 py-0.5 rounded-full text-[10px] font-medium border transition-colors ${selectedTag === tag
-                  ? "bg-action text-action-text border-action"
-                  : "bg-base-surface text-muted-foreground border-base-border hover:border-action hover:text-action"
-                  }`}
-              >
-                #{tag}
-              </button>
-            ))}
-          </div>
-          {/* 💡 Fade Mask */}
-          <div
-            className="absolute right-0 top-0 bottom-1 w-12 bg-linear-to-r from-transparent to-base-surface pointer-events-none"
-            aria-hidden="true"
-          />
-        </div>
-      )}
-    </div>
-  );
+			{/* Tag Pills */}
+			{availableTags.length > 0 && (
+				<div className="relative w-full min-w-0 shrink-0 overflow-hidden">
+					<div className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-hide pr-12">
+						{availableTags.map((tag) => (
+							<button
+								key={tag}
+								type="button"
+								onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
+								className={`cursor-pointer whitespace-nowrap px-2 py-0.5 rounded-full text-[10px] font-medium border transition-colors ${
+									selectedTag === tag
+										? "bg-action text-action-text border-action"
+										: "bg-base-surface text-muted-foreground border-base-border hover:border-action hover:text-action"
+								}`}
+							>
+								#{tag}
+							</button>
+						))}
+					</div>
+					{/* 💡 Fade Mask */}
+					<div
+						className="absolute right-0 top-0 bottom-1 w-12 bg-linear-to-r from-transparent to-base-surface pointer-events-none"
+						aria-hidden="true"
+					/>
+				</div>
+			)}
+		</div>
+	);
 }

--- a/apps/extension/src/components/Header.tsx
+++ b/apps/extension/src/components/Header.tsx
@@ -5,292 +5,292 @@ import toast from "react-hot-toast";
 import { supabase } from "../supabaseClient";
 
 interface HeaderProps {
-  url: string;
-  title: string;
-  domain: string; // Used for settings key
-  session: Session;
-  onLogout: () => void;
+	url: string;
+	title: string;
+	domain: string; // Used for settings key
+	session: Session;
+	onLogout: () => void;
 }
 
 interface DomainSettings {
-  color: string;
-  label: string;
+	color: string;
+	label: string;
 }
 
 const COLORS = [
-  { name: "Blue", value: "blue-400", hex: "#60a5fa" }, // Blue
-  { name: "Red", value: "rose-400", hex: "#fb7185" }, // Rose
-  { name: "Yellow", value: "amber-400", hex: "#fbbf24" }, // Amber
-  { name: "Green", value: "emerald-400", hex: "#34d399" }, // Emerald
-  { name: "Purple", value: "violet-400", hex: "#a78bfa" }, // Violet
+	{ name: "Blue", value: "blue-400", hex: "#60a5fa" }, // Blue
+	{ name: "Red", value: "rose-400", hex: "#fb7185" }, // Rose
+	{ name: "Yellow", value: "amber-400", hex: "#fbbf24" }, // Amber
+	{ name: "Green", value: "emerald-400", hex: "#34d399" }, // Emerald
+	{ name: "Purple", value: "violet-400", hex: "#a78bfa" }, // Violet
 ];
 
 export default function Header({
-  url,
-  title,
-  domain,
-  session,
-  onLogout,
+	url,
+	title,
+	domain,
+	session,
+	onLogout,
 }: HeaderProps) {
-  const [settings, setSettings] = useState<DomainSettings | null>(null);
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [editColor, setEditColor] = useState("sky-600");
-  const [editLabel, setEditLabel] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [isProfileOpen, setIsProfileOpen] = useState(false);
-  const profileMenuRef = useRef<HTMLDivElement>(null);
+	const [settings, setSettings] = useState<DomainSettings | null>(null);
+	const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+	const [editColor, setEditColor] = useState("sky-600");
+	const [editLabel, setEditLabel] = useState("");
+	const [saving, setSaving] = useState(false);
+	const [isProfileOpen, setIsProfileOpen] = useState(false);
+	const profileMenuRef = useRef<HTMLDivElement>(null);
 
-  const avatarUrl = session?.user?.user_metadata?.avatar_url;
-  const emailInitial = session?.user?.email?.[0]?.toUpperCase() || "?";
-  const webUrl = import.meta.env.VITE_WEB_URL || "https://app.sitecue.app";
+	const avatarUrl = session?.user?.user_metadata?.avatar_url;
+	const emailInitial = session?.user?.email?.[0]?.toUpperCase() || "?";
+	const webUrl = import.meta.env.VITE_WEB_URL || "https://app.sitecue.app";
 
-  // Close menu on outside click
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        profileMenuRef.current &&
-        !profileMenuRef.current.contains(event.target as Node)
-      ) {
-        setIsProfileOpen(false);
-      }
-    };
-    if (isProfileOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [isProfileOpen]);
+	// Close menu on outside click
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (
+				profileMenuRef.current &&
+				!profileMenuRef.current.contains(event.target as Node)
+			) {
+				setIsProfileOpen(false);
+			}
+		};
+		if (isProfileOpen) {
+			document.addEventListener("mousedown", handleClickOutside);
+		}
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside);
+		};
+	}, [isProfileOpen]);
 
-  const fetchSettings = useCallback(async () => {
-    const { data } = await supabase
-      .from("sitecue_domain_settings")
-      .select("*")
-      .eq("domain", domain)
-      .maybeSingle();
+	const fetchSettings = useCallback(async () => {
+		const { data } = await supabase
+			.from("sitecue_domain_settings")
+			.select("*")
+			.eq("domain", domain)
+			.maybeSingle();
 
-    if (data) {
-      setSettings({ color: data.color ?? "", label: data.label ?? "" });
-      setEditColor(data.color || "sky-600");
-      setEditLabel(data.label || "");
-    } else {
-      setSettings(null);
-      setEditColor(""); // Default to empty/cleared for new settings
+		if (data) {
+			setSettings({ color: data.color ?? "", label: data.label ?? "" });
+			setEditColor(data.color || "sky-600");
+			setEditLabel(data.label || "");
+		} else {
+			setSettings(null);
+			setEditColor(""); // Default to empty/cleared for new settings
 
-      setEditLabel("");
-    }
-  }, [domain]);
+			setEditLabel("");
+		}
+	}, [domain]);
 
-  useEffect(() => {
-    if (!domain || !session) return;
-    fetchSettings();
-  }, [domain, session, fetchSettings]);
+	useEffect(() => {
+		if (!domain || !session) return;
+		fetchSettings();
+	}, [domain, session, fetchSettings]);
 
-  const handleSave = async () => {
-    if (!domain) return;
-    setSaving(true);
-    try {
-      if (editColor === "") {
-        // Delete settings if cleared
-        const { error } = await supabase
-          .from("sitecue_domain_settings")
-          .delete()
-          .eq("user_id", session.user.id)
-          .eq("domain", domain);
+	const handleSave = async () => {
+		if (!domain) return;
+		setSaving(true);
+		try {
+			if (editColor === "") {
+				// Delete settings if cleared
+				const { error } = await supabase
+					.from("sitecue_domain_settings")
+					.delete()
+					.eq("user_id", session.user.id)
+					.eq("domain", domain);
 
-        if (error) throw error;
-      } else {
-        // Upsert settings
-        const { error } = await supabase.from("sitecue_domain_settings").upsert(
-          {
-            user_id: session.user.id,
-            domain: domain,
-            color: editColor,
-            label: editLabel.trim() || null,
-          },
-          { onConflict: "user_id, domain" },
-        );
+				if (error) throw error;
+			} else {
+				// Upsert settings
+				const { error } = await supabase.from("sitecue_domain_settings").upsert(
+					{
+						user_id: session.user.id,
+						domain: domain,
+						color: editColor,
+						label: editLabel.trim() || null,
+					},
+					{ onConflict: "user_id, domain" },
+				);
 
-        if (error) throw error;
-      }
+				if (error) throw error;
+			}
 
-      setIsSettingsOpen(false);
-      fetchSettings();
-      toast.success("Settings saved");
-    } catch (error) {
-      console.error("Failed to save domain settings", error);
-      toast.error("Failed to save settings");
-    } finally {
-      setSaving(false);
-    }
-  };
+			setIsSettingsOpen(false);
+			fetchSettings();
+			toast.success("Settings saved");
+		} catch (error) {
+			console.error("Failed to save domain settings", error);
+			toast.error("Failed to save settings");
+		} finally {
+			setSaving(false);
+		}
+	};
 
-  return (
-    <div className="p-4 bg-base-surface border-b border-base-border sticky top-0 z-50 w-full min-w-0">
-      <div className="flex justify-between items-center gap-2 w-full min-w-0">
-        <div className="flex-1 min-w-0">
-          <h1 className="text-lg font-semibold text-action flex items-center gap-2 w-full min-w-0">
-            {/* Indicator Dot */}
-            {settings?.color && (
-              <div
-                className="w-2 h-2 shrink-0 rounded-full"
-                style={{
-                  backgroundColor: COLORS.find(
-                    (c) => c.value === settings?.color,
-                  )?.hex,
-                }}
-              />
-            )}
-            <span
-              className="truncate flex-1 min-w-0 text-left"
-              title={title || "sitecue"}
-            >
-              {title || "sitecue"}
-            </span>
-            {settings?.label && (
-              <span className="text-[10px] bg-action text-action-text px-1.5 py-0.5 rounded border border-base-border font-mono shrink-0">
-                {settings.label}
-              </span>
-            )}
-          </h1>
-          <p
-            className="text-xs text-muted-foreground truncate w-full"
-            title={url}
-          >
-            {url || "Waiting..."}
-          </p>
-        </div>
-        <div className="flex items-center gap-1.5 shrink-0">
-          <button
-            type="button"
-            onClick={() => setIsSettingsOpen(!isSettingsOpen)}
-            className={`cursor-pointer p-1.5 rounded-full transition-colors ${isSettingsOpen ? "bg-action text-action-text" : "text-muted-foreground hover:text-action"}`}
-          >
-            <Settings className="w-4 h-4" aria-hidden="true" />
-          </button>
+	return (
+		<div className="p-4 bg-base-surface border-b border-base-border sticky top-0 z-50 w-full min-w-0">
+			<div className="flex justify-between items-center gap-2 w-full min-w-0">
+				<div className="flex-1 min-w-0">
+					<h1 className="text-lg font-semibold text-action flex items-center gap-2 w-full min-w-0">
+						{/* Indicator Dot */}
+						{settings?.color && (
+							<div
+								className="w-2 h-2 shrink-0 rounded-full"
+								style={{
+									backgroundColor: COLORS.find(
+										(c) => c.value === settings?.color,
+									)?.hex,
+								}}
+							/>
+						)}
+						<span
+							className="truncate flex-1 min-w-0 text-left"
+							title={title || "sitecue"}
+						>
+							{title || "sitecue"}
+						</span>
+						{settings?.label && (
+							<span className="text-[10px] bg-action text-action-text px-1.5 py-0.5 rounded border border-base-border font-mono shrink-0">
+								{settings.label}
+							</span>
+						)}
+					</h1>
+					<p
+						className="text-xs text-muted-foreground truncate w-full"
+						title={url}
+					>
+						{url || "Waiting..."}
+					</p>
+				</div>
+				<div className="flex items-center gap-1.5 shrink-0">
+					<button
+						type="button"
+						onClick={() => setIsSettingsOpen(!isSettingsOpen)}
+						className={`cursor-pointer p-1.5 rounded-full transition-colors ${isSettingsOpen ? "bg-action text-action-text" : "text-muted-foreground hover:text-action"}`}
+					>
+						<Settings className="w-4 h-4" aria-hidden="true" />
+					</button>
 
-          {/* Profile Dropdown */}
-          <div className="relative" ref={profileMenuRef}>
-            <button
-              type="button"
-              onClick={() => setIsProfileOpen(!isProfileOpen)}
-              className="cursor-pointer w-6 h-6 rounded-full overflow-hidden border border-base-border hover:ring-2 hover:ring-action/20 transition-all focus:outline-none shrink-0"
-              title="Account & Links"
-            >
-              {avatarUrl ? (
-                <img
-                  src={avatarUrl}
-                  alt="Avatar"
-                  className="w-full h-full object-cover"
-                />
-              ) : (
-                <div className="w-full h-full bg-base-surface flex items-center justify-center text-[10px] font-bold text-action">
-                  {emailInitial}
-                </div>
-              )}
-            </button>
+					{/* Profile Dropdown */}
+					<div className="relative" ref={profileMenuRef}>
+						<button
+							type="button"
+							onClick={() => setIsProfileOpen(!isProfileOpen)}
+							className="cursor-pointer w-6 h-6 rounded-full overflow-hidden border border-base-border hover:ring-2 hover:ring-action/20 transition-all focus:outline-none shrink-0"
+							title="Account & Links"
+						>
+							{avatarUrl ? (
+								<img
+									src={avatarUrl}
+									alt="Avatar"
+									className="w-full h-full object-cover"
+								/>
+							) : (
+								<div className="w-full h-full bg-base-surface flex items-center justify-center text-[10px] font-bold text-action">
+									{emailInitial}
+								</div>
+							)}
+						</button>
 
-            {isProfileOpen && (
-              <div className="absolute right-0 top-full mt-2 bg-base-surface border border-base-border rounded-md shadow-md z-20 py-1 min-w-[160px] animate-in fade-in slide-in-from-top-1 duration-200">
-                <a
-                  href={webUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-action hover:bg-base-bg transition-colors"
-                  onClick={() => setIsProfileOpen(false)}
-                >
-                  Open Basecamp{" "}
-                  <ExternalLink
-                    className="w-3.5 h-3.5 ml-auto text-muted-foreground"
-                    aria-hidden="true"
-                  />
-                </a>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setIsProfileOpen(false);
-                    onLogout();
-                  }}
-                  className="cursor-pointer flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-note-alert hover:bg-note-alert/10 transition-colors"
-                >
-                  Log out{" "}
-                  <LogOut className="w-3.5 h-3.5 ml-auto" aria-hidden="true" />
-                </button>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+						{isProfileOpen && (
+							<div className="absolute right-0 top-full mt-2 bg-base-surface border border-base-border rounded-md shadow-md z-20 py-1 min-w-[160px] animate-in fade-in slide-in-from-top-1 duration-200">
+								<a
+									href={webUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-action hover:bg-base-bg transition-colors"
+									onClick={() => setIsProfileOpen(false)}
+								>
+									Open Basecamp{" "}
+									<ExternalLink
+										className="w-3.5 h-3.5 ml-auto text-muted-foreground"
+										aria-hidden="true"
+									/>
+								</a>
+								<button
+									type="button"
+									onClick={() => {
+										setIsProfileOpen(false);
+										onLogout();
+									}}
+									className="cursor-pointer flex items-center gap-2 w-full text-left px-3 py-2 text-xs text-note-alert hover:bg-note-alert/10 transition-colors"
+								>
+									Log out{" "}
+									<LogOut className="w-3.5 h-3.5 ml-auto" aria-hidden="true" />
+								</button>
+							</div>
+						)}
+					</div>
+				</div>
+			</div>
 
-      {/* Settings Popup / Expandable Area */}
-      {isSettingsOpen && (
-        <div className="mt-3 pt-3 border-t border-base-border animate-in slide-in-from-top-2 fade-in duration-200">
-          <div className="space-y-3">
-            <div>
-              <label
-                htmlFor="label-input"
-                className="text-xs font-medium text-muted-foreground mb-1.5 block"
-              >
-                Label
-              </label>
-              <input
-                id="label-input"
-                type="text"
-                value={editLabel}
-                onChange={(e) => setEditLabel(e.target.value.slice(0, 10))}
-                placeholder="e.g. PROD, DEV"
-                className="w-full text-xs text-action border border-base-border rounded p-1.5 focus:outline-none focus:ring-1 focus:ring-action placeholder-muted-foreground"
-              />
-            </div>
-            <div>
-              <label
-                htmlFor="color-button"
-                className="text-xs font-medium text-muted-foreground mb-1.5 block"
-              >
-                Color
-              </label>
-              <div className="flex gap-2 items-center">
-                <button
-                  id="color-button"
-                  type="button"
-                  onClick={() => setEditColor("")}
-                  className={`cursor-pointer w-4 h-4 rounded-full transition-all flex items-center justify-center border border-transparent text-muted-foreground hover:text-action ${editColor === "" ? "text-action bg-base-bg" : ""}`}
-                  title="Clear Settings"
-                >
-                  <CircleOff className="w-3.5 h-3.5" aria-hidden="true" />
-                </button>
-                {COLORS.map((c) => (
-                  <button
-                    type="button"
-                    key={c.value}
-                    onClick={() => setEditColor(c.value)}
-                    className={`cursor-pointer w-4 h-4 rounded-full transition-all ${editColor === c.value ? "scale-130 ring-2 ring-offset-1 ring-base-border" : "border-transparent hover:scale-130"}`}
-                    style={{ backgroundColor: c.hex }}
-                    title={c.name}
-                  />
-                ))}
-              </div>
-            </div>
-            <div className="flex justify-end gap-2 pt-1">
-              <button
-                type="button"
-                onClick={() => setIsSettingsOpen(false)}
-                className="cursor-pointer px-3 py-1 text-xs text-muted-foreground hover:text-action"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handleSave}
-                disabled={saving}
-                className="cursor-pointer px-3 py-1 bg-action text-action-text text-xs rounded hover:bg-action-hover disabled:opacity-50 flex items-center gap-1"
-              >
-                {saving ? "Saving..." : "Save"}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
+			{/* Settings Popup / Expandable Area */}
+			{isSettingsOpen && (
+				<div className="mt-3 pt-3 border-t border-base-border animate-in slide-in-from-top-2 fade-in duration-200">
+					<div className="space-y-3">
+						<div>
+							<label
+								htmlFor="label-input"
+								className="text-xs font-medium text-muted-foreground mb-1.5 block"
+							>
+								Label
+							</label>
+							<input
+								id="label-input"
+								type="text"
+								value={editLabel}
+								onChange={(e) => setEditLabel(e.target.value.slice(0, 10))}
+								placeholder="e.g. PROD, DEV"
+								className="w-full text-xs text-action border border-base-border rounded p-1.5 focus:outline-none focus:ring-1 focus:ring-action placeholder-muted-foreground"
+							/>
+						</div>
+						<div>
+							<label
+								htmlFor="color-button"
+								className="text-xs font-medium text-muted-foreground mb-1.5 block"
+							>
+								Color
+							</label>
+							<div className="flex gap-2 items-center">
+								<button
+									id="color-button"
+									type="button"
+									onClick={() => setEditColor("")}
+									className={`cursor-pointer w-4 h-4 rounded-full transition-all flex items-center justify-center border border-transparent text-muted-foreground hover:text-action ${editColor === "" ? "text-action bg-base-bg" : ""}`}
+									title="Clear Settings"
+								>
+									<CircleOff className="w-3.5 h-3.5" aria-hidden="true" />
+								</button>
+								{COLORS.map((c) => (
+									<button
+										type="button"
+										key={c.value}
+										onClick={() => setEditColor(c.value)}
+										className={`cursor-pointer w-4 h-4 rounded-full transition-all ${editColor === c.value ? "scale-130 ring-2 ring-offset-1 ring-base-border" : "border-transparent hover:scale-130"}`}
+										style={{ backgroundColor: c.hex }}
+										title={c.name}
+									/>
+								))}
+							</div>
+						</div>
+						<div className="flex justify-end gap-2 pt-1">
+							<button
+								type="button"
+								onClick={() => setIsSettingsOpen(false)}
+								className="cursor-pointer px-3 py-1 text-xs text-muted-foreground hover:text-action"
+							>
+								Cancel
+							</button>
+							<button
+								type="button"
+								onClick={handleSave}
+								disabled={saving}
+								className="cursor-pointer px-3 py-1 bg-action text-action-text text-xs rounded hover:bg-action-hover disabled:opacity-50 flex items-center gap-1"
+							>
+								{saving ? "Saving..." : "Save"}
+							</button>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
 }

--- a/apps/extension/src/hooks/useNotes.test.ts
+++ b/apps/extension/src/hooks/useNotes.test.ts
@@ -1,7 +1,8 @@
-import type { Session } from "@supabase/supabase-js";
-import { renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { useNotes } from "./useNotes";
+
+vi.mock("../supabaseClient", () => ({
+	supabase: {},
+}));
 
 // @sitecue/sharedのモック
 vi.mock("@sitecue/shared", async (importOriginal) => {
@@ -21,6 +22,9 @@ import {
 	fetchExtensionNoteMetadatas,
 	type Note,
 } from "@sitecue/shared";
+import type { Session } from "@supabase/supabase-js";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useNotes } from "./useNotes";
 
 describe("useNotes hook (Hybrid Fetching)", () => {
 	const mockSession = { user: { id: "user-1" } } as unknown as Session;
@@ -28,7 +32,13 @@ describe("useNotes hook (Hybrid Fetching)", () => {
 
 	it("初回フェッチ（fetchNotes）では、contentが含まれていないこと (Slim Fetching)", async () => {
 		const mockSlimNotes = [
-			{ id: "1", url_pattern: "example.com", scope: "domain", tags: ["test"] },
+			{
+				id: "1",
+				url_pattern: "example.com",
+				scope: "domain",
+				tags: ["test"],
+				created_at: new Date().toISOString(),
+			},
 		];
 
 		// モックの挙動設定: 初回フェッチ
@@ -55,6 +65,7 @@ describe("useNotes hook (Hybrid Fetching)", () => {
 				url_pattern: "example.com",
 				scope: "domain",
 				tags: ["test"],
+				created_at: new Date().toISOString(),
 			},
 		];
 		const mockHydratedData = [{ id: "note-1", content: "Hydrated Content" }];
@@ -85,7 +96,12 @@ describe("useNotes hook (Hybrid Fetching)", () => {
 
 	it("Inbox閲覧中にURLが変化しても、再フェッチ（supabase.from呼び出し）が走らないこと", async () => {
 		const mockInboxNotes = [
-			{ id: "inbox-1", scope: "inbox", content: "Inbox Note" },
+			{
+				id: "inbox-1",
+				scope: "inbox",
+				content: "Inbox Note",
+				created_at: new Date().toISOString(),
+			},
 		];
 
 		// Supabaseモックの初期設定
@@ -132,7 +148,9 @@ describe("useNotes - Silent Refetching", () => {
 	const mockUrl = "https://example.com/page";
 
 	it("メモリ上にデータがある場合、再フェッチ時に loading が true にならないこと", async () => {
-		const mockNotes = [{ id: "1", content: "existing" }];
+		const mockNotes = [
+			{ id: "1", content: "existing", created_at: new Date().toISOString() },
+		];
 		vi.mocked(fetchExtensionNoteMetadatas).mockResolvedValue(
 			mockNotes as unknown as Note[],
 		);
@@ -162,7 +180,9 @@ describe("useNotes - Silent Refetching", () => {
 
 	it("再フェッチ時に既存の content が新しいメタデータにマージされて保護されること", async () => {
 		// 初期状態のモック（メタデータのみ）
-		const initialNotes = [{ id: "1", content: undefined }];
+		const initialNotes = [
+			{ id: "1", content: undefined, created_at: new Date().toISOString() },
+		];
 		vi.mocked(fetchExtensionNoteMetadatas).mockResolvedValueOnce(
 			initialNotes as unknown as Note[],
 		);
@@ -183,7 +203,14 @@ describe("useNotes - Silent Refetching", () => {
 		result.current.notes[0].content = "User typed this text";
 
 		// 再フェッチを発生させるためのモック準備（DBからは content なしのメタデータが返ってくる）
-		const newMetadatas = [{ id: "1", content: undefined, is_pinned: true }]; // ピン留めされたと仮定
+		const newMetadatas = [
+			{
+				id: "1",
+				content: undefined,
+				is_pinned: true,
+				created_at: new Date().toISOString(),
+			},
+		]; // ピン留めされたと仮定
 		vi.mocked(fetchExtensionNoteMetadatas).mockResolvedValueOnce(
 			newMetadatas as unknown as Note[],
 		);
@@ -196,7 +223,108 @@ describe("useNotes - Silent Refetching", () => {
 		});
 
 		// 新しいメタデータ (is_pinned: true) が反映されつつ、既存の content は保護されていること
-		expect(result.current.notes[0].is_pinned).toBe(true);
-		expect(result.current.notes[0].content).toBe("User typed this text");
+		await waitFor(() => {
+			expect(result.current.notes[0].is_pinned).toBe(true);
+			expect(result.current.notes[0].content).toBe("User typed this text");
+		});
+	});
+
+	it("updateNoteOrder実行時、別スコープや別URLのノートが混在していても、同一コンテキストのノートのみを隔離して正確に順序計算されること", async () => {
+		// 表示コンテキストが「example.com (exactスコープ)」のノート2つと、
+		// 画面外の別コンテキスト「another.com (domainスコープ)」のノートが混在している状態を再現
+		const mockNotes = [
+			{
+				id: "note-target",
+				url_pattern: "https://example.com/page",
+				scope: "exact",
+				sort_order: 2.0,
+				created_at: "2026-01-02T00:00:00.000Z",
+			},
+			{
+				id: "note-above",
+				url_pattern: "https://example.com/page",
+				scope: "exact",
+				sort_order: 1.0,
+				created_at: "2026-01-01T00:00:00.000Z",
+			},
+			// 💥これが画面外の隠しノート。sort_orderが間に挟まっているが、スコープが違うので隔離・無視されなければならない
+			{
+				id: "note-hidden",
+				url_pattern: "another.com",
+				scope: "domain",
+				sort_order: 1.5,
+				created_at: "2026-01-01T05:00:00.000Z",
+			},
+		];
+
+		vi.mocked(fetchExtensionNoteMetadatas).mockResolvedValue(
+			mockNotes as unknown as Note[],
+		);
+		vi.mocked(fetchExtensionNoteContents).mockResolvedValue([]);
+
+		const { result } = renderHook(() =>
+			useNotes(mockSession, "https://example.com/page", vi.fn(), "exact"),
+		);
+
+		// 初回フェッチ完了待ち
+		await waitFor(() => expect(result.current.loading).toBe(false));
+		expect(result.current.notes.length).toBe(3);
+
+		// 仕様追従: 表示コンテキストに合致するもののみを抽出して渡す
+		const visibleNotes = result.current.notes.filter(
+			(n) => n.scope === "exact" && n.url_pattern === "https://example.com/page",
+		);
+
+		let success = false;
+		await act(async () => {
+			success = await result.current.updateNoteOrder("note-target", "up", visibleNotes);
+		});
+		expect(success).toBe(true);
+
+		// 楽観的UI更新後の値を確認
+		await waitFor(() => {
+			const updatedTarget = result.current.notes.find(
+				(n) => n.id === "note-target",
+			);
+			expect(updatedTarget?.sort_order).toBe(0.0);
+		});
+	});
+
+	it("検索やタグ等のフィルターで絞り込まれた状態でも、実際に画面に表示されているノート配列を基準に正確にごぼう抜き順序計算が行われること", async () => {
+		// 表示コンテキストは同一だが、内容フィルターによって1つ（note-hidden）が非表示になる状況を再現
+		const mockNotes = [
+			{ id: "note-1", url_pattern: "https://example.com/page", scope: "exact", sort_order: 1.0, content: "りんごのメモ #fruit", created_at: "2026-01-01T00:00:00.000Z" },
+			// 💥これが検索ワード「みかん」によって画面上から除外（非表示）される隠しノート
+			{ id: "note-hidden", url_pattern: "https://example.com/page", scope: "exact", sort_order: 1.5, content: "りんごのメモ2 #fruit", created_at: "2026-01-01T05:00:00.000Z" },
+			{ id: "note-2", url_pattern: "https://example.com/page", scope: "exact", sort_order: 2.0, content: "みかんのメモ #fruit", created_at: "2026-01-02T00:00:00.000Z" },
+		];
+
+		vi.mocked(fetchExtensionNoteMetadatas).mockResolvedValue(
+			mockNotes as unknown as Note[],
+		);
+		vi.mocked(fetchExtensionNoteContents).mockResolvedValue([]);
+
+		const { result } = renderHook(() =>
+			useNotes(mockSession, "https://example.com/page", vi.fn(), "exact"),
+		);
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		// 画面上の絞り込み結果（note-hiddenが除外された、実際に見えている状態の配列）を模倣
+		const visibleNotes = [result.current.notes[0], result.current.notes[2]];
+
+		// 画面上での隣（note-1: 1.0）を追い越すため、「上（up）」へ移動させる
+		// 画面外の note-hidden (1.5) を適切にスキップしていれば、1.0 - 1.0 = 0.0 が算出される
+		let success = false;
+		await act(async () => {
+			success = await result.current.updateNoteOrder("note-2", "up", visibleNotes);
+		});
+		expect(success).toBe(true);
+
+		// 楽観的UI更新結果が 0.0（note-1の前に出た状態）になっているかをアサーション
+		await waitFor(() => {
+			const updated = result.current.notes.find((n) => n.id === "note-2");
+			expect(updated?.sort_order).toBe(0.0);
+		});
 	});
 });

--- a/apps/extension/src/hooks/useNotes.ts
+++ b/apps/extension/src/hooks/useNotes.ts
@@ -25,6 +25,18 @@ export function useNotes(
 ) {
 	const [notes, setNotes] = useState<Note[]>([]);
 	const [loading, setLoading] = useState(false);
+	const [processingNoteIds, setProcessingNoteIds] = useState<Set<string>>(
+		new Set(),
+	);
+
+	// ソート条件式の共通化ヘルパー（DB側 order("sort_order").order("created_at") と100%同期）
+	const sortNotesConsistent = (a: Note, b: Note) => {
+		if ((a.sort_order ?? 0) !== (b.sort_order ?? 0)) {
+			return (a.sort_order ?? 0) - (b.sort_order ?? 0);
+		}
+		return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+	};
+
 	const prevUrlRef = useRef<string>(currentFullUrl);
 
 	// 危険な notesRef を排除し、「初回フェッチが完了したか」だけを追跡する安全なフラグを導入
@@ -277,37 +289,50 @@ export function useNotes(
 		}
 	};
 
-	const updateNoteOrder = async (id: string, direction: "up" | "down") => {
+	const updateNoteOrder = async (
+		id: string,
+		direction: "up" | "down",
+		currentVisibleNotes: Note[],
+	) => {
+		// 二重防壁ロック: すでに処理中なら即座にガードブロック
+		if (processingNoteIds.has(id)) return false;
+
 		const targetNote = notes.find((n) => n.id === id);
 		if (!targetNote) return false;
 
-		// NoteList.tsx の表示グループ（Favorites / Page / Pinned）に準拠してソート対象を抽出
-		const filtered = notes.filter((n) => {
+		// ソフトウェアロック of 有効化
+		setProcessingNoteIds((prev) => {
+			const next = new Set(prev);
+			next.add(id);
+			return next;
+		});
+
+		// 画面上に実際に見えているノート配列（フィルター適用後）から、同じ表示グループ（Favorite / Pinned / Normal）を抽出
+		const filtered = currentVisibleNotes.filter((n) => {
 			if (targetNote.is_favorite) return n.is_favorite;
 			return !n.is_favorite && n.is_pinned === targetNote.is_pinned;
 		});
 
-		const group = [...filtered].sort(
-			(a, b) =>
-				(a.sort_order || 0) - (b.sort_order || 0) ||
-				new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
-		);
+		// 一貫性あるソート関数を適用
+		const group = [...filtered].sort(sortNotesConsistent);
 
-		// 純粋関数により最適なオーダー値を一意に取得
+		// 純粋関数により最適なオーダー値を一意に取得（画面外のノートはOFFSETガードですり抜ける）
 		const newSortOrder = calculateOrderForDirection(group, id, direction);
-		if (newSortOrder === null) return false;
+		if (newSortOrder === null) {
+			setProcessingNoteIds((prev) => {
+				const next = new Set(prev);
+				next.delete(id);
+				return next;
+			});
+			return false;
+		}
 
-		// Optimistic UI Update
+		// 0msレスポンスのインメモリ楽観的UI更新
 		setNotes((prevNotes) => {
 			const newNotes = prevNotes.map((n) =>
 				n.id === id ? { ...n, sort_order: newSortOrder } : n,
 			);
-			newNotes.sort(
-				(a, b) =>
-					(a.sort_order || 0) - (b.sort_order || 0) ||
-					new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
-			);
-			return newNotes;
+			return newNotes.sort(sortNotesConsistent);
 		});
 
 		try {
@@ -316,8 +341,15 @@ export function useNotes(
 		} catch (error) {
 			console.error("Failed to update note order", error);
 			toast.error("Failed to reorder notes");
-			fetchNotes(); // エラー時は確実なロールバック
+			fetchNotes(); // ロールバック
 			return false;
+		} finally {
+			// ソフトウェアロックの解除
+			setProcessingNoteIds((prev) => {
+				const next = new Set(prev);
+				next.delete(id);
+				return next;
+			});
 		}
 	};
 

--- a/packages/shared/src/dal/notes.ts
+++ b/packages/shared/src/dal/notes.ts
@@ -25,9 +25,6 @@ export async function fetchNoteMetadatas(
 	return (data as NoteMetadata[]) || [];
 }
 
-/**
- * ノートを作成する
- */
 export async function createNoteEntity(
 	supabase: SupabaseClient,
 	userId: string,
@@ -35,21 +32,35 @@ export async function createNoteEntity(
 ): Promise<Note> {
 	const payload = resolveNotePayload(input);
 
+	// 未ピン留めノートの中から最も若い（最小の）sort_orderを取得する
 	const { data: existingNotes, error: fetchError } = await supabase
 		.from("sitecue_notes")
 		.select("sort_order")
 		.eq("user_id", userId)
 		.eq("scope", payload.scope)
-		.order("sort_order", { ascending: false })
+		.eq("is_pinned", false)
+		.order("sort_order", { ascending: true })
 		.limit(1);
 
 	if (fetchError) throw fetchError;
 
-	const maxSortOrder =
-		existingNotes && existingNotes.length > 0
-			? existingNotes[0].sort_order
-			: -1;
-	const newSortOrder = maxSortOrder + 1.0;
+	let newSortOrder = 0.0;
+	if (existingNotes && existingNotes.length > 0) {
+		// 最小値からさらに -1.0 減算することで、ピン留め直下の最上部に差し込む若い値を採番
+		newSortOrder = existingNotes[0].sort_order - 1.0;
+	} else {
+		// 未ピン留めノートが存在しない場合は、全ノートの最小値を取得して基準とする
+		const { data: allNotes, error: allFetchError } = await supabase
+			.from("sitecue_notes")
+			.select("sort_order")
+			.eq("user_id", userId)
+			.eq("scope", payload.scope)
+			.order("sort_order", { ascending: true })
+			.limit(1);
+		
+		if (allFetchError) throw allFetchError;
+		newSortOrder = allNotes && allNotes.length > 0 ? allNotes[0].sort_order - 1.0 : 0.0;
+	}
 
 	const insertData = {
 		user_id: userId,

--- a/packages/shared/src/utils/ordering.test.ts
+++ b/packages/shared/src/utils/ordering.test.ts
@@ -4,45 +4,43 @@ import { calculateOrderForDirection } from "./ordering";
 describe("Ordering Utilities: calculateOrderForDirection", () => {
 	it("正常な少数オーダーの隙間に正しく中間値が算出されること", () => {
 		const items = [
-			{ id: "A", sort_order: 1.0 },
-			{ id: "B", sort_order: 2.0 },
-			{ id: "C", sort_order: 3.0 },
+			{ id: "A", sort_order: 1.0, created_at: "2026-01-01T00:00:00.000Z" },
+			{ id: "B", sort_order: 2.0, created_at: "2026-01-02T00:00:00.000Z" },
+			{ id: "C", sort_order: 3.0, created_at: "2026-01-03T00:00:00.000Z" },
 		];
-		// Bを上に移動 ➔ 先頭越えになるため全体の最小値(1.0) - 1.0 = 0
+		// Bを上に移動 -> 先頭アイテムAを追い越すため A(1.0) - 1.0 = 0
 		expect(calculateOrderForDirection(items, "B", "up")).toBe(0);
-		// Bを下に移動 ➔ 末尾越えになるため全体の最大値(3.0) + 1.0 = 4.0
+		// Bを下に移動 -> 末尾アイテムCを追い越すため C(3.0) + 1.0 = 4.0
 		expect(calculateOrderForDirection(items, "B", "down")).toBe(4.0);
 	});
 
-	it("sort_orderがすべて同値(0)の競合地帯からの脱出時、既存の誰とも被らない全体境界値が割り当てられること", () => {
+	it("sort_orderがすべて同値(0)の競合地帯からの脱出時、極小オフセットによる防壁防護で境界線をすり抜けること", () => {
 		const items = [
-			{ id: "A", sort_order: 0 },
-			{ id: "B", sort_order: 0 },
-			{ id: "C", sort_order: 0 },
-			{ id: "D", sort_order: 0 },
+			{ id: "A", sort_order: 0, created_at: "2026-01-01T00:00:00.000Z" },
+			{ id: "B", sort_order: 0, created_at: "2026-01-02T00:00:00.000Z" },
+			{ id: "C", sort_order: 0, created_at: "2026-01-03T00:00:00.000Z" },
+			{ id: "D", sort_order: 0, created_at: "2026-01-04T00:00:00.000Z" },
 		];
-		// 隙間がないため、Cを上に動かすと全体の最小値(0)から確実に引き算される
-		expect(calculateOrderForDirection(items, "C", "up")).toBe(-1.0);
-		// Bを下に動かすと全体の最大値(0)から確実に加算される
-		expect(calculateOrderForDirection(items, "B", "down")).toBe(1.0);
+		// Cを上に動かすと、Bのsort_order(0)から極小オフセット(0.0001)が減算され、-0.0001になることを証明
+		expect(calculateOrderForDirection(items, "C", "up")).toBe(-0.0001);
+		// Bを下に動かすと、Cのsort_order(0)から極小オフセット(0.0001)が加算され、0.0001になることを証明
+		expect(calculateOrderForDirection(items, "B", "down")).toBe(0.0001);
 	});
 
-	it("【重要】すでに移動済みのマイナス値が存在する混迷状態でも、移動先での値の衝突を起こさずに確実なブレイク値を返すこと", () => {
-		// ユーザー操作履歴によって一部のノートだけ先行してマイナス値になっているケース（2回クリックバグの原因モデル）
+	it("【重要】すでに移動済みのマイナス値が存在する混迷状態でも、移動先での衝突を起こさずにオフセットブレイク値を返すこと", () => {
 		const items = [
-			{ id: "A", sort_order: -1.0 },
-			{ id: "B", sort_order: 0 },
-			{ id: "C", sort_order: 0 }, // Bと同値競合中
+			{ id: "A", sort_order: -1.0, created_at: "2026-01-01T00:00:00.000Z" },
+			{ id: "B", sort_order: 0, created_at: "2026-01-02T00:00:00.000Z" },
+			{ id: "C", sort_order: 0, created_at: "2026-01-03T00:00:00.000Z" },
 		];
-		// Cを上に動かした際、単に B(0) - 1.0 をすると A(-1.0) と衝突して空振りする。
-		// グローバル境界ロジックにより、全体の最小値(-1.0)からさらに引いた -2.0 が返ることを証明する。
-		expect(calculateOrderForDirection(items, "C", "up")).toBe(-2.0);
+		// Cを上に動かした際、B(0)との衝突を検知して 0 - 0.0001 = -0.0001 となり、A(-1.0)と衝突せず安全に割り込めることを実証
+		expect(calculateOrderForDirection(items, "C", "up")).toBe(-0.0001);
 	});
 
 	it("移動不可な境界操作時はnullを返すこと", () => {
 		const items = [
-			{ id: "A", sort_order: 0 },
-			{ id: "B", sort_order: 1 },
+			{ id: "A", sort_order: 0, created_at: "2026-01-01T00:00:00.000Z" },
+			{ id: "B", sort_order: 1, created_at: "2026-01-02T00:00:00.000Z" },
 		];
 		expect(calculateOrderForDirection(items, "A", "up")).toBeNull();
 		expect(calculateOrderForDirection(items, "B", "down")).toBeNull();

--- a/packages/shared/src/utils/ordering.ts
+++ b/packages/shared/src/utils/ordering.ts
@@ -1,15 +1,11 @@
 export interface SortableItem {
 	id: string;
 	sort_order?: number;
+	created_at: string; // 順序一貫性保証のために必須化
 }
 
 /**
  * 上下ボタンによる順序移動のための、安全な Fractional Indexing オーダーを算出する純粋関数。
- * 移動先での同値衝突を防ぐため、隙間がない場合はリスト全体の最小値・最大値を基準に確実なブレイクを行う。
- * @param items 現在のソート済み配列（画面上の並び順通りであること）
- * @param targetId 移動させたいアイテムのID
- * @param direction 移動方向 ("up" または "down")
- * @returns 新たに割り当てるべき sort_order の少数値（移動不可な場合は null）
  */
 export function calculateOrderForDirection<T extends SortableItem>(
 	items: T[],
@@ -20,61 +16,68 @@ export function calculateOrderForDirection<T extends SortableItem>(
 	if (currentIndex === -1) return null;
 
 	const currentOrder = items[currentIndex].sort_order ?? 0;
-
-	// リスト全体の存在するオーダーの最小値と最大値を抽出（安全な外側境界の確保）
 	const allOrders = items.map((item) => item.sort_order ?? 0);
 	const minOrder = Math.min(...allOrders);
 	const maxOrder = Math.max(...allOrders);
 
+	const EPSILON = 1e-9;
+	const OFFSET = 0.0001; // コンテキストに応じた極小のオフセット値
+
 	if (direction === "up") {
-		// すでに先頭の場合は移動不可
 		if (currentIndex === 0) return null;
 
 		const targetAbove = items[currentIndex - 1];
 		const targetAboveOrder = targetAbove.sort_order ?? 0;
 		const targetTwoAbove = items[currentIndex - 2];
 
-		// Case 1: 追い越す相手が先頭アイテムだった場合
 		if (!targetTwoAbove) {
-			// 既存のどの値とも衝突しないよう、全体の最小値からさらに押し下げる
-			return minOrder - 1.0;
+			// 先頭アイテムを追い越す場合
+			return targetAboveOrder - 1.0;
 		}
 
-		// Case 2: 追い越す相手とその上のアイテムとの間に十分な「隙間」があるかを判定
 		const twoAboveOrder = targetTwoAbove.sort_order ?? 0;
 
-		// 隙間がない、あるいは移動元が既に上のアイテムと同値衝突している場合は、
-		// 局所計算を捨てて全体の最小値を更新するセーフティを発動
+		// 境界線ブロック自動解消（防壁ロジック）: 同値衝突または中間値計算限界の検知
+		if (Math.abs(currentOrder - targetAboveOrder) < EPSILON || Math.abs(targetAboveOrder - twoAboveOrder) < EPSILON) {
+			return targetAboveOrder - OFFSET;
+		}
+
 		if (targetAboveOrder <= twoAboveOrder || currentOrder <= targetAboveOrder) {
 			return minOrder - 1.0;
 		}
 
-		// 隙間が存在する場合は、純粋な中間値を算出して安全に割り込む
-		return (targetAboveOrder + twoAboveOrder) / 2.0;
+		const mid = (targetAboveOrder + twoAboveOrder) / 2.0;
+		if (Math.abs(mid - targetAboveOrder) < EPSILON || Math.abs(mid - twoAboveOrder) < EPSILON) {
+			return targetAboveOrder - OFFSET;
+		}
+		return mid;
 	} else {
-		// すでに末尾の場合は移動不可
 		if (currentIndex === items.length - 1) return null;
 
 		const targetBelow = items[currentIndex + 1];
 		const targetBelowOrder = targetBelow.sort_order ?? 0;
 		const targetTwoBelow = items[currentIndex + 2];
 
-		// Case 1: 追い越す相手が末尾アイテムだった場合
 		if (!targetTwoBelow) {
-			// 既存のどの値とも衝突しないよう、全体の最大値からさらに押し上げる
-			return maxOrder + 1.0;
+			// 末尾アイテムを追い越す場合
+			return targetBelowOrder + 1.0;
 		}
 
-		// Case 2: 追い越す相手とその下のアイテムとの間に十分な「隙間」があるかを判定
 		const twoBelowOrder = targetTwoBelow.sort_order ?? 0;
 
-		// 隙間がない、あるいは移動元が既に下のアイテムと同値衝突している場合は、
-		// 全体の最大値を更新させて確実なごぼう抜きを保証する
+		// 境界線ブロック自動解消（防壁ロジック）: 同値衝突または中間値計算限界の検知
+		if (Math.abs(currentOrder - targetBelowOrder) < EPSILON || Math.abs(targetBelowOrder - twoBelowOrder) < EPSILON) {
+			return targetBelowOrder + OFFSET;
+		}
+
 		if (targetBelowOrder >= twoBelowOrder || currentOrder >= targetBelowOrder) {
 			return maxOrder + 1.0;
 		}
 
-		// 隙間が存在する場合は、純粋な中間値を算出
-		return (targetBelowOrder + twoBelowOrder) / 2.0;
+		const mid = (targetBelowOrder + twoBelowOrder) / 2.0;
+		if (Math.abs(mid - targetBelowOrder) < EPSILON || Math.abs(mid - twoBelowOrder) < EPSILON) {
+			return targetBelowOrder + OFFSET;
+		}
+		return mid;
 	}
 }


### PR DESCRIPTION
…d support filtered reordering

Why:
- Notes with identical `sort_order` values would default to `created_at` sorting, which physically broke fractional indexing calculations and caused reordering buttons to become unresponsive.
- Calculating order based on the complete unisolated data mixed hidden notes from other scopes/URLs into the sequence, causing reordering actions to become visually static on the current screen.
- Rapid successive click events on reorder buttons during network lag triggered race conditions and redundant API communication.

What:
- Updated `createNoteEntity` to query the minimum `sort_order` of existing unpinned notes and subtract `1.0` to support top-insertion for newly created notes.
- Rewrote `calculateOrderForDirection` to detect floating-point same-value collisions via `EPSILON = 1e-9` and slide past boundaries using a small `OFFSET = 0.0001` guard.
- Expanded `updateNoteOrder` in `useNotes.ts` to accept `currentVisibleNotes`, isolating the calculation array to match the actual visible screen and enabling frictionless leapfrog reordering even while filtered.
- Bound the filtered array (`finalFilteredNotes`) into the `onUpdateNoteOrder` callback within `SidePanel.tsx` to align the visual layout state with the indexing utility.
- Implemented a state-driven software double-click lock (`processingNoteIds`) with a secure `try...finally` block to safely block concurrent reorder invocations.
- Centralized an in-memory sorting logic helper `sortNotesConsistent` to keep local array state changes 100% synced with the remote database's sorting behavior.
- Added comprehensive unit and integration tests in `ordering.test.ts` and `useNotes.test.ts` covering edge cases like context isolation, offset bypass, and filtered reordering.