### PR TITLE
feat(app): add instant loading states for dashboard and notes

### DIFF
--- a/apps/app/src/app/(dashboard)/loading.tsx
+++ b/apps/app/src/app/(dashboard)/loading.tsx
@@ -1,0 +1,43 @@
+import { Activity, Layers } from "lucide-react";
+import {
+	ContributionTimelineSkeleton,
+	DomainDashboardGridSkeleton,
+	RadialActivityChartSkeleton,
+	TodayRecapCardSkeleton,
+} from "./_components/Skeletons";
+
+export default function DashboardLoading() {
+	return (
+		<div className="flex-1 bg-base-bg text-action font-sans overflow-y-auto">
+			<div className="mx-auto px-4 py-8 md:px-6 md:py-12 flex flex-col gap-12">
+				{/* ① [最上部] ダッシュボード */}
+				<section className="grid grid-cols-1 md:grid-cols-3 gap-6">
+					<TodayRecapCardSkeleton />
+					<RadialActivityChartSkeleton />
+				</section>
+
+				{/* ② [中央] Domain Activity 情報コンテナ */}
+				<section>
+					<div className="flex items-center gap-2 mb-6">
+						<Layers aria-hidden="true" className="w-5 h-5 text-neutral-400" />
+						<h2 className="text-3xl font-bold tracking-tight text-action">
+							Domain Activity
+						</h2>
+					</div>
+					<DomainDashboardGridSkeleton />
+				</section>
+
+				{/* ③ [下部] Contribution Activity タイムライン */}
+				<section className="pb-8">
+					<div className="flex items-center gap-2 mb-6">
+						<Activity aria-hidden="true" className="w-5 h-5 text-neutral-400" />
+						<h2 className="text-3xl font-bold tracking-tight text-action">
+							Activity Log
+						</h2>
+					</div>
+					<ContributionTimelineSkeleton />
+				</section>
+			</div>
+		</div>
+	);
+}

--- a/apps/app/src/app/(dashboard)/notes/loading.tsx
+++ b/apps/app/src/app/(dashboard)/notes/loading.tsx
@@ -1,0 +1,31 @@
+import { MiddlePaneListSkeleton } from "./_components/NotesSkeletons";
+import { ResponsiveNotesLayout } from "./_components/ResponsiveNotesLayout";
+
+export default function NotesLoading() {
+	return (
+		<ResponsiveNotesLayout
+			middleNode={
+				<div className="flex flex-col h-full bg-base-bg md:border-r md:border-base-border md:w-96">
+					{/* 1〜3段目の外殻ヘッダー構造を維持 */}
+					<div className="flex-shrink-0 p-4 space-y-3 border-b border-base-border bg-base-bg">
+						<div className="flex justify-start w-full items-center h-11">
+							<div className="grid grid-cols-4 gap-1 w-full bg-base-surface rounded-full p-1 h-10">
+								<div className="bg-action rounded-full h-full" />
+								<div className="rounded-full h-full" />
+								<div className="rounded-full h-full" />
+								<div className="rounded-full h-full" />
+							</div>
+						</div>
+						<div className="h-9 w-full bg-base-surface/50 rounded-full animate-pulse" />
+						<div className="h-10 w-full bg-base-surface/50 rounded-full animate-pulse" />
+					</div>
+					{/* リスト領域のみスケルトン */}
+					<MiddlePaneListSkeleton />
+				</div>
+			}
+			rightNode={null}
+			selectedDraftId={null}
+			selectedNoteId={null}
+		/>
+	);
+}


### PR DESCRIPTION
- Why:
  - Improve blank screen wait times during server response and hydration, especially on iPhone PWA or cold starts.
  - Maximize perceived speed by rendering identical-height skeletons at 0ms upon tap, following Next.js App Router Instant Loading conventions.

- What:
  - Add `apps/app/src/app/(dashboard)/loading.tsx` to instantly render skeleton layouts for top page (Launchpad) including TodayRecapCard, RadialActivityChart, DomainDashboardGrid, and ContributionTimeline.
  - Add `apps/app/src/app/(dashboard)/notes/loading.tsx` to instantly render responsive skeleton layouts for `/notes` including MiddlePaneListSkeleton.