### PR TITLE
feat(extension): overhaul action bar layout and centralize note expan…

### DIFF
--- a/apps/extension/src/SidePanel.test.tsx
+++ b/apps/extension/src/SidePanel.test.tsx
@@ -236,4 +236,23 @@ describe("SidePanel Component", () => {
 			screen.queryByText("Favorite Note (Other Scope)"),
 		).not.toBeInTheDocument();
 	});
+
+	it("コピーボタンをクリックしてメニューからTextコピーができること", async () => {
+		const writeTextMock = vi.fn().mockResolvedValue(undefined);
+		Object.defineProperty(navigator, "clipboard", {
+			value: { writeText: writeTextMock },
+			configurable: true,
+		});
+
+		render(<SidePanel />);
+
+		const copyButton = screen.getByLabelText("Open copy options menu");
+		fireEvent.click(copyButton);
+
+		const copyTextButton = screen.getByText("Copy as Text");
+		fireEvent.click(copyTextButton);
+
+		// デフォルトで表示されている Exact Note のコンテンツがコピーされること
+		expect(writeTextMock).toHaveBeenCalledWith("Exact Note");
+	});
 });

--- a/apps/extension/src/SidePanel.tsx
+++ b/apps/extension/src/SidePanel.tsx
@@ -1,7 +1,7 @@
 import { getScopeUrls } from "@sitecue/shared";
 import type { Session } from "@supabase/supabase-js";
