### PR TITLE
feat(app): add service worker app shell caching and PWA metadata

### DIFF
--- a/apps/app/public/sw.js
+++ b/apps/app/public/sw.js
@@ -1,0 +1,63 @@
+const CACHE_NAME = "sitecue-app-shell-v1";
+const STATIC_ASSETS = [
+	"/",
+	"/notes",
+	"/logo.svg",
+	"/icon.ico",
+	"/apple-icon.png",
+];
+
+self.addEventListener("install", (event) => {
+	event.waitUntil(
+		caches.open(CACHE_NAME).then((cache) => {
+			return cache.addAll(STATIC_ASSETS);
+		}),
+	);
+	self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+	event.waitUntil(
+		caches.keys().then((keys) => {
+			return Promise.all(
+				keys.map((key) => {
+					if (key !== CACHE_NAME) {
+						return caches.delete(key);
+					}
+				}),
+			);
+		}),
+	);
+	self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+	if (event.request.method !== "GET") return;
+
+	const url = new URL(event.request.url);
+	// APIや認証関連リクエストはキャッシュ除外
+	if (
+		url.pathname.startsWith("/api/") ||
+		url.pathname.startsWith("/auth/")
+	) {
+		return;
+	}
+
+	event.respondWith(
+		caches.match(event.request).then((cachedResponse) => {
+			const fetchPromise = fetch(event.request)
+				.then((networkResponse) => {
+					if (networkResponse && networkResponse.status === 200) {
+						const responseToCache = networkResponse.clone();
+						caches.open(CACHE_NAME).then((cache) => {
+							cache.put(event.request, responseToCache);
+						});
+					}
+					return networkResponse;
+				})
+				.catch(() => cachedResponse);
+
+			return cachedResponse || fetchPromise;
+		}),
+	);
+});

--- a/apps/app/src/app/layout.tsx
+++ b/apps/app/src/app/layout.tsx
@@ -1,6 +1,9 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import localFont from "next/font/local";
+import { Toaster } from "react-hot-toast";
+import { ServiceWorkerRegister } from "@/components/pwa/ServiceWorkerRegister";
+import { QueryProvider } from "@/providers/QueryProvider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -31,12 +34,21 @@ const hackFont = localFont({
 });
 
 export const metadata: Metadata = {
-	title: "sitecue - context-aware notes",
-	description: "The simplest context-aware notepad for your browser.",
+	title: "sitecue",
+	description: "Context-aware note taking app",
+	appleWebApp: {
+		capable: true,
+		statusBarStyle: "black-translucent",
+		title: "sitecue",
+	},
 };
 
-import { Toaster } from "react-hot-toast";
-import { QueryProvider } from "@/providers/QueryProvider";
+export const viewport: Viewport = {
+	themeColor: "#0a0a0a",
+	width: "device-width",
+	initialScale: 1,
+	maximumScale: 1,
+};
 
 export default function RootLayout({
 	children,
@@ -49,6 +61,7 @@ export default function RootLayout({
 				className={`${geistSans.variable} ${geistMono.variable} ${hackFont.variable} antialiased`}
 			>
 				<QueryProvider>
+					<ServiceWorkerRegister />
 					{children}
 					<Toaster
 						position="top-center"

--- a/apps/app/src/app/manifest.ts
+++ b/apps/app/src/app/manifest.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+	return {
+		name: "sitecue",
+		short_name: "sitecue",
+		description: "Context-aware note taking app",
+		start_url: "/",
+		display: "standalone",
+		background_color: "#0a0a0a",
+		theme_color: "#0a0a0a",
+		icons: [
+			{
+				src: "/apple-icon.png",
+				sizes: "180x180",
+				type: "image/png",
+				purpose: "any",
+			},
+		],
+	};
+}

--- a/apps/app/src/components/pwa/ServiceWorkerRegister.tsx
+++ b/apps/app/src/components/pwa/ServiceWorkerRegister.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ServiceWorkerRegister() {
+	useEffect(() => {
+		if ("serviceWorker" in navigator && process.env.NODE_ENV === "production") {
+			navigator.serviceWorker
+				.register("/sw.js")
+				.catch((error) => console.error("SW registration failed:", error));
+		}
+	}, []);
+
+	return null;
+}


### PR DESCRIPTION
- Prevent white screen delay on iOS PWA cold start
- Implement stale-while-revalidate strategy in sw.js for App Shell
- Add web app manifest and iOS-specific meta tags
- Register service worker conditionally in production environments