-import { Loader2, Plus } from "lucide-react";
-import { useRef, useState } from "react";
+import { Check, Copy, Loader2, Plus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { Toaster } from "react-hot-toast";
 import FilterBar from "./components/FilterBar";
 import Header from "./components/Header";
@@ -74,6 +74,61 @@ function NotesUI({
 	const listContainerRef = useRef<HTMLDivElement>(null);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+	// 📋 一括コピー用のステートとロジック
+	const [isCopied, setIsCopied] = useState(false);
+	const [isCopyMenuOpen, setIsCopyMenuOpen] = useState(false);
+	const menuRef = useRef<HTMLDivElement>(null);
+	const copyToClipboard = async (text: string) => {
+		try {
+			await navigator.clipboard.writeText(text);
+			setIsCopied(true);
+			setTimeout(() => setIsCopied(false), 2000);
+		} catch {
+			// clipboard write failed silently
+		}
+	};
+
+	const handleCopyText = async () => {
+		const text = finalFilteredNotes.map((n) => n.content ?? "").join("\n\n");
+		await copyToClipboard(text);
+		setIsCopyMenuOpen(false);
+	};
+
+	const handleCopyJson = async () => {
+		const json = finalFilteredNotes.map((n) => ({
+			type: n.note_type || "info",
+			content: n.content,
+		}));
+		await copyToClipboard(JSON.stringify(json, null, 2));
+		setIsCopyMenuOpen(false);
+	};
+
+	// Close search and menu when pressing Escape
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				setIsCopyMenuOpen(false);
+			}
+		};
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, []);
+
+	// Close menu when clicking outside
+	useEffect(() => {
+		const handleClickOutside = (event: MouseEvent) => {
+			if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+				setIsCopyMenuOpen(false);
+			}
+		};
+		if (isCopyMenuOpen) {
+			document.addEventListener("mousedown", handleClickOutside);
+		}
+		return () => {
+			document.removeEventListener("mousedown", handleClickOutside);
+		};
+	}, [isCopyMenuOpen]);
+
 	const {
 		notes,
 		loading,
@@ -95,7 +150,7 @@ function NotesUI({
 	) => {
 		const success = await originalAddNote(content, scope, type);
 		if (success) {
-			// 新規ノート追加時、背後のノートリストを最上部へ自動でスクロールバック
+			// 新規ノート追加時、背後のノートリストを最上部へ自动でスクロールバック
 			setTimeout(() => {
 				if (listContainerRef.current) {
 					listContainerRef.current.scrollTo({
@@ -217,17 +272,17 @@ function NotesUI({
 				setViewScope={setViewScope}
 				searchQuery={searchQuery}
 				setSearchQuery={setSearchQuery}
-				filteredNotes={finalFilteredNotes} // コピー対象はタグ絞り込み後の最終リスト
 				selectedTag={selectedTag}
 				setSelectedTag={setSelectedTag}
 				availableTags={availableTags}
 			/>
 
-			<div className="grid grid-cols-3 items-center px-4 py-1.5 bg-base-surface shrink-0 border-b border-base-border shadow-xs">
-				{/* 左カラム（将来の拡張アクションボタン用スペース） */}
+			{/* 🚀 等幅3カラム中央集権型アクションバー (グレー背景を白背景 bg-base-bg へ融和) */}
+			<div className="grid grid-cols-3 items-center px-4 py-2 bg-base-bg shrink-0 border-b border-base-border/40 shadow-xs">
+				{/* 左カラム：拡張用スペース */}
 				<div className="flex justify-start" />
 
-				{/* 中央カラム（「＋」ボタンを物理的中心に完全ロック） */}
+				{/* 中央カラム：「＋」ボタンを物理的中心に完全ロック */}
 				<div className="flex justify-center">
 					<button
 						type="button"
@@ -242,8 +297,47 @@ function NotesUI({
 					</button>
 				</div>
 
-				{/* 右カラム（将来の拡張アクションボタン用スペース） */}
-				<div className="flex justify-end" />
+				{/* 右カラム：移設された一括コピーボタン (ドロップダウン) */}
+				<div className="flex justify-end relative" ref={menuRef}>
+					<button
+						type="button"
+						onClick={() => setIsCopyMenuOpen(!isCopyMenuOpen)}
+						className={`cursor-pointer flex items-center justify-center rounded-full transition-colors shrink-0 size-7 ${
+							isCopied
+								? "text-note-info bg-note-info/10"
+								: isCopyMenuOpen
+									? "text-action bg-base-border"
+									: "text-muted-foreground bg-base-surface hover:text-action hover:bg-base-border"
+						}`}
+						title={isCopied ? "Copied!" : "Copy options"}
+						aria-label={isCopied ? "Copied!" : "Open copy options menu"}
+					>
+						{isCopied ? (
+							<Check className="w-3.5 h-3.5" />
+						) : (
+							<Copy className="w-3.5 h-3.5" />
+						)}
+					</button>
+
+					{isCopyMenuOpen && (
+						<div className="absolute right-0 top-full mt-1 bg-base-surface border border-base-border rounded shadow-md z-40 py-1 min-w-[120px]">
+							<button
+								type="button"
+								onClick={handleCopyText}
+								className="w-full text-left px-3 py-1.5 text-xs text-muted-foreground hover:bg-base-bg transition-colors"
+							>
+								Copy as Text
+							</button>
+							<button
+								type="button"
+								onClick={handleCopyJson}
+								className="w-full text-left px-3 py-1.5 text-xs text-muted-foreground hover:bg-base-bg transition-colors"
+							>
+								Copy as JSON
+							</button>
+						</div>
+					)}
+				</div>
 			</div>
 
 			<div

--- a/apps/extension/src/components/FilterBar.test.tsx
+++ b/apps/extension/src/components/FilterBar.test.tsx
@@ -1,36 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { Note } from "../hooks/useNotes";
 import FilterBar from "./FilterBar";
 
 describe("FilterBar Component", () => {
-	const mockNotes: Note[] = [
-		{
-			id: "1",
-			content: "Note 1",
-			note_type: "info",
-			scope: "exact",
-			url_pattern: "example.com",
-			is_resolved: false,
-			is_pinned: false,
-			is_favorite: false,
-			sort_order: 1,
-			created_at: new Date().toISOString(),
-		},
-		{
-			id: "2",
-			content: "Note 2",
-			note_type: "alert",
-			scope: "exact",
-			url_pattern: "example.com",
-			is_resolved: false,
-			is_pinned: false,
-			is_favorite: false,
-			sort_order: 2,
-			created_at: new Date().toISOString(),
-		},
-	] as unknown as Note[];
-
 	const mockProps = {
 		filterType: "all" as const,
 		setFilterType: vi.fn(),
@@ -40,7 +12,6 @@ describe("FilterBar Component", () => {
 		setViewScope: vi.fn(),
 		searchQuery: "",
 		setSearchQuery: vi.fn(),
-		filteredNotes: mockNotes,
 		selectedTag: null,
 		setSelectedTag: vi.fn(),
 		availableTags: ["tag1", "tag2"],
@@ -54,24 +25,6 @@ describe("FilterBar Component", () => {
 
 		rerender(<FilterBar {...mockProps} searchQuery="" />);
 		expect(screen.queryByTitle("Clear search")).not.toBeInTheDocument();
-	});
-
-	it("コピーボタンをクリックしてメニューからTextコピーができること", async () => {
-		const writeTextMock = vi.fn().mockResolvedValue(undefined);
-		Object.defineProperty(navigator, "clipboard", {
-			value: { writeText: writeTextMock },
-			configurable: true,
-		});
-
-		render(<FilterBar {...mockProps} />);
-
-		const copyButton = screen.getByLabelText("Open copy options menu");
-		fireEvent.click(copyButton);
-
-		const copyTextButton = screen.getByText("Copy as Text");
-		fireEvent.click(copyTextButton);
-
-		expect(writeTextMock).toHaveBeenCalledWith("Note 1\n\nNote 2");
 	});
 
 	it("タグのフェードマスクが正しくレンダリングされること", () => {

--- a/apps/extension/src/components/FilterBar.tsx
+++ b/apps/extension/src/components/FilterBar.tsx
@@ -1,316 +1,216 @@
 import {
-	AlertTriangle,
-	Check,
-	CheckSquare,
-	Copy,
-	Info,
-	Lightbulb,
-	Search,
-	X,
+  AlertTriangle,
+  CheckSquare,
+  Info,
+  Lightbulb,
+  Search,
+  X,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import type { Note } from "../hooks/useNotes";
 
 interface FilterBarProps {
-	filterType: "all" | "info" | "alert" | "idea";
-	setFilterType: (type: "all" | "info" | "alert" | "idea") => void;
-	showResolved: boolean;
-	setShowResolved: (show: boolean) => void;
-	viewScope: "exact" | "domain" | "inbox";
-	setViewScope: (scope: "exact" | "domain" | "inbox") => void;
-	searchQuery: string;
-	setSearchQuery: (query: string) => void;
-	filteredNotes: Note[];
-	selectedTag: string | null;
-	setSelectedTag: (tag: string | null) => void;
-	availableTags: string[];
+  filterType: "all" | "info" | "alert" | "idea";
+  setFilterType: (type: "all" | "info" | "alert" | "idea") => void;
+  showResolved: boolean;
+  setShowResolved: (show: boolean) => void;
+  viewScope: "exact" | "domain" | "inbox";
+  setViewScope: (scope: "exact" | "domain" | "inbox") => void;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  selectedTag: string | null;
+  setSelectedTag: (tag: string | null) => void;
+  availableTags: string[];
 }
 
 export default function FilterBar({
-	filterType,
-	setFilterType,
-	showResolved,
-	setShowResolved,
-	viewScope,
-	setViewScope,
-	searchQuery,
-	setSearchQuery,
-	filteredNotes,
-	selectedTag,
-	setSelectedTag,
-	availableTags,
+  filterType,
+  setFilterType,
+  showResolved,
+  setShowResolved,
+  viewScope,
+  setViewScope,
+  searchQuery,
+  setSearchQuery,
+  selectedTag,
+  setSelectedTag,
+  availableTags,
 }: FilterBarProps) {
-	const [isSearchOpen, setIsSearchOpen] = useState(false);
-	const [isCopied, setIsCopied] = useState(false);
-	const [isCopyMenuOpen, setIsCopyMenuOpen] = useState(false);
-	const inputRef = useRef<HTMLInputElement>(null);
-	const menuRef = useRef<HTMLDivElement>(null);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-	const copyToClipboard = async (text: string) => {
-		try {
-			await navigator.clipboard.writeText(text);
-			setIsCopied(true);
-			setTimeout(() => setIsCopied(false), 2000);
-		} catch {
-			// clipboard write failed silently
-		}
-	};
+  // Close search when pressing Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        if (!searchQuery) setIsSearchOpen(false);
+        inputRef.current?.blur();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [searchQuery]);
 
-	const handleCopyText = async () => {
-		const text = filteredNotes.map((n) => n.content ?? "").join("\n\n");
-		await copyToClipboard(text);
-		setIsCopyMenuOpen(false);
-	};
+  useEffect(() => {
+    if (isSearchOpen && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [isSearchOpen]);
 
-	const handleCopyJson = async () => {
-		const json = filteredNotes.map((n) => ({
-			type: n.note_type || "info",
-			content: n.content,
-		}));
-		await copyToClipboard(JSON.stringify(json, null, 2));
-		setIsCopyMenuOpen(false);
-	};
+  return (
+    <div className="bg-base-surface border-b border-base-border px-3 py-2 flex flex-col gap-2.5 z-20 w-full min-w-0">
+      {/* Scope Tabs: カプセル背景の中に綺麗に整列 */}
+      <div className="grid grid-cols-3 gap-1 bg-base-bg p-1 rounded-full border border-base-border/50">
+        <button
+          type="button"
+          onClick={() => setViewScope("exact")}
+          className={`cursor-pointer py-1.5 text-xs font-bold rounded-full transition-all text-center ${viewScope === "exact"
+            ? "bg-action text-action-text shadow-sm"
+            : "text-muted-foreground hover:bg-base-surface"
+            }`}
+        >
+          Page
+        </button>
+        <button
+          type="button"
+          onClick={() => setViewScope("domain")}
+          className={`cursor-pointer py-1.5 text-xs font-bold rounded-full transition-all text-center ${viewScope === "domain"
+            ? "bg-action text-action-text shadow-sm"
+            : "text-muted-foreground hover:bg-base-surface"
+            }`}
+        >
+          Domain
+        </button>
+        <button
+          type="button"
+          onClick={() => setViewScope("inbox")}
+          className={`cursor-pointer py-1.5 text-xs font-bold rounded-full transition-all text-center ${viewScope === "inbox"
+            ? "bg-action text-action-text shadow-sm"
+            : "text-muted-foreground hover:bg-base-surface"
+            }`}
+        >
+          Inbox
+        </button>
+      </div>
 
-	// Close search and menu when pressing Escape
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (e.key === "Escape") {
-				if (!searchQuery) setIsSearchOpen(false);
-				inputRef.current?.blur();
-				setIsCopyMenuOpen(false);
-			}
-		};
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [searchQuery]);
+      <div className="flex items-center justify-between gap-2 w-full">
+        {/* Note Type Filter: rounded-full に統一 */}
+        <div className="flex bg-base-bg p-1 rounded-full border border-base-border/50 shrink-0">
+          <button
+            type="button"
+            onClick={() => setFilterType("all")}
+            className={`cursor-pointer py-1 px-2.5 rounded-full text-xs font-medium transition-colors ${filterType === "all"
+              ? "bg-action text-action-text shadow-sm"
+              : "text-muted-foreground hover:text-action hover:bg-base-surface"
+              }`}
+          >
+            All
+          </button>
+          <button
+            type="button"
+            onClick={() => setFilterType("info")}
+            className={`cursor-pointer flex items-center justify-center rounded-full transition-colors size-7 ${filterType === "info"
+              ? "bg-action text-action-text shadow-sm"
+              : "text-muted-foreground hover:text-note-info hover:bg-base-surface"
+              }`}
+            title="Filter by Info"
+          >
+            <Info className="size-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setFilterType("alert")}
+            className={`cursor-pointer flex items-center justify-center rounded-full transition-colors size-7 ${filterType === "alert"
+              ? "bg-action text-action-text shadow-sm"
+              : "text-muted-foreground hover:text-note-alert hover:bg-base-surface"
+              }`}
+            title="Filter by Alert"
+          >
+            <AlertTriangle className="size-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setFilterType("idea")}
+            className={`cursor-pointer flex items-center justify-center rounded-full transition-colors size-7 ${filterType === "idea"
+              ? "bg-action text-action-text shadow-sm"
+              : "text-muted-foreground hover:text-note-idea hover:bg-base-surface"
+              }`}
+            title="Filter by Idea"
+          >
+            <Lightbulb className="size-4" />
+          </button>
+        </div>
 
-	// Close menu when clicking outside
-	useEffect(() => {
-		const handleClickOutside = (event: MouseEvent) => {
-			if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-				setIsCopyMenuOpen(false);
-			}
-		};
-		if (isCopyMenuOpen) {
-			document.addEventListener("mousedown", handleClickOutside);
-		}
-		return () => {
-			document.removeEventListener("mousedown", handleClickOutside);
-		};
-	}, [isCopyMenuOpen]);
+        {/* 右側の検索窓とResolvedトグルもすべて rounded-full (カプセル) で統一 */}
+        <div className="flex items-center gap-1.5 flex-1 justify-end min-w-0">
+          {/* 検索窓コンテナ */}
+          <div className="relative flex items-center bg-base-bg border border-base-border/50 rounded-full px-2 py-0.5 flex-1 max-w-[140px]">
+            <Search className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder="Search..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full min-w-0 text-xs pl-1 bg-transparent border-none focus:outline-none placeholder:text-muted-foreground text-action"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                }}
+                onClick={() => {
+                  setSearchQuery("");
+                  inputRef.current?.focus();
+                }}
+                className="absolute right-1 cursor-pointer p-1 text-muted-foreground hover:text-action transition-colors shrink-0"
+                title="Clear search"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            )}
+          </div>
 
-	useEffect(() => {
-		if (isSearchOpen && inputRef.current) {
-			inputRef.current.focus();
-		}
-	}, [isSearchOpen]);
+          {/* Resolved Toggle: カプセル型へ一元化 */}
+          <button
+            type="button"
+            onClick={() => setShowResolved(!showResolved)}
+            className={`cursor-pointer flex items-center justify-center p-1.5 rounded-full border transition-colors shrink-0 size-7 ${showResolved
+              ? "bg-action border-action text-action-text"
+              : "bg-base-surface border-base-border text-muted-foreground hover:bg-base-bg"
+              }`}
+            title="Show/Hide Resolved Notes"
+          >
+            <CheckSquare className="size-4" />
+          </button>
+        </div>
+      </div>
 
-	return (
-		<div className="bg-base-surface border-b border-base-border px-3 py-2 flex flex-col gap-2.5 z-20 w-full min-w-0">
-			{/* Scope Tabs: カプセル背景の中に綺麗に整列 */}
-			<div className="grid grid-cols-3 gap-1 bg-base-bg p-1 rounded-full border border-base-border/50">
-				<button
-					type="button"
-					onClick={() => setViewScope("exact")}
-					className={`cursor-pointer py-1.5 text-xs font-bold rounded-full transition-all text-center ${
-						viewScope === "exact"
-							? "bg-action text-action-text shadow-sm"
-							: "text-muted-foreground hover-safe:bg-base-surface/50"
-					}`}
-				>
-					Page
-				</button>
-				<button
-					type="button"
-					onClick={() => setViewScope("domain")}
-					className={`cursor-pointer py-1.5 text-xs font-bold rounded-full transition-all text-center ${
-						viewScope === "domain"
-							? "bg-action text-action-text shadow-sm"
-							: "text-muted-foreground hover-safe:bg-base-surface/50"
-					}`}
-				>
-					Domain
-				</button>
-				<button
-					type="button"
-					onClick={() => setViewScope("inbox")}
-					className={`cursor-pointer py-1.5 text-xs font-bold rounded-full transition-all text-center ${
-						viewScope === "inbox"
-							? "bg-action text-action-text shadow-sm"
-							: "text-muted-foreground hover-safe:bg-base-surface/50"
-					}`}
-				>
-					Inbox
-				</button>
-			</div>
-
-			<div className="flex items-center justify-between gap-2 w-full">
-				{/* Note Type Filter: rounded-full に統一 */}
-				<div className="flex bg-base-bg p-1 rounded-full border border-base-border/50 shrink-0">
-					<button
-						type="button"
-						onClick={() => setFilterType("all")}
-						className={`cursor-pointer py-1 px-2.5 rounded-full text-xs font-medium transition-colors ${
-							filterType === "all"
-								? "bg-action text-action-text shadow-sm"
-								: "text-muted-foreground hover-safe:text-action"
-						}`}
-					>
-						All
-					</button>
-					<button
-						type="button"
-						onClick={() => setFilterType("info")}
-						className={`cursor-pointer flex items-center justify-center rounded-full transition-colors size-7 ${
-							filterType === "info"
-								? "bg-action text-action-text shadow-sm"
-								: "text-muted-foreground hover-safe:text-note-info"
-						}`}
-						title="Filter by Info"
-					>
-						<Info className="w-3.5 h-3.5" />
-					</button>
-					<button
-						type="button"
-						onClick={() => setFilterType("alert")}
-						className={`cursor-pointer flex items-center justify-center rounded-full transition-colors size-7 ${
-							filterType === "alert"
-								? "bg-action text-action-text shadow-sm"
-								: "text-muted-foreground hover-safe:text-note-alert"
-						}`}
-						title="Filter by Alert"
-					>
-						<AlertTriangle className="w-3.5 h-3.5" />
-					</button>
-					<button
-						type="button"
-						onClick={() => setFilterType("idea")}
-						className={`cursor-pointer flex items-center justify-center rounded-full transition-colors size-7 ${
-							filterType === "idea"
-								? "bg-action text-action-text shadow-sm"
-								: "text-muted-foreground hover-safe:text-note-idea"
-						}`}
-						title="Filter by Idea"
-					>
-						<Lightbulb className="w-3.5 h-3.5" />
-					</button>
-				</div>
-
-				{/* 右側の検索窓とResolvedトグルもすべて rounded-full (カプセル) で統一 */}
-				<div className="flex items-center gap-1.5 flex-1 justify-end min-w-0">
-					{/* 検索窓コンテナ */}
-					<div className="relative flex items-center bg-base-bg border border-base-border/50 rounded-full px-2 py-0.5 flex-1 max-w-[140px]">
-						<Search className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
-						<input
-							ref={inputRef}
-							type="text"
-							placeholder="Search..."
-							value={searchQuery}
-							onChange={(e) => setSearchQuery(e.target.value)}
-							className="w-full min-w-0 text-xs pl-1 bg-transparent border-none focus:outline-none placeholder:text-muted-foreground text-action"
-						/>
-						{searchQuery && (
-							<button
-								type="button"
-								onMouseDown={(e) => {
-									e.preventDefault();
-								}}
-								onClick={() => {
-									setSearchQuery("");
-									inputRef.current?.focus();
-								}}
-								className="absolute right-1 cursor-pointer p-0.5 text-muted-foreground hover-safe:text-action transition-colors shrink-0"
-								title="Clear search"
-							>
-								<X className="w-3 h-3" />
-							</button>
-						)}
-					</div>
-
-					{/* Copy All Dropdown */}
-					<div className="relative" ref={menuRef}>
-						<button
-							type="button"
-							onClick={() => setIsCopyMenuOpen(!isCopyMenuOpen)}
-							className={`cursor-pointer flex items-center justify-center rounded-full transition-colors shrink-0 size-7 ${
-								isCopied
-									? "text-note-info bg-note-info/10"
-									: isCopyMenuOpen
-										? "text-action bg-base-bg"
-										: "text-muted-foreground hover-safe:text-action hover-safe:bg-base-bg"
-							}`}
-							title={isCopied ? "Copied!" : "Copy options"}
-							aria-label={isCopied ? "Copied!" : "Open copy options menu"}
-						>
-							{isCopied ? (
-								<Check className="w-3.5 h-3.5" />
-							) : (
-								<Copy className="w-3.5 h-3.5" />
-							)}
-						</button>
-
-						{isCopyMenuOpen && (
-							<div className="absolute right-0 top-full mt-1 bg-base-surface border border-base-border rounded shadow-md z-20 py-1 min-w-[120px]">
-								<button
-									type="button"
-									onClick={handleCopyText}
-									className="w-full text-left px-3 py-1.5 text-xs text-muted-foreground hover-safe:bg-base-bg transition-colors"
-								>
-									Copy as Text
-								</button>
-								<button
-									type="button"
-									onClick={handleCopyJson}
-									className="w-full text-left px-3 py-1.5 text-xs text-muted-foreground hover-safe:bg-base-bg transition-colors"
-								>
-									Copy as JSON
-								</button>
-							</div>
-						)}
-					</div>
-
-					{/* Resolved Toggle: カプセル型へ一元化 */}
-					<button
-						type="button"
-						onClick={() => setShowResolved(!showResolved)}
-						className={`cursor-pointer flex items-center justify-center p-1.5 rounded-full border transition-colors shrink-0 size-7 ${
-							showResolved
-								? "bg-action border-action text-action-text"
-								: "bg-base-surface border-base-border text-muted-foreground hover-safe:bg-base-bg"
-						}`}
-						title="Show/Hide Resolved Notes"
-					>
-						<CheckSquare className="w-3.5 h-3.5" />
-					</button>
-				</div>
-			</div>
-
-			{/* Tag Pills */}
-			{availableTags.length > 0 && (
-				<div className="relative w-full min-w-0 shrink-0 overflow-hidden">
-					<div className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-hide pr-12">
-						{availableTags.map((tag) => (
-							<button
-								key={tag}
-								type="button"
-								onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
-								className={`cursor-pointer whitespace-nowrap px-2 py-0.5 rounded-full text-[10px] font-medium border transition-colors ${
-									selectedTag === tag
-										? "bg-action text-action-text border-action"
-										: "bg-base-surface text-muted-foreground border-base-border hover-safe:border-action hover-safe:text-action"
-								}`}
-							>
-								#{tag}
-							</button>
-						))}
-					</div>
-					{/* 💡 Fade Mask */}
-					<div
-						className="absolute right-0 top-0 bottom-1 w-12 bg-linear-to-r from-transparent to-base-surface pointer-events-none"
-						aria-hidden="true"
-					/>
-				</div>
-			)}
-		</div>
-	);
+      {/* Tag Pills */}
+      {availableTags.length > 0 && (
+        <div className="relative w-full min-w-0 shrink-0 overflow-hidden">
+          <div className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-hide pr-12">
+            {availableTags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
+                className={`cursor-pointer whitespace-nowrap px-2 py-0.5 rounded-full text-[10px] font-medium border transition-colors ${selectedTag === tag
+                  ? "bg-action text-action-text border-action"
+                  : "bg-base-surface text-muted-foreground border-base-border hover:bg-base-bg hover:text-action"
+                  }`}
+              >
+                #{tag}
+              </button>
+            ))}
+          </div>
+          {/* 💡 Fade Mask */}
+          <div
+            className="absolute right-0 top-0 bottom-1 w-12 bg-linear-to-r from-transparent to-base-surface pointer-events-none"
+            aria-hidden="true"
+          />
+        </div>
+      )}
+    </div>
+  );
 }

--- a/apps/extension/src/components/NoteItem.tsx
+++ b/apps/extension/src/components/NoteItem.tsx
@@ -1,19 +1,19 @@
 import { getScopeUrls } from "@sitecue/shared";
 import {
-	AlertTriangle,
-	Check,
-	ChevronDown,
-	ChevronUp,
-	Copy,
-	Edit2,
-	Info,
-	Lightbulb,
-	Loader2,
-	Pin,
-	RotateCcw,
-	Star,
-	Trash2,
-	X,
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  Edit2,
+  Info,
+  Lightbulb,
+  Loader2,
+  Pin,
+  RotateCcw,
+  Star,
+  Trash2,
+  X,
 } from "lucide-react";
 import { useLayoutEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
@@ -25,433 +25,449 @@ import MarkdownRenderer from "./MarkdownRenderer";
 const COLLAPSE_THRESHOLD = 160;
 
 interface NoteItemProps {
-	note: Note;
-	currentFullUrl: string;
-	onUpdate: (
-		id: string,
-		content: string,
-		type: NoteType,
-		scope: NoteScope,
-	) => Promise<boolean>;
-	onDelete: (id: string) => Promise<boolean>;
-	onToggleResolved: (
-		id: string,
-		status: boolean | undefined,
-	) => Promise<boolean>;
-	onToggleFavorite: (note: Note) => Promise<boolean>;
-	onTogglePinned: (note: Note) => Promise<boolean>;
-	onMoveUp?: () => Promise<void>;
-	onMoveDown?: () => Promise<void>;
-	onToggleExpansion: (id: string, current: boolean) => Promise<boolean>;
-	isFavoriteList?: boolean;
-	isFirst?: boolean;
-	isLast?: boolean;
-	isSorting?: boolean;
+  note: Note;
+  currentFullUrl: string;
+  onUpdate: (
+    id: string,
+    content: string,
+    type: NoteType,
+    scope: NoteScope,
+  ) => Promise<boolean>;
+  onDelete: (id: string) => Promise<boolean>;
+  onToggleResolved: (
+    id: string,
+    status: boolean | undefined,
+  ) => Promise<boolean>;
+  onToggleFavorite: (note: Note) => Promise<boolean>;
+  onTogglePinned: (note: Note) => Promise<boolean>;
+  onMoveUp?: () => Promise<void>;
+  onMoveDown?: () => Promise<void>;
+  onToggleExpansion: (id: string, current: boolean) => Promise<boolean>;
+  isFavoriteList?: boolean;
+  isFirst?: boolean;
+  isLast?: boolean;
+  isSorting?: boolean;
 }
 
 export default function NoteItem({
-	note,
-	currentFullUrl,
-	onUpdate,
-	onDelete,
-	onToggleResolved,
-	onToggleFavorite,
-	onTogglePinned,
-	onMoveUp,
-	onMoveDown,
-	onToggleExpansion,
-	isFavoriteList = false,
-	isFirst = false,
-	isLast = false,
-	isSorting = false,
+  note,
+  currentFullUrl,
+  onUpdate,
+  onDelete,
+  onToggleResolved,
+  onToggleFavorite,
+  onTogglePinned,
+  onMoveUp,
+  onMoveDown,
+  onToggleExpansion,
+  isFavoriteList = false,
+  isFirst = false,
+  isLast = false,
+  isSorting = false,
 }: NoteItemProps) {
-	const [isEditing, setIsEditing] = useState(false);
-	const [editContent, setEditContent] = useState("");
-	const [editType, setEditType] = useState<NoteType>("info");
-	const [editScope, setEditScope] = useState<NoteScope>(note.scope);
-	const [updating, setUpdating] = useState(false);
-	const [copiedNoteId, setCopiedNoteId] = useState<string | null>(null);
-	const [isOverflowing, setIsOverflowing] = useState(false);
-	const [isSwapping, setIsSwapping] = useState(false);
-	const handleAutoIndent = useAutoIndent();
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState("");
+  const [editType, setEditType] = useState<NoteType>("info");
+  const [editScope, setEditScope] = useState<NoteScope>(note.scope);
+  const [updating, setUpdating] = useState(false);
+  const [copiedNoteId, setCopiedNoteId] = useState<string | null>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const [isSwapping, setIsSwapping] = useState(false);
+  const handleAutoIndent = useAutoIndent();
 
-	const contentRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Needed to recalculate height on content change
-	useLayoutEffect(() => {
-		if (contentRef.current) {
-			setIsOverflowing(contentRef.current.scrollHeight > COLLAPSE_THRESHOLD);
-		}
-	}, [note.content]);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Needed to recalculate height on content change
+  useLayoutEffect(() => {
+    if (contentRef.current) {
+      setIsOverflowing(contentRef.current.scrollHeight > COLLAPSE_THRESHOLD);
+    }
+  }, [note.content]);
 
-	const startEditing = () => {
-		setIsEditing(true);
-		setEditContent(note.content);
-		setEditType(note.note_type || "info");
-		setEditScope(note.scope);
-	};
+  const startEditing = () => {
+    setIsEditing(true);
+    setEditContent(note.content);
+    setEditType(note.note_type || "info");
+    setEditScope(note.scope);
+  };
 
-	const cancelEditing = () => {
-		setIsEditing(false);
-		setEditContent("");
-		setEditType("info");
-		setEditScope(note.scope);
-	};
+  const cancelEditing = () => {
+    setIsEditing(false);
+    setEditContent("");
+    setEditType("info");
+    setEditScope(note.scope);
+  };
 
-	const handleUpdate = async () => {
-		if (!editContent.trim()) return;
-		setUpdating(true);
-		const success = await onUpdate(note.id, editContent, editType, editScope);
-		if (success) {
-			setIsEditing(false);
-		}
-		setUpdating(false);
-	};
+  const handleUpdate = async () => {
+    if (!editContent.trim()) return;
+    setUpdating(true);
+    const success = await onUpdate(note.id, editContent, editType, editScope);
+    if (success) {
+      setIsEditing(false);
+    }
+    setUpdating(false);
+  };
 
-	const handleCopyNote = () => {
-		navigator.clipboard.writeText(note.content);
-		setCopiedNoteId(note.id);
-		toast("Copied to clipboard");
-		setTimeout(() => setCopiedNoteId(null), 2000);
-	};
+  const handleCopyNote = () => {
+    navigator.clipboard.writeText(note.content);
+    setCopiedNoteId(note.id);
+    toast("Copied to clipboard");
+    setTimeout(() => setCopiedNoteId(null), 2000);
+  };
 
-	const handleMoveUp = async () => {
-		if (!onMoveUp || isSwapping || isFirst) return;
-		setIsSwapping(true);
-		await onMoveUp();
-		setIsSwapping(false);
-	};
+  const handleMoveUp = async () => {
+    if (!onMoveUp || isSwapping || isFirst) return;
+    setIsSwapping(true);
+    await onMoveUp();
+    setIsSwapping(false);
+  };
 
-	const handleMoveDown = async () => {
-		if (!onMoveDown || isSwapping || isLast) return;
-		setIsSwapping(true);
-		await onMoveDown();
-		setIsSwapping(false);
-	};
+  const handleMoveDown = async () => {
+    if (!onMoveDown || isSwapping || isLast) return;
+    setIsSwapping(true);
+    await onMoveDown();
+    setIsSwapping(false);
+  };
 
-	let badgeBgColor = "bg-note-info/5";
-	let badgeTextColor = "text-note-info";
+  let badgeBgColor = "bg-note-info/5";
+  let badgeTextColor = "text-note-info";
 
-	if (note.note_type === "alert") {
-		badgeBgColor = "bg-note-alert/5";
-		badgeTextColor = "text-note-alert";
-	} else if (note.note_type === "idea") {
-		badgeBgColor = "bg-note-idea/5";
-		badgeTextColor = "text-note-idea";
-	}
+  if (note.note_type === "alert") {
+    badgeBgColor = "bg-note-alert/5";
+    badgeTextColor = "text-note-alert";
+  } else if (note.note_type === "idea") {
+    badgeBgColor = "bg-note-idea/5";
+    badgeTextColor = "text-note-idea";
+  }
 
-	const resolvedClasses = note.is_resolved ? "opacity-60 grayscale-[0.5]" : "";
-	const isCollapsed = isOverflowing && !note.is_expanded;
+  const resolvedClasses = note.is_resolved ? "opacity-60 grayscale-[0.5]" : "";
+  const isCollapsed = isOverflowing && !note.is_expanded;
 
-	return (
-		<div
-			className={`bg-base-bg p-4 rounded-xl border border-base-border shadow-sm transition-all group relative flex flex-col ${resolvedClasses}`}
-			style={{ contentVisibility: "auto" }}
-		>
-			{isEditing ? (
-				<div className="space-y-2">
-					<div className="flex items-center justify-between mb-2">
-						<div className="flex items-center gap-4 text-xs">
-							<label className="flex items-center gap-1.5 cursor-pointer text-action hover-safe:text-action-hover">
-								<input
-									type="radio"
-									name={`scope-${note.id}`}
-									checked={editScope === "exact"}
-									onChange={() => setEditScope("exact")}
-									className="accent-action focus:ring-action"
-								/>
-								<span>Page</span>
-							</label>
-							<label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover-safe:text-black">
-								<input
-									type="radio"
-									name={`scope-${note.id}`}
-									checked={editScope === "domain"}
-									onChange={() => setEditScope("domain")}
-									className="accent-action focus:ring-action"
-								/>
-								<span>Domain</span>
-							</label>
-							<label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover-safe:text-black">
-								<input
-									type="radio"
-									name={`scope-${note.id}`}
-									checked={editScope === "inbox"}
-									onChange={() => setEditScope("inbox")}
-									className="accent-action focus:ring-action"
-								/>
-								<span>Inbox</span>
-							</label>
-						</div>
-						<div className="flex bg-base-surface p-1 rounded-full border border-base-border/50 w-fit">
-							<button
-								type="button"
-								onClick={() => setEditType("info")}
-								className={`cursor-pointer flex items-center justify-center rounded-full size-7 transition-colors ${editType === "info" ? "bg-note-info text-action-text shadow-sm" : "text-muted-foreground hover-safe:text-note-info"}`}
-								title="Info"
-							>
-								<Info className="w-3.5 h-3.5" />
-							</button>
-							<button
-								type="button"
-								onClick={() => setEditType("alert")}
-								className={`cursor-pointer flex items-center justify-center rounded-full size-7 transition-colors ${editType === "alert" ? "bg-note-alert text-action-text shadow-sm" : "text-muted-foreground hover-safe:text-note-alert"}`}
-								title="Alert"
-							>
-								<AlertTriangle className="w-3.5 h-3.5" />
-							</button>
-							<button
-								type="button"
-								onClick={() => setEditType("idea")}
-								className={`cursor-pointer flex items-center justify-center rounded-full size-7 transition-colors ${editType === "idea" ? "bg-note-idea text-action-text shadow-sm" : "text-muted-foreground hover-safe:text-note-idea"}`}
-								title="Idea"
-							>
-								<Lightbulb className="w-3.5 h-3.5" />
-							</button>
-						</div>
-					</div>
-					<TextareaAutosize
-						value={editContent}
-						onChange={(e) => setEditContent(e.target.value)}
-						className="w-full border border-base-border rounded p-2 text-sm focus:outline-none focus:ring-2 focus:ring-action/5 resize-none bg-base-bg"
-						minRows={3}
-						autoFocus
-						onKeyDown={(e) => {
-							if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-								e.preventDefault();
-								handleUpdate();
-							} else {
-								handleAutoIndent(e);
-							}
-						}}
-					/>
-					<div className="flex justify-end gap-2">
-						<button
-							type="button"
-							onClick={cancelEditing}
-							className="cursor-pointer flex items-center justify-center rounded-full size-7 text-muted-foreground hover-safe:bg-base-surface transition-colors"
-							title="Cancel"
-						>
-							<X className="w-4 h-4" />
-						</button>
-						<button
-							type="button"
-							onClick={handleUpdate}
-							disabled={updating}
-							className="cursor-pointer flex items-center justify-center rounded-full size-7 bg-action text-action-text hover-safe:bg-action-hover disabled:opacity-50 transition-colors"
-							title="Save"
-						>
-							{updating ? (
-								<Loader2 className="w-4 h-4 animate-spin" />
-							) : (
-								<Check className="w-4 h-4" />
-							)}
-						</button>
-					</div>
-				</div>
-			) : (
-				<div className="flex flex-col flex-1">
-					{/* 🚀 2段構成 Sticky ヘッダーコンテナ (背景透過度を98%に高め、境界線を常時固定) */}
-					<div className="sticky top-0 z-10 bg-base-bg/98 backdrop-blur-xs pt-1 pb-2 border-b border-base-border/40 transition-colors flex flex-col gap-1.5">
-						{/* 1段目：メタデータ、タイプ、Pin/Star（固定アクション） */}
-						<div className="flex items-center justify-between w-full">
-							{/* 左側：Typeアイコン＋完了/未完了トグル (カプセル) */}
-							<button
-								type="button"
-								onClick={() => onToggleResolved(note.id, note.is_resolved)}
-								className={`group/icon relative flex items-center gap-1.5 px-2.5 py-1 rounded-full cursor-pointer transition-all ${badgeBgColor} ${badgeTextColor} hover-safe:opacity-80`}
-								title={
-									note.is_resolved ? "Mark as unresolved" : "Mark as resolved"
-								}
-							>
-								{/* アイコン部分 (通常時とホバー時で透過度を切り替え) */}
-								<div className="relative w-3.5 h-3.5 shrink-0">
-									<div className="absolute inset-0 transition-opacity group-hover/icon:opacity-0">
-										{note.note_type === "alert" && (
-											<AlertTriangle
-												className="w-3.5 h-3.5"
-												aria-hidden="true"
-											/>
-										)}
-										{note.note_type === "idea" && (
-											<Lightbulb className="w-3.5 h-3.5" aria-hidden="true" />
-										)}
-										{(note.note_type === "info" || !note.note_type) && (
-											<Info className="w-3.5 h-3.5" aria-hidden="true" />
-										)}
-									</div>
-									<div className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover/icon:opacity-100">
-										{note.is_resolved ? (
-											<RotateCcw className="w-3.5 h-3.5" aria-hidden="true" />
-										) : (
-											<Check className="w-3.5 h-3.5" aria-hidden="true" />
-										)}
-									</div>
-								</div>
+  return (
+    <div
+      className={`bg-base-bg p-2 rounded-xl border border-base-border transition-all group relative flex flex-col ${resolvedClasses}`}
+      style={{ contentVisibility: "auto" }}
+    >
+      {isEditing ? (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-4 text-xs">
+              <label className="flex items-center gap-1.5 cursor-pointer text-action hover:text-action-hover">
+                <input
+                  type="radio"
+                  name={`scope-${note.id}`}
+                  checked={editScope === "exact"}
+                  onChange={() => setEditScope("exact")}
+                  className="accent-action focus:ring-action"
+                />
+                <span>Page</span>
+              </label>
+              <label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover:text-black">
+                <input
+                  type="radio"
+                  name={`scope-${note.id}`}
+                  checked={editScope === "domain"}
+                  onChange={() => setEditScope("domain")}
+                  className="accent-action focus:ring-action"
+                />
+                <span>Domain</span>
+              </label>
+              <label className="flex items-center gap-1.5 cursor-pointer text-neutral-800 hover:text-black">
+                <input
+                  type="radio"
+                  name={`scope-${note.id}`}
+                  checked={editScope === "inbox"}
+                  onChange={() => setEditScope("inbox")}
+                  className="accent-action focus:ring-action"
+                />
+                <span>Inbox</span>
+              </label>
+            </div>
+            <div className="flex bg-base-surface p-1 rounded-full border border-base-border/50 w-fit">
+              <button
+                type="button"
+                onClick={() => setEditType("info")}
+                className={`cursor-pointer flex items-center justify-center rounded-full size-7 transition-colors ${editType === "info" ? "bg-note-info text-action-text shadow-sm" : "text-muted-foreground hover:text-note-info"}`}
+                title="Info"
+              >
+                <Info className="w-3.5 h-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setEditType("alert")}
+                className={`cursor-pointer flex items-center justify-center rounded-full size-7 transition-colors ${editType === "alert" ? "bg-note-alert text-action-text shadow-sm" : "text-muted-foreground hover:text-note-alert"}`}
+                title="Alert"
+              >
+                <AlertTriangle className="w-3.5 h-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setEditType("idea")}
+                className={`cursor-pointer flex items-center justify-center rounded-full size-7 transition-colors ${editType === "idea" ? "bg-note-idea text-action-text shadow-sm" : "text-muted-foreground hover:text-note-idea"}`}
+                title="Idea"
+              >
+                <Lightbulb className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          </div>
+          <TextareaAutosize
+            value={editContent}
+            onChange={(e) => setEditContent(e.target.value)}
+            className="w-full border border-base-border rounded p-2 text-sm focus:outline-none focus:ring-2 focus:ring-action/5 resize-none bg-base-bg"
+            minRows={3}
+            autoFocus
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                handleUpdate();
+              } else {
+                handleAutoIndent(e);
+              }
+            }}
+          />
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={cancelEditing}
+              className="cursor-pointer flex items-center justify-center rounded-full size-7 text-muted-foreground hover:bg-base-surface transition-colors"
+              title="Cancel"
+            >
+              <X className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              onClick={handleUpdate}
+              disabled={updating}
+              className="cursor-pointer flex items-center justify-center rounded-full size-7 bg-action text-action-text hover:bg-action-hover disabled:opacity-50 transition-colors"
+              title="Save"
+            >
+              {updating ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Check className="w-4 h-4" />
+              )}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col flex-1">
+          {/* 🚀 2段構成 Sticky ヘッダーコンテナ (完全不透明 bg-base-bg/100 化と下部境界線の常時明瞭化 border-b border-base-border/50) */}
+          <div className="sticky top-0 z-10 bg-base-bg transition-colors flex flex-col gap-0">
+            {/* 1段目：メタデータ、タイプ、Pin/Star（固定アクション） */}
+            <div className="flex items-center justify-between w-full p-1">
+              {/* 左側：Typeアイコン＋完了/未完了トグル (カプセル) */}
+              <button
+                type="button"
+                onClick={() => onToggleResolved(note.id, note.is_resolved)}
+                className={`group/icon relative flex items-center gap-1.5 px-2.5 py-1 rounded-full cursor-pointer transition-all ${badgeBgColor} ${badgeTextColor} hover:opacity-80`}
+                title={
+                  note.is_resolved ? "Mark as unresolved" : "Mark as resolved"
+                }
+              >
+                {/* アイコン部分 (通常時とホバー時で透過度を切り替え) */}
+                <div className="relative w-3.5 h-3.5 shrink-0">
+                  <div className="absolute inset-0 transition-opacity group-hover/icon:opacity-0">
+                    {note.note_type === "alert" && (
+                      <AlertTriangle
+                        className="w-3.5 h-3.5"
+                        aria-hidden="true"
+                      />
+                    )}
+                    {note.note_type === "idea" && (
+                      <Lightbulb className="w-3.5 h-3.5" aria-hidden="true" />
+                    )}
+                    {(note.note_type === "info" || !note.note_type) && (
+                      <Info className="w-3.5 h-3.5" aria-hidden="true" />
+                    )}
+                  </div>
+                  <div className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover/icon:opacity-100">
+                    {note.is_resolved ? (
+                      <RotateCcw className="w-3.5 h-3.5" aria-hidden="true" />
+                    ) : (
+                      <Check className="w-3.5 h-3.5" aria-hidden="true" />
+                    )}
+                  </div>
+                </div>
 
-								{/* テキスト部分 */}
-								<span
-									className={`text-[11px] font-bold tracking-wide uppercase ${note.is_resolved ? "line-through opacity-70" : ""}`}
-								>
-									{note.note_type || "info"}
-								</span>
-							</button>
+                {/* テキスト部分 */}
+                <span
+                  className={`text-[11px] font-bold tracking-wide uppercase ${note.is_resolved ? "line-through opacity-70" : ""}`}
+                >
+                  {note.note_type || "info"}
+                </span>
+              </button>
 
-							{/* 右側：固定アクション（正円絶対死守ルール適用 size-7） */}
-							<div className="flex items-center gap-1">
-								<button
-									type="button"
-									onClick={() => onToggleFavorite(note)}
-									className={`cursor-pointer size-7 rounded-full flex items-center justify-center transition-all ${note.is_favorite ? "text-action bg-action/5" : "text-muted-foreground hover-safe:bg-base-surface"}`}
-									title={
-										note.is_favorite
-											? "Remove from favorites"
-											: "Add to favorites"
-									}
-								>
-									<Star
-										className={`w-3.5 h-3.5 ${note.is_favorite ? "fill-current" : ""}`}
-									/>
-								</button>
-								<button
-									type="button"
-									onClick={() => onTogglePinned(note)}
-									className={`cursor-pointer size-7 rounded-full flex items-center justify-center transition-all ${note.is_pinned ? "text-action bg-action/5" : "text-muted-foreground hover-safe:bg-base-surface"}`}
-									title={note.is_pinned ? "Unpin note" : "Pin note"}
-								>
-									<Pin
-										className={`w-3.5 h-3.5 ${note.is_pinned ? "fill-current" : ""}`}
-									/>
-								</button>
-							</div>
-						</div>
+              {/* 右側：固定アクション（正円絶対死守ルール適用 size-7） */}
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => onToggleFavorite(note)}
+                  className={`cursor-pointer size-7 rounded-full flex items-center justify-center transition-all ${note.is_favorite ? "text-action bg-action/5" : "text-muted-foreground hover:bg-base-surface"}`}
+                  title={
+                    note.is_favorite
+                      ? "Remove from favorites"
+                      : "Add to favorites"
+                  }
+                >
+                  <Star
+                    className={`w-3.5 h-3.5 ${note.is_favorite ? "fill-current" : ""}`}
+                  />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onTogglePinned(note)}
+                  className={`cursor-pointer size-7 rounded-full flex items-center justify-center transition-all ${note.is_pinned ? "text-action bg-action/5" : "text-muted-foreground hover:bg-base-surface"}`}
+                  title={note.is_pinned ? "Unpin note" : "Pin note"}
+                >
+                  <Pin
+                    className={`w-3.5 h-3.5 ${note.is_pinned ? "fill-current" : ""}`}
+                  />
+                </button>
+              </div>
+            </div>
 
-						{/* 2段目：操作アクション群（バリアント競合を排除し、淡色での常時露出へシフト） */}
-						<div className="flex items-center justify-between w-full pt-1.5 transition-opacity duration-200 border-t border-base-border/20">
-							{/* 左側：並び替え操作（正円サイズロック size-6） */}
-							<div className="flex items-center gap-0.5 text-muted-foreground/50">
-								{!note.is_pinned ? (
-									<>
-										<button
-											type="button"
-											onClick={handleMoveUp}
-											disabled={isFirst || isSorting}
-											className="cursor-pointer size-6 rounded-full flex items-center justify-center text-muted-foreground/50 hover-safe:text-action hover-safe:bg-base-surface disabled:opacity-30 transition-colors"
-											title="Move up"
-										>
-											<ChevronUp className="w-3.5 h-3.5" />
-										</button>
-										<button
-											type="button"
-											onClick={handleMoveDown}
-											disabled={isLast || isSorting}
-											className="cursor-pointer size-6 rounded-full flex items-center justify-center text-muted-foreground/50 hover-safe:text-action hover-safe:bg-base-surface disabled:opacity-30 transition-colors"
-											title="Move down"
-										>
-											<ChevronDown className="w-3.5 h-3.5" />
-										</button>
-									</>
-								) : (
-									<span className="text-[10px] text-muted-foreground/60 font-medium pl-1">
-										Pinned
-									</span>
-								)}
-							</div>
+            {/* 🚀 2段目：並び替え、中央展開トグル、操作群の grid シンメトリー統合構造 */}
+            <div className="grid grid-cols-[1fr_auto_1fr] items-center w-full p-1 transition-opacity duration-200 border-t border-base-border/20">
+              {/* 左側：並び替え操作（justify-startを指定） */}
+              <div className="flex items-center gap-0.5 text-muted-foreground/50 justify-start">
+                {!note.is_pinned ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={handleMoveUp}
+                      disabled={isFirst || isSorting}
+                      className="hover:enabled:cursor-pointer size-6 rounded-full flex items-center justify-center text-muted-foreground/50 hover:enabled:text-action hover:enabled:bg-base-surface disabled:opacity-30 transition-colors"
+                      title="Move up"
+                    >
+                      <ChevronUp className="w-3.5 h-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleMoveDown}
+                      disabled={isLast || isSorting}
+                      className="hover:enabled:cursor-pointer size-6 rounded-full flex items-center justify-center text-muted-foreground/50 hover:enabled:text-action hover:enabled:bg-base-surface disabled:opacity-30 transition-colors"
+                      title="Move down"
+                    >
+                      <ChevronDown className="w-3.5 h-3.5" />
+                    </button>
+                  </>
+                ) : (
+                  <span className="text-[10px] text-muted-foreground/60 font-medium pl-1">
+                    Pinned
+                  </span>
+                )}
+              </div>
 
-							{/* 右側：共通アクション（Copy, Edit, Delete - 正円 size-7、通常時は淡色でノイズカット） */}
-							<div className="flex items-center gap-1 text-muted-foreground/50">
-								<button
-									type="button"
-									onClick={handleCopyNote}
-									className="cursor-pointer size-7 rounded-full flex items-center justify-center text-muted-foreground/60 hover-safe:text-action hover-safe:bg-base-surface transition-colors"
-									title="Copy note"
-								>
-									{copiedNoteId === note.id ? (
-										<Check className="w-3.5 h-3.5 text-note-info" />
-									) : (
-										<Copy className="w-3.5 h-3.5" />
-									)}
-								</button>
-								<button
-									type="button"
-									onClick={startEditing}
-									className="cursor-pointer size-7 rounded-full flex items-center justify-center text-muted-foreground/60 hover-safe:text-action hover-safe:bg-base-surface transition-colors"
-									title="Edit"
-								>
-									<Edit2 className="w-3.5 h-3.5" />
-								</button>
-								<button
-									type="button"
-									onClick={() => onDelete(note.id)}
-									className="cursor-pointer size-7 rounded-full flex items-center justify-center text-muted-foreground/60 hover-safe:text-note-alert hover-safe:bg-note-alert/10 transition-colors"
-									title="Delete"
-								>
-									<Trash2 className="w-3.5 h-3.5" />
-								</button>
-							</div>
-						</div>
-					</div>
+              {/* 🚀 中央：動的矢印アイコン付き「Read more / Show less」カプセルボタン */}
+              <div className="flex justify-center">
+                {isOverflowing && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onToggleExpansion(note.id, note.is_expanded ?? false)
+                    }
+                    className="cursor-pointer text-[10px] font-bold text-muted-foreground hover:text-action bg-base-surface hover:bg-base-border px-2.5 py-0.5 rounded-full shadow-xs flex items-center gap-1 transition-colors"
+                  >
+                    {note.is_expanded ? (
+                      <>
+                        <ChevronUp
+                          className="w-3 h-3 shrink-0"
+                          aria-hidden="true"
+                        />
+                        <span>Show less</span>
+                      </>
+                    ) : (
+                      <>
+                        <ChevronDown
+                          className="w-3 h-3 shrink-0"
+                          aria-hidden="true"
+                        />
+                        <span>Read more</span>
+                      </>
+                    )}
+                  </button>
+                )}
+              </div>
 
-					{/* 本文エリア (ヘッダー境界線の常時固定化に伴い、mt-3 に微調整して美しい空気感を確保) */}
-					<div className="mt-3 flex-1 min-w-0">
-						<div
-							className={`relative ${isCollapsed ? "max-h-40 overflow-hidden" : ""} w-full`}
-						>
-							<div
-								ref={contentRef}
-								className={`text-sm pt-1 pl-1 ${note.is_resolved ? "line-through text-muted-foreground" : "text-action"}`}
-							>
-								<MarkdownRenderer content={note.content} />
-							</div>
-							{isCollapsed && (
-								<div className="absolute bottom-0 left-0 w-full h-12 bg-linear-to-t from-base-bg to-transparent pointer-events-none" />
-							)}
-						</div>
+              {/* 右側：共通アクション（justify-endを指定） */}
+              <div className="flex items-center gap-1 text-muted-foreground/50 justify-end">
+                <button
+                  type="button"
+                  onClick={handleCopyNote}
+                  className="cursor-pointer size-7 rounded-full flex items-center justify-center text-muted-foreground/60 hover:text-action hover:bg-base-surface transition-colors"
+                  title="Copy note"
+                >
+                  {copiedNoteId === note.id ? (
+                    <Check className="w-3.5 h-3.5 text-note-info" />
+                  ) : (
+                    <Copy className="w-3.5 h-3.5" />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={startEditing}
+                  className="cursor-pointer size-7 rounded-full flex items-center justify-center text-muted-foreground/60 hover:text-action hover:bg-base-surface transition-colors"
+                  title="Edit"
+                >
+                  <Edit2 className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDelete(note.id)}
+                  className="cursor-pointer size-7 rounded-full flex items-center justify-center text-muted-foreground/60 hover:text-note-alert hover:bg-note-alert/10 transition-colors"
+                  title="Delete"
+                >
+                  <Trash2 className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            </div>
+          </div>
 
-						{/* 展開ボタン */}
-						{(isCollapsed || (note.is_expanded && isOverflowing)) && (
-							<div className="mt-1 flex justify-center relative z-10">
-								<button
-									type="button"
-									onClick={() =>
-										onToggleExpansion(note.id, note.is_expanded ?? false)
-									}
-									className="cursor-pointer text-[10px] text-muted-foreground hover-safe:text-action transition-colors bg-base-surface hover-safe:bg-base-border px-2 py-0.5 rounded-full"
-								>
-									{isCollapsed ? "Read more" : "Show less"}
-								</button>
-							</div>
-						)}
-					</div>
+          {/* 本文エリア (ヘッダー境界線の常時固定化に伴い、mt-3 に微調整して美しい空気感を確保) */}
+          <div className="mt-2 flex-1 min-w-0">
+            <div
+              className={`relative ${isCollapsed ? "max-h-40 overflow-hidden" : ""} w-full`}
+            >
+              <div
+                ref={contentRef}
+                className={`text-sm px-4 py-2 ${note.is_resolved ? "line-through text-muted-foreground" : "text-action"}`}
+              >
+                <MarkdownRenderer content={note.content} />
+              </div>
+              {isCollapsed && (
+                <div className="absolute bottom-0 left-0 w-full h-12 bg-linear-to-t from-base-bg to-transparent pointer-events-none" />
+              )}
+            </div>
+          </div>
 
-					{/* Favoriteリスト時のみのメタデータ（必要なら引き続き表示） */}
-					{isFavoriteList && note.scope !== "inbox" && (
-						<div className="text-[10px] text-muted-foreground flex items-center gap-2 mt-1">
-							<span
-								className={`px-2 py-0.5 rounded-full border ${note.scope === "exact" ? "bg-base-bg border-base-border text-gray-500" : "bg-base-surface border-base-border text-muted-foreground"}`}
-							>
-								{note.scope === "exact" ? "Page" : "Domain"}
-							</span>
-							{note.url_pattern !==
-								(note.scope === "domain"
-									? getScopeUrls(currentFullUrl).domain
-									: getScopeUrls(currentFullUrl).exact) && (
-								<a
-									href={`https://${note.url_pattern}`}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="flex items-center gap-1 hover-safe:text-blue-400 hover-safe:underline transition-colors max-w-48 truncate"
-									title={`Open ${note.url_pattern}`}
-								>
-									<span className="truncate hover-safe:text-action">
-										{note.url_pattern}
-									</span>
-								</a>
-							)}
-						</div>
-					)}
-				</div>
-			)}
-		</div>
-	);
+          {/* Favoriteリスト時のみのメタデータ（必要なら引き続き表示） */}
+          {isFavoriteList && note.scope !== "inbox" && (
+            <div className="text-[10px] text-muted-foreground flex items-center gap-2 mt-1">
+              <span
+                className={`px-2 py-0.5 rounded-full border ${note.scope === "exact" ? "bg-base-bg border-base-border text-gray-500" : "bg-base-surface border-base-border text-muted-foreground"}`}
+              >
+                {note.scope === "exact" ? "Page" : "Domain"}
+              </span>
+              {note.url_pattern !==
+                (note.scope === "domain"
+                  ? getScopeUrls(currentFullUrl).domain
+                  : getScopeUrls(currentFullUrl).exact) && (
+                  <a
+                    href={`https://${note.url_pattern}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 hover:text-blue-400 hover:underline transition-colors max-w-48 truncate"
+                    title={`Open ${note.url_pattern}`}
+                  >
+                    <span className="truncate hover:text-action">
+                      {note.url_pattern}
+                    </span>
+                  </a>
+                )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
-  "name": "sitecue",
-  "packageManager": "bun@1.2.2",
-  "version": "1.0.1",
-  "scripts": {
-    "dev": "turbo dev",
-    "build": "turbo build",
-    "db:start": "bun x supabase start",
-    "db:stop": "bun x supabase stop",
-    "stop": "bun x supabase stop",
-    "repomix:app": "tree -I \"node_modules|.git|.next|dist|build|.turbo|coverage|public|migrations|snippets|test_output.txt\" > project-tree.txt && repomix -c repomix-app.config.json && rm project-tree.txt",
-    "repomix:ext": "tree -I \"node_modules|.git|.next|dist|build|.turbo|coverage|public|migrations|snippets|test_output.txt\" > project-tree.txt && repomix -c repomix-ext.config.json && rm project-tree.txt"
-  },
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ],
-  "dependencies": {},
-  "devDependencies": {
-    "@biomejs/biome": "^2.4.10",
-    "turbo": "^2.8.21"
-  }
+	"name": "sitecue",
+	"packageManager": "bun@1.2.2",
+	"version": "1.0.1",
+	"scripts": {
+		"dev": "turbo dev",
+		"build": "turbo build",
+		"db:start": "bun x supabase start",
+		"db:stop": "bun x supabase stop",
+		"stop": "bun x supabase stop",
+		"repomix:app": "tree -I \"node_modules|.git|.next|dist|build|.turbo|coverage|public|migrations|snippets|test_output.txt\" > project-tree.txt && repomix -c repomix-app.config.json && rm project-tree.txt",
+		"repomix:ext": "tree -I \"node_modules|.git|.next|dist|build|.turbo|coverage|public|migrations|snippets|test_output.txt\" > project-tree.txt && repomix -c repomix-ext.config.json && rm project-tree.txt"
+	},
+	"workspaces": [
+		"apps/*",
+		"packages/*"
+	],
+	"dependencies": {},
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.10",
+		"turbo": "^2.8.21"
+	}
 }

--- a/packages/shared/src/dal/notes.ts
+++ b/packages/shared/src/dal/notes.ts
@@ -57,9 +57,10 @@ export async function createNoteEntity(
 			.eq("scope", payload.scope)
 			.order("sort_order", { ascending: true })
 			.limit(1);
-		
+
 		if (allFetchError) throw allFetchError;
-		newSortOrder = allNotes && allNotes.length > 0 ? allNotes[0].sort_order - 1.0 : 0.0;
+		newSortOrder =
+			allNotes && allNotes.length > 0 ? allNotes[0].sort_order - 1.0 : 0.0;
 	}
 
 	const insertData = {

--- a/packages/shared/src/utils/ordering.ts
+++ b/packages/shared/src/utils/ordering.ts
@@ -38,7 +38,10 @@ export function calculateOrderForDirection<T extends SortableItem>(
 		const twoAboveOrder = targetTwoAbove.sort_order ?? 0;
 
 		// 境界線ブロック自動解消（防壁ロジック）: 同値衝突または中間値計算限界の検知
-		if (Math.abs(currentOrder - targetAboveOrder) < EPSILON || Math.abs(targetAboveOrder - twoAboveOrder) < EPSILON) {
+		if (
+			Math.abs(currentOrder - targetAboveOrder) < EPSILON ||
+			Math.abs(targetAboveOrder - twoAboveOrder) < EPSILON
+		) {
 			return targetAboveOrder - OFFSET;
 		}
 
@@ -47,7 +50,10 @@ export function calculateOrderForDirection<T extends SortableItem>(
 		}
 
 		const mid = (targetAboveOrder + twoAboveOrder) / 2.0;
-		if (Math.abs(mid - targetAboveOrder) < EPSILON || Math.abs(mid - twoAboveOrder) < EPSILON) {
+		if (
+			Math.abs(mid - targetAboveOrder) < EPSILON ||
+			Math.abs(mid - twoAboveOrder) < EPSILON
+		) {
 			return targetAboveOrder - OFFSET;
 		}
 		return mid;
@@ -66,7 +72,10 @@ export function calculateOrderForDirection<T extends SortableItem>(
 		const twoBelowOrder = targetTwoBelow.sort_order ?? 0;
 
 		// 境界線ブロック自動解消（防壁ロジック）: 同値衝突または中間値計算限界の検知
-		if (Math.abs(currentOrder - targetBelowOrder) < EPSILON || Math.abs(targetBelowOrder - twoBelowOrder) < EPSILON) {
+		if (
+			Math.abs(currentOrder - targetBelowOrder) < EPSILON ||
+			Math.abs(targetBelowOrder - twoBelowOrder) < EPSILON
+		) {
 			return targetBelowOrder + OFFSET;
 		}
 
@@ -75,7 +84,10 @@ export function calculateOrderForDirection<T extends SortableItem>(
 		}
 
 		const mid = (targetBelowOrder + twoBelowOrder) / 2.0;
-		if (Math.abs(mid - targetBelowOrder) < EPSILON || Math.abs(mid - twoBelowOrder) < EPSILON) {
+		if (
+			Math.abs(mid - targetBelowOrder) < EPSILON ||
+			Math.abs(mid - twoBelowOrder) < EPSILON
+		) {
 			return targetBelowOrder + OFFSET;
 		}
 		return mid;


### PR DESCRIPTION
…sion toggle in sticky header

Why:
- To optimize structural role division and guarantee future extensibility by purging the "Copy All" action from the filtering context into a central command center.
- To maximize visual robustness and tactile accessibility during scrolling by making the stuck headers completely opaque and shifting the "Read more" toggle into the header bar.
- To repair a context-mixing bug where Next.js-specific mobile touch-safe variants (`hover-safe:`) were mistakenly applied to the PC-only extension layout, causing hover feedbacks to be dropped.

What:
- Reconstructed the old single-button row into a symmetrical 3-column grid action bar, locking the "+" button at the absolute center and moving the "Copy All" dropdown into the right column.
- Purged all legacy clipboard state, outside click handlers, and dropdown UI from `FilterBar.tsx`.
- Reinforced the sticky header container in `NoteItem.tsx` with full opacity (`bg-base-bg/100`) and a constant discrete bottom border.
- Integrated the card expansion logic into the second row of the header using a grid symmetric setup, embedding dynamic arrow icons (`ChevronUp`/`ChevronDown`) that adapt to the expansion state.
- Replaced all non-functional `hover-safe:` prefixes with standard native `hover:` classes across `SidePanel.tsx` and `NoteItem.tsx`, instantly reviving elegant gray circular hover feedback on the real browser.
- Adjusted related unit test scripts to support the new DOM hierarchy and unified state flow.