### PR TITLE
feat(app): optimize PWA startup, enable RSC streaming, and enhance UI…

### DIFF
--- a/.agent/skills/basecamp-routing/SKILL.md
+++ b/.agent/skills/basecamp-routing/SKILL.md
@@ -39,6 +39,8 @@ App Basecamp（`apps/app/`）に新しい機能や画面を追加する場合、
 ## 5. Server Component Constraints (RSCの掟)
 - **イベントハンドラの禁止**: `page.tsx` や `layout.tsx` などの Server Component 内で、直接 `onClick` や `onChange` などのイベントハンドラを記述したり、`useState` などの React Hooks を呼び出したりすることは**厳禁**。
 - **解決策 (Expand & Contract)**: ボタンのクリックによるトースト通知や状態変更など、インタラクティブな処理が必要な場合は、そのボタン部分のみを純粋な Client Component (`"use client"`) として別ファイル（例: `_components/HogeButton.tsx`）に切り出し、Server Component にインポートして配置すること。
+- **RSC Top-level Blocking の禁止**: ダッシュボード等のポータルページにおいて、すべての通信フェッチを親の `page.tsx` 直下で一括 `await` してSSRレスポンスを止める実装を禁止する。必ずコンポーネント単位で `<Suspense>` を配置し、RSC Streaming を実現すること。
+- **ローカルURLに対する外部 Favicon API リクエストの遮断**: `localhost`, `127.0.0.1`, `0.0.0.0`, `.local` 等のローカルドメインに対しては、Google Favicon API 等の外部ネットワーク通信を呼び出さず、専用のフォールバックアイコン (`Laptop`) を返すこと。
 
 ## 6. Route Protection & Auth Constraints (多層防御の掟)
 - **オプトアウト方式の Middleware**:

--- a/apps/app/public/sw.js
+++ b/apps/app/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "sitecue-app-shell-v3";
+const CACHE_NAME = "sitecue-app-shell-v4";
 const STATIC_ASSETS = [
 	"/",
 	"/notes",
@@ -9,22 +9,22 @@ const STATIC_ASSETS = [
 
 self.addEventListener("install", (event) => {
 	event.waitUntil(
-		caches.open(CACHE_NAME).then((cache) => {
-			return cache.addAll(STATIC_ASSETS);
-		}),
+		caches.open(CACHE_NAME).then((cache) => cache.addAll(STATIC_ASSETS)),
 	);
 	self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
 	event.waitUntil(
-		caches.keys().then((keys) => {
-			return Promise.all(
-				keys
-					.filter((key) => key !== CACHE_NAME)
-					.map((key) => caches.delete(key)),
-			);
-		}),
+		caches
+			.keys()
+			.then((keys) =>
+				Promise.all(
+					keys
+						.filter((key) => key !== CACHE_NAME)
+						.map((key) => caches.delete(key)),
+				),
+			),
 	);
 	self.clients.claim();
 });
@@ -33,12 +33,36 @@ self.addEventListener("fetch", (event) => {
 	if (event.request.method !== "GET") return;
 
 	const url = new URL(event.request.url);
-	// API、認証、Web Manifest リクエストはキャッシュ除外
 	if (
 		url.pathname.startsWith("/api/") ||
 		url.pathname.startsWith("/auth/") ||
 		url.pathname.endsWith(".webmanifest")
 	) {
+		return;
+	}
+
+	const isDocument =
+		event.request.mode === "navigate" ||
+		event.request.headers.get("accept")?.includes("text/html");
+
+	if (isDocument) {
+		event.respondWith(
+			fetch(event.request)
+				.then((networkResponse) => {
+					if (networkResponse && networkResponse.status === 200) {
+						const responseToCache = networkResponse.clone();
+						caches.open(CACHE_NAME).then((cache) => {
+							cache.put(event.request, responseToCache);
+						});
+					}
+					return networkResponse;
+				})
+				.catch(() => {
+					return caches.match(event.request).then((cachedResponse) => {
+						return cachedResponse || caches.match("/");
+					});
+				}),
+		);
 		return;
 	}
 

--- a/apps/app/src/app/(dashboard)/_components/ContributionTimeline.tsx
+++ b/apps/app/src/app/(dashboard)/_components/ContributionTimeline.tsx
@@ -1,3 +1,4 @@
+import { buildNoteContextHref } from "@sitecue/shared";
 import type { User } from "@supabase/supabase-js";
 import { Edit3, FileText, Zap } from "lucide-react";
 import { CustomLink as Link } from "@/components/ui/custom-link";
@@ -16,6 +17,7 @@ export interface ActivityItem {
 	domain?: string;
 	noteType?: "info" | "alert" | "idea";
 	scope?: "exact" | "domain" | "inbox";
+	isResolved?: boolean;
 }
 
 export interface ActivityEvent {
@@ -69,7 +71,9 @@ export async function ContributionTimeline({ supabase, user }: Props) {
 	const [notesResult, draftsResult] = await Promise.all([
 		supabase
 			.from("sitecue_notes")
-			.select("id, content, scope, url_pattern, created_at, note_type")
+			.select(
+				"id, content, scope, url_pattern, created_at, note_type, is_resolved",
+			)
 			.eq("user_id", user.id)
 			.gte("created_at", dateStr)
 			.order("created_at", { ascending: false }),
@@ -109,6 +113,7 @@ export async function ContributionTimeline({ supabase, user }: Props) {
 			domain: extractDomain(note.url_pattern || ""),
 			noteType: (note.note_type as "info" | "alert" | "idea") || undefined,
 			scope: (note.scope as "exact" | "domain" | "inbox") || undefined,
+			isResolved: note.is_resolved,
 		});
 	}
 
@@ -203,15 +208,11 @@ export async function ContributionTimeline({ supabase, user }: Props) {
 											// ドラフト成果物はスタジオの動的ルートへダイレクトパス遷移
 											href = `/studio/${item.id}`;
 										} else {
-											// ノートはスコープに応じてパラメータを厳密に分離マッピング
-											if (item.scope === "inbox") {
-												href = `/notes?view=inbox&noteId=${item.id}`;
-											} else if (item.scope === "domain") {
-												href = `/notes?domain=${encodeURIComponent(item.title)}&view=domains&exact=all&noteId=${item.id}`;
-											} else if (item.scope === "exact") {
-												const targetDomain = item.domain || "inbox";
-												href = `/notes?domain=${encodeURIComponent(targetDomain)}&view=domains&exact=${encodeURIComponent(item.title)}&noteId=${item.id}`;
-											}
+											href = buildNoteContextHref({
+												id: item.id,
+												scope: item.scope,
+												url_pattern: item.title,
+											});
 										}
 
 										// 第1軸: ドットのカラー決定
@@ -273,7 +274,9 @@ export async function ContributionTimeline({ supabase, user }: Props) {
 															•
 														</span>
 														<span
-															className="truncate text-neutral-400 group-hover/item:text-neutral-500 transition-colors w-full leading-none"
+															className={`truncate text-neutral-400 group-hover/item:text-neutral-500 transition-colors w-full leading-none ${
+																item.isResolved ? "line-through opacity-50" : ""
+															}`}
 															title={contentPreview}
 														>
 															{contentPreview}

--- a/apps/app/src/app/(dashboard)/_components/DomainDashboardCard.test.tsx
+++ b/apps/app/src/app/(dashboard)/_components/DomainDashboardCard.test.tsx
@@ -6,86 +6,58 @@ import { DomainDashboardCard } from "./DomainDashboardCard";
 const mockData: DashboardDomainActivity = {
 	domain: "example.com",
 	total_count: 12,
-	domain_notes: [{ id: "1", content: "Domain note content" }],
+	domain_notes: [
+		{ id: "1", content: "Domain note content", is_resolved: false },
+	],
 	top_pages: [
 		{
 			page_url: "https://example.com/blog/1",
 			page_title: "React Hooks Guide",
 			page_count: 5,
-			page_notes: [{ id: "2", content: "Page note content" }],
+			page_notes: [
+				{ id: "2", content: "Page note content", is_resolved: true },
+			],
 		},
 	],
 };
 
 describe("DomainDashboardCard", () => {
-	it("renders domain and nested page structure with exact URL parameter routing and complete context links", () => {
+	it("renders domain and nested page structure with resolved note styling", () => {
 		render(<DomainDashboardCard data={mockData} />);
 
-		// ドメイン情報の検証
 		expect(screen.getByText("example.com")).toBeInTheDocument();
 		expect(screen.getByText("12 notes")).toBeInTheDocument();
-
-		// ネストされたページ情報の検証
 		expect(screen.getByText("React Hooks Guide")).toBeInTheDocument();
-		expect(screen.getByText("5 notes")).toBeInTheDocument();
 
-		// ドメインおよびページ直下のノートスニペットの検証
-		expect(screen.getByText("Domain note content")).toBeInTheDocument();
-		expect(screen.getByText("Page note content")).toBeInTheDocument();
-
-		// 英語ラベル化（日本語の排除）の検証
-		expect(screen.getByText("Open")).toBeInTheDocument();
-
-		// 各リンクが正しいクエリパラメータ（/notes?domain=... 形式）を持っているかの検証
-		const links = screen.getAllByRole("link");
-
-		const domainLink = links.find(
-			(l) =>
-				l.getAttribute("href") === "/notes?domain=example.com&view=domains",
-		);
-		const pageLink = links.find(
-			(l) =>
-				l.getAttribute("href") ===
-				`/notes?domain=example.com&view=domains&exact=${encodeURIComponent("https://example.com/blog/1")}`,
-		);
-		const externalDomainLink = links.find(
-			(l) => l.getAttribute("href") === "https://example.com",
-		);
-		const externalPageLink = links.find(
-			(l) => l.getAttribute("href") === "https://example.com/blog/1",
+		const activeNote = screen.getByText("Domain note content");
+		expect(activeNote).toBeInTheDocument();
+		expect(activeNote.className).not.toContain("line-through");
+		const domainNoteLink = activeNote.closest("a");
+		expect(domainNoteLink?.getAttribute("href")).toBe(
+			"/notes?domain=example.com&view=domains&exact=all&noteId=1",
 		);
 
-		// ノートスニペットからのコンテキスト付きダイレクト起動リンクの検証
-		const domainNoteLink = links.find(
-			(l) =>
-				l.getAttribute("href") ===
-				"/notes?domain=example.com&view=domains&noteId=1",
-		);
-		const pageNoteLink = links.find(
-			(l) =>
-				l.getAttribute("href") ===
-				`/notes?domain=example.com&view=domains&exact=${encodeURIComponent("https://example.com/blog/1")}&noteId=2`,
-		);
+		const resolvedNote = screen.getByText("Page note content");
+		expect(resolvedNote).toBeInTheDocument();
+		expect(resolvedNote.className).toContain("line-through");
+	});
 
-		expect(domainLink).toBeDefined();
-		expect(pageLink).toBeDefined();
-		expect(externalDomainLink).toBeDefined();
-		expect(externalPageLink).toBeDefined();
-		expect(domainNoteLink).toBeDefined();
-		expect(pageNoteLink).toBeDefined();
+	it("renders local domain with port correctly", () => {
+		const mockLocalData: DashboardDomainActivity = {
+			domain: "127.0.0.1:3000",
+			total_count: 2,
+			domain_notes: [
+				{ id: "1", content: "Local note content", is_resolved: false },
+			],
+			top_pages: [],
+		};
 
-		// Verify that Open link exists and routes correctly
-		const openLink = screen.getByRole("link", { name: /Open/i });
-		expect(openLink).toHaveAttribute(
-			"href",
-			"/notes?domain=example.com&view=domains",
-		);
+		render(<DomainDashboardCard data={mockLocalData} />);
 
-		// Verify title attributes for tooltips
-		const domainText = screen.getByText("example.com");
-		expect(domainText).toHaveAttribute("title", "example.com");
+		expect(screen.getByText("127.0.0.1:3000")).toBeInTheDocument();
+		expect(screen.getByText("2 notes")).toBeInTheDocument();
 
-		const pageLinkEl = screen.getByTitle("https://example.com/blog/1");
-		expect(pageLinkEl).toBeInTheDocument();
+		const activeNote = screen.getByText("Local note content");
+		expect(activeNote).toBeInTheDocument();
 	});
 });

--- a/apps/app/src/app/(dashboard)/_components/DomainDashboardCard.tsx
+++ b/apps/app/src/app/(dashboard)/_components/DomainDashboardCard.tsx
@@ -1,8 +1,11 @@
-import type { DashboardDomainActivity } from "@sitecue/shared";
+import {
+	buildNoteContextHref,
+	type DashboardDomainActivity,
+} from "@sitecue/shared";
 import { FileText, FolderOpen } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import { CustomLink as Link } from "@/components/ui/custom-link";
-import { DomainFavicon } from "./DomainFavicon"; //
+import { DomainFavicon } from "./DomainFavicon";
 
 const getFallbackPathname = (urlStr: string) => {
 	try {
@@ -30,7 +33,6 @@ export function DomainDashboardCard({ data }: Props) {
 						className="flex items-center gap-2 text-base-text hover-safe:text-action hover-safe:underline min-w-0"
 					>
 						<DomainFavicon domain={data.domain} />
-
 						<span
 							className="truncate block font-medium text-2xl"
 							title={data.domain}
@@ -58,8 +60,14 @@ export function DomainDashboardCard({ data }: Props) {
 					{data.domain_notes.map((note) => (
 						<Link
 							key={note.id}
-							href={`/notes?domain=${data.domain}&view=domains&noteId=${note.id}`}
-							className="text-xs font-normal text-neutral-600 hover-safe:text-action leading-tight truncate font-sans transition-colors block"
+							href={buildNoteContextHref({
+								id: note.id,
+								scope: "domain",
+								url_pattern: data.domain,
+							})}
+							className={`text-xs font-normal text-neutral-600 hover-safe:text-action leading-tight truncate font-sans transition-colors block ${
+								note.is_resolved ? "line-through opacity-50" : ""
+							}`}
 						>
 							<FileText
 								className="w-2.5 h-2.5 text-neutral-400 shrink-0 inline-block mr-1"
@@ -95,7 +103,6 @@ export function DomainDashboardCard({ data }: Props) {
 												domain={data.domain}
 												sizeClassName="w-3 h-3"
 											/>
-
 											<span className="text-base text-base-content line-clamp-1 truncate block min-w-0">
 												{page.page_title || getFallbackPathname(page.page_url)}
 											</span>
@@ -115,8 +122,14 @@ export function DomainDashboardCard({ data }: Props) {
 										{page.page_notes.map((note) => (
 											<Link
 												key={note.id}
-												href={`/notes?domain=${data.domain}&view=domains&exact=${encodeURIComponent(page.page_url)}&noteId=${note.id}`}
-												className="text-[11px] font-normal text-neutral-600 hover-safe:text-action leading-tight truncate font-sans transition-colors block"
+												href={buildNoteContextHref({
+													id: note.id,
+													scope: "exact",
+													url_pattern: page.page_url,
+												})}
+												className={`text-[11px] font-normal text-neutral-600 hover-safe:text-action leading-tight truncate font-sans transition-colors block ${
+													note.is_resolved ? "line-through opacity-50" : ""
+												}`}
 											>
 												<FileText
 													className="w-3 h-3 text-neutral-400 shrink-0 inline-block mr-1"

--- a/apps/app/src/app/(dashboard)/_components/DomainFavicon.tsx
+++ b/apps/app/src/app/(dashboard)/_components/DomainFavicon.tsx
@@ -1,11 +1,23 @@
 "use client";
 
-import { Globe } from "lucide-react";
+import { Globe, Laptop } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 interface DomainFaviconProps {
 	domain: string;
 	sizeClassName?: string;
+}
+
+function isLocalDomain(domain: string): boolean {
+	if (!domain) return false;
+	// ポート番号 (:3000 等) およびプロトコルや末尾スラッシュを除去した純粋なホスト名を抽出
+	const host = domain.toLowerCase().trim().split("/")[0].split(":")[0];
+	return (
+		host === "localhost" ||
+		host === "127.0.0.1" ||
+		host === "0.0.0.0" ||
+		host.endsWith(".local")
+	);
 }
 
 export function DomainFavicon({
@@ -15,7 +27,6 @@ export function DomainFavicon({
 	const [isFallback, setIsFallback] = useState(false);
 	const imgRef = useRef<HTMLImageElement>(null);
 
-	// useEffect を早期リターン（if文）よりも「上」に配置
 	useEffect(() => {
 		if (imgRef.current?.complete) {
 			if (
@@ -27,7 +38,15 @@ export function DomainFavicon({
 		}
 	}, []);
 
-	// 早期リターン（条件分岐でのUI変更）は、すべてのフックが宣言し終わった「後」に行う
+	if (isLocalDomain(domain)) {
+		return (
+			<Laptop
+				className={`${sizeClassName} text-neutral-400 shrink-0 object-contain align-middle`}
+				aria-hidden="true"
+			/>
+		);
+	}
+
 	if (isFallback || !domain) {
 		return (
 			<Globe

--- a/apps/app/src/app/(dashboard)/_components/RadialActivityChart.tsx
+++ b/apps/app/src/app/(dashboard)/_components/RadialActivityChart.tsx
@@ -1,5 +1,7 @@
+import { buildNoteContextHref } from "@sitecue/shared";
 import type { User } from "@supabase/supabase-js";
 import { Edit3, FileText } from "lucide-react";
+import { CustomLink as Link } from "@/components/ui/custom-link";
 import type { createClient } from "@/utils/supabase/server";
 
 type Props = {
@@ -7,12 +9,27 @@ type Props = {
 	user: User;
 };
 
+type RecentItem = {
+	id: string;
+	type: "note" | "draft";
+	title: string;
+	content: string;
+	isResolved?: boolean;
+	href: string;
+	createdAt: string;
+};
+
 export async function RadialActivityChart({ supabase, user }: Props) {
 	const sevenDaysAgo = new Date();
 	sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 	const dateStr = sevenDaysAgo.toISOString();
 
-	const [{ data: notes }, { data: drafts }] = await Promise.all([
+	const [
+		{ data: notes },
+		{ data: drafts },
+		{ data: recentNotes },
+		{ data: recentDrafts },
+	] = await Promise.all([
 		supabase
 			.from("sitecue_notes")
 			.select("id")
@@ -23,6 +40,18 @@ export async function RadialActivityChart({ supabase, user }: Props) {
 			.select("id")
 			.eq("user_id", user.id)
 			.gte("created_at", dateStr),
+		supabase
+			.from("sitecue_notes")
+			.select("id, content, is_resolved, scope, url_pattern, created_at")
+			.eq("user_id", user.id)
+			.order("created_at", { ascending: false })
+			.limit(5),
+		supabase
+			.from("sitecue_drafts")
+			.select("id, title, content, created_at")
+			.eq("user_id", user.id)
+			.order("created_at", { ascending: false })
+			.limit(5),
 	]);
 
 	const noteCount = notes?.length || 0;
@@ -47,115 +76,199 @@ export async function RadialActivityChart({ supabase, user }: Props) {
 	const c2 = 2 * Math.PI * r2;
 	const offset2 = c2 - (draftPct / 100) * c2;
 
+	// Combine and sort recent items
+	const rawRecentItems: RecentItem[] = [];
+
+	if (recentNotes) {
+		for (const n of recentNotes) {
+			const href = buildNoteContextHref({
+				id: n.id,
+				scope: n.scope,
+				url_pattern: n.url_pattern,
+			});
+			rawRecentItems.push({
+				id: n.id,
+				type: "note",
+				title: n.url_pattern || "Note",
+				content: n.content || "",
+				isResolved: n.is_resolved,
+				href,
+				createdAt: n.created_at,
+			});
+		}
+	}
+
+	if (recentDrafts) {
+		for (const d of recentDrafts) {
+			rawRecentItems.push({
+				id: d.id,
+				type: "draft",
+				title: d.title || "Untitled Draft",
+				content: d.content || "",
+				href: `/studio/${d.id}`,
+				createdAt: d.created_at,
+			});
+		}
+	}
+
+	const recentItems = rawRecentItems
+		.sort(
+			(a, b) =>
+				new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+		)
+		.slice(0, 5);
+
 	return (
-		<div className="flex flex-col md:flex-row items-center gap-6 p-6 rounded-xl border border-base-border md:col-span-2">
-			<div className="relative w-32 h-32 flex items-center justify-center shrink-0">
-				<svg
-					className="w-full h-full transform -rotate-90"
-					viewBox="0 0 160 160"
-					aria-label="Weekly activity circular progress chart"
-					role="img"
-				>
-					{/* Outer Track (Notes) */}
-					<circle
-						cx="80"
-						cy="80"
-						r={r1}
-						className="stroke-neutral-100 dark:stroke-neutral-800"
-						strokeWidth="8"
-						fill="transparent"
-					/>
-					{/* Outer Progress (Notes) */}
-					<circle
-						cx="80"
-						cy="80"
-						r={r1}
-						stroke="var(--color-note-info)"
-						strokeWidth="8"
-						fill="transparent"
-						strokeDasharray={c1}
-						strokeDashoffset={offset1}
-						strokeLinecap="round"
-						className="transition-all duration-500 ease-out"
-					/>
+		<div className="flex flex-col gap-6 p-6 rounded-xl border border-base-border md:col-span-2 h-full justify-between">
+			<div className="flex flex-col md:flex-row items-center gap-6 flex-1 my-auto">
+				<div className="relative w-32 h-32 flex items-center justify-center shrink-0">
+					<svg
+						className="w-full h-full transform -rotate-90"
+						viewBox="0 0 160 160"
+						aria-label="Weekly activity circular progress chart"
+						role="img"
+					>
+						{/* Outer Track (Notes) */}
+						<circle
+							cx="80"
+							cy="80"
+							r={r1}
+							className="stroke-neutral-100 dark:stroke-neutral-800"
+							strokeWidth="8"
+							fill="transparent"
+						/>
+						{/* Outer Progress (Notes) */}
+						<circle
+							cx="80"
+							cy="80"
+							r={r1}
+							stroke="var(--color-note-info)"
+							strokeWidth="8"
+							fill="transparent"
+							strokeDasharray={c1}
+							strokeDashoffset={offset1}
+							strokeLinecap="round"
+							className="transition-all duration-500 ease-out"
+						/>
 
-					{/* Inner Track (Drafts) */}
-					<circle
-						cx="80"
-						cy="80"
-						r={r2}
-						className="stroke-neutral-100 dark:stroke-neutral-800"
-						strokeWidth="8"
-						fill="transparent"
-					/>
-					{/* Inner Progress (Drafts) */}
-					<circle
-						cx="80"
-						cy="80"
-						r={r2}
-						stroke="var(--color-note-idea)"
-						strokeWidth="8"
-						fill="transparent"
-						strokeDasharray={c2}
-						strokeDashoffset={offset2}
-						strokeLinecap="round"
-						className="transition-all duration-500 ease-out"
-					/>
-				</svg>
+						{/* Inner Track (Drafts) */}
+						<circle
+							cx="80"
+							cy="80"
+							r={r2}
+							className="stroke-neutral-100 dark:stroke-neutral-800"
+							strokeWidth="8"
+							fill="transparent"
+						/>
+						{/* Inner Progress (Drafts) */}
+						<circle
+							cx="80"
+							cy="80"
+							r={r2}
+							stroke="var(--color-note-idea)"
+							strokeWidth="8"
+							fill="transparent"
+							strokeDasharray={c2}
+							strokeDashoffset={offset2}
+							strokeLinecap="round"
+							className="transition-all duration-500 ease-out"
+						/>
+					</svg>
 
-				{/* Center Content */}
-				<div className="absolute flex flex-col items-center justify-center text-center">
-					<span className="text-2xl font-bold tracking-tight text-action">
-						{noteCount + draftCount}
-					</span>
-					<span className="text-[8px] uppercase tracking-wider text-neutral-500 font-mono">
-						Activities
-					</span>
+					{/* Center Content */}
+					<div className="absolute flex flex-col items-center justify-center text-center">
+						<span className="text-2xl font-bold tracking-tight text-action">
+							{noteCount + draftCount}
+						</span>
+						<span className="text-[8px] uppercase tracking-wider text-neutral-500 font-mono">
+							Activities
+						</span>
+					</div>
+				</div>
+
+				<div className="flex-1 flex flex-col justify-center gap-4 w-full">
+					<div>
+						<h3 className="text-xl font-bold text-action">Weekly Progress</h3>
+						<p className="text-xs text-neutral-500 mt-0.5">
+							Your note-taking activity over the last 7 days.
+						</p>
+					</div>
+
+					<div className="flex flex-col gap-3">
+						{/* Notes captured row */}
+						<div className="flex items-center justify-between text-xs">
+							<div className="flex items-center gap-2">
+								<div className="w-2.5 h-2.5 rounded-full bg-note-info shrink-0" />
+								<FileText
+									className="w-3.5 h-3.5 text-neutral-500"
+									aria-hidden="true"
+								/>
+								<span className="font-medium text-action">Notes Captured</span>
+							</div>
+							<div className="font-mono text-neutral-600 font-bold text-sm">
+								{noteCount}
+							</div>
+						</div>
+
+						{/* Drafts created row */}
+						<div className="flex items-center justify-between text-xs">
+							<div className="flex items-center gap-2">
+								<div className="w-2.5 h-2.5 rounded-full bg-note-idea shrink-0" />
+								<Edit3
+									className="w-3.5 h-3.5 text-neutral-500"
+									aria-hidden="true"
+								/>
+								<span className="font-medium text-action">Drafts Created</span>
+							</div>
+							<div className="font-mono text-neutral-600 font-bold text-sm">
+								{draftCount}
+							</div>
+						</div>
+					</div>
 				</div>
 			</div>
 
-			<div className="flex-1 flex flex-col justify-center gap-4 w-full">
-				<div>
-					<h3 className="text-xl font-bold text-action">Weekly Progress</h3>
-					<p className="text-xs text-neutral-500 mt-0.5">
-						Your note-taking activity over the last 7 days.
-					</p>
-				</div>
-
-				<div className="flex flex-col gap-3">
-					{/* Notes captured row */}
-					<div className="flex items-center justify-between text-xs">
-						<div className="flex items-center gap-2">
-							<div className="w-2.5 h-2.5 rounded-full bg-note-info shrink-0" />
-							<FileText
-								className="w-3.5 h-3.5 text-neutral-500"
-								aria-hidden="true"
-							/>
-							<span className="font-medium text-action">Notes Captured</span>
-						</div>
-						{/* 分母表示（/ {targetNotes}）を完全に排除し、分子の実績のみを出力 */}
-						<div className="font-mono text-neutral-600 font-bold text-sm">
-							{noteCount}
-						</div>
+			{/* Recent Items Section */}
+			{recentItems.length > 0 && (
+				<div className="pt-4 border-t border-base-border/60 flex flex-col gap-2 w-full min-w-0 shrink-0">
+					<span className="text-[10px] font-mono uppercase tracking-wider text-neutral-400">
+						Recent Items
+					</span>
+					<div className="flex flex-col gap-1.5 w-full min-w-0">
+						{recentItems.map((item) => (
+							<Link
+								key={item.id}
+								href={item.href}
+								className="grid grid-cols-[14px_minmax(0,1fr)] gap-2 items-center text-xs text-neutral-600 hover-safe:text-action transition-colors w-full min-w-0"
+							>
+								<div className="shrink-0">
+									{item.type === "note" ? (
+										<FileText
+											className="w-3.5 h-3.5 text-neutral-400"
+											aria-hidden="true"
+										/>
+									) : (
+										<Edit3
+											className="w-3.5 h-3.5 text-neutral-400"
+											aria-hidden="true"
+										/>
+									)}
+								</div>
+								<span
+									className={`truncate font-sans ${
+										item.isResolved ? "line-through opacity-50" : ""
+									}`}
+									title={item.content || item.title}
+								>
+									{item.content
+										? item.content.replace(/[#*`-]/g, "")
+										: item.title}
+								</span>
+							</Link>
+						))}
 					</div>
-
-					{/* Drafts created row */}
-					<div className="flex items-center justify-between text-xs">
-						<div className="flex items-center gap-2">
-							<div className="w-2.5 h-2.5 rounded-full bg-note-idea shrink-0" />
-							<Edit3
-								className="w-3.5 h-3.5 text-neutral-500"
-								aria-hidden="true"
-							/>
-							<span className="font-medium text-action">Drafts Created</span>
-						</div>
-						{/* 分母表示（/ {targetDrafts}）を完全に排除し、分子の実績のみを出力 */}
-						<div className="font-mono text-neutral-600 font-bold text-sm">
-							{draftCount}
-						</div>
-					</div>
 				</div>
-			</div>
+			)}
 		</div>
 	);
 }

--- a/apps/app/src/app/(dashboard)/page.test.tsx
+++ b/apps/app/src/app/(dashboard)/page.test.tsx
@@ -2,7 +2,6 @@ import { act, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import LaunchpadPage from "./page";
 
-// Next.js Server Component mock for Supabase & Auth
 vi.mock("@/utils/supabase/server", () => {
 	const mockBuilder = {
 		select: vi.fn().mockReturnThis(),
@@ -35,49 +34,46 @@ vi.mock("@/utils/supabase/server", () => {
 	};
 });
 
-// Mock shared DAL functions
-vi.mock("@sitecue/shared", () => ({
-	fetchTopDomainActivity: vi.fn().mockResolvedValue([
-		{ domain: "github.com", noteCount: 5 },
-		{ domain: "127.0.0.1", noteCount: 2 }, // IP fallback test
-	]),
-	fetchDashboardDomainActivity: vi.fn().mockResolvedValue([
-		{ domain: "github.com", note_count: 5, domain_notes: [], top_pages: [] },
-		{ domain: "127.0.0.1", note_count: 2, domain_notes: [], top_pages: [] },
-	]),
-}));
+vi.mock("@sitecue/shared", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@sitecue/shared")>();
+	return {
+		...actual,
+		fetchTopDomainActivity: vi.fn().mockResolvedValue([
+			{ domain: "github.com", noteCount: 5 },
+			{ domain: "127.0.0.1", noteCount: 2 },
+		]),
+		fetchDashboardDomainActivity: vi.fn().mockResolvedValue([
+			{
+				domain: "github.com",
+				total_count: 5,
+				domain_notes: [
+					{ id: "n1", content: "GitHub Note", is_resolved: false },
+				],
+				top_pages: [],
+			},
+			{
+				domain: "127.0.0.1",
+				total_count: 2,
+				domain_notes: [{ id: "n2", content: "Local Note", is_resolved: true }],
+				top_pages: [],
+			},
+		]),
+	};
+});
 
-describe("LaunchpadPage - High Density Linear Style UI", () => {
-	it("renders refined sections correctly", async () => {
-		// Resolve Async Server Component
+describe("LaunchpadPage - RSC Streaming & Dashboard UI", () => {
+	it("renders all streaming sections correctly including Recent Items and local domain icon", async () => {
 		const PageComponent = await LaunchpadPage();
 
 		await act(async () => {
 			render(PageComponent);
 		});
 
-		// 1. Verify voxel bar capacity metrics text is completely removed
-		expect(
-			screen.queryByText("Total processed capacity"),
-		).not.toBeInTheDocument();
-		expect(
-			screen.queryByText("Total processed capacity: 42 notes"),
-		).not.toBeInTheDocument();
-
-		// 2. Verify new dashboard sections render correctly
 		expect(await screen.findByText("Weekly Progress")).toBeInTheDocument();
-		expect(await screen.findByText("Notes Captured")).toBeInTheDocument();
-		expect(await screen.findByText("Drafts Created")).toBeInTheDocument();
-
-		// 3. Verify Today's Focus / Recap section renders
 		expect(await screen.findByText("Today's Focus")).toBeInTheDocument();
-
-		// 4. Verify Domain Activity grid header and cards render (including IP domain)
 		expect(await screen.findByText("Domain Activity")).toBeInTheDocument();
 		expect(await screen.findByText("github.com")).toBeInTheDocument();
 		expect(await screen.findByText("127.0.0.1")).toBeInTheDocument();
-
-		// 5. Verify Activity Log timeline renders
 		expect(await screen.findByText("Activity Log")).toBeInTheDocument();
 	});
 });

--- a/apps/app/src/app/(dashboard)/page.tsx
+++ b/apps/app/src/app/(dashboard)/page.tsx
@@ -15,6 +15,8 @@ import {
 	TodayRecapCardSkeleton,
 } from "./_components/Skeletons";
 
+export const dynamic = "force-dynamic";
+
 type ComponentAuthProps = {
 	supabase: Awaited<ReturnType<typeof createClient>>;
 	user: User;

--- a/apps/app/src/components/dialogs/GlobalNewNoteDialog.test.tsx
+++ b/apps/app/src/components/dialogs/GlobalNewNoteDialog.test.tsx
@@ -10,9 +10,14 @@ import { GlobalNewNoteDialog } from "./GlobalNewNoteDialog";
 // next/navigation のモック
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
+const mockRefresh = vi.fn();
 const mockUseSearchParams = vi.fn();
 vi.mock("next/navigation", () => ({
-	useRouter: () => ({ push: mockPush, replace: mockReplace }),
+	useRouter: () => ({
+		push: mockPush,
+		replace: mockReplace,
+		refresh: mockRefresh,
+	}),
 	useSearchParams: () => mockUseSearchParams(),
 }));
 

--- a/apps/app/src/components/dialogs/GlobalNewNoteDialog.tsx
+++ b/apps/app/src/components/dialogs/GlobalNewNoteDialog.tsx
@@ -5,6 +5,7 @@ import type {
 	Note,
 	ViewScope as NoteScope,
 } from "@sitecue/shared";
+import { APP_LIMITS } from "@sitecue/shared";
 import { CalendarDays, Inbox, PenTool } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -14,7 +15,6 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { APP_LIMITS } from "@sitecue/shared";
 import { useAppendDiary } from "@/hooks/useDiariesQuery";
 import { useCreateNote } from "@/hooks/useNotesQuery";
 import { cn } from "@/lib/utils";
@@ -140,6 +140,7 @@ export function GlobalNewNoteDialog() {
 					text: capturedContent,
 				});
 				toast.success("Logged");
+				router.refresh();
 				return;
 			}
 
@@ -152,6 +153,7 @@ export function GlobalNewNoteDialog() {
 
 			await createNoteMutation.mutateAsync(input);
 			toast.success("Saved");
+			router.refresh();
 		} catch (err: unknown) {
 			console.error("Failed to save via background pipeline:", err);
 			const errorMessage =

--- a/apps/app/src/components/pwa/ServiceWorkerRegister.tsx
+++ b/apps/app/src/components/pwa/ServiceWorkerRegister.tsx
@@ -1,15 +1,43 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 
 export function ServiceWorkerRegister() {
+	const router = useRouter();
+
 	useEffect(() => {
-		if ("serviceWorker" in navigator && process.env.NODE_ENV === "production") {
-			navigator.serviceWorker
-				.register("/sw.js")
-				.catch((error) => console.error("SW registration failed:", error));
+		if (
+			!("serviceWorker" in navigator) ||
+			process.env.NODE_ENV !== "production"
+		) {
+			return;
 		}
-	}, []);
+
+		navigator.serviceWorker
+			.register("/sw.js")
+			.catch((error) => console.error("SW registration failed:", error));
+
+		const handleRefresh = async () => {
+			if (document.visibilityState === "visible") {
+				try {
+					const registration = await navigator.serviceWorker.ready;
+					await registration.update();
+				} catch (e) {
+					console.error("SW update failed:", e);
+				}
+				router.refresh();
+			}
+		};
+
+		window.addEventListener("visibilitychange", handleRefresh);
+		window.addEventListener("focus", handleRefresh);
+
+		return () => {
+			window.removeEventListener("visibilitychange", handleRefresh);
+			window.removeEventListener("focus", handleRefresh);
+		};
+	}, [router]);
 
 	return null;
 }

--- a/packages/shared/src/dal/profiles.test.ts
+++ b/packages/shared/src/dal/profiles.test.ts
@@ -60,7 +60,9 @@ describe("Shared DAL: profiles (Lazy Reset)", () => {
 			error: null,
 		});
 
-		const mockUpdateSelect = vi.fn().mockReturnValue({ single: mockSingleUpdate });
+		const mockUpdateSelect = vi
+			.fn()
+			.mockReturnValue({ single: mockSingleUpdate });
 		const mockUpdateEq = vi.fn().mockReturnValue({ select: mockUpdateSelect });
 		const mockUpdate = vi.fn().mockReturnValue({ eq: mockUpdateEq });
 

--- a/packages/shared/src/types/app.ts
+++ b/packages/shared/src/types/app.ts
@@ -34,6 +34,7 @@ export type PinnedSite = SitecuePinnedSiteBase;
 export interface DashboardSnippetNote {
 	id: string;
 	content: string;
+	is_resolved: boolean;
 }
 
 export interface DashboardPageActivity {

--- a/packages/shared/src/types/supabase.ts
+++ b/packages/shared/src/types/supabase.ts
@@ -1,633 +1,635 @@
 export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+	| string
+	| number
+	| boolean
+	| null
+	| { [key: string]: Json | undefined }
+	| Json[];
 
 export type Database = {
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-  public: {
-    Tables: {
-      sitecue_diaries: {
-        Row: {
-          content: string
-          created_at: string
-          date: string
-          topics: string[]
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          content?: string
-          created_at?: string
-          date: string
-          topics?: string[]
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          content?: string
-          created_at?: string
-          date?: string
-          topics?: string[]
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
-      sitecue_domain_settings: {
-        Row: {
-          color: string | null
-          created_at: string
-          domain: string
-          id: string
-          label: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          color?: string | null
-          created_at?: string
-          domain: string
-          id?: string
-          label?: string | null
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          color?: string | null
-          created_at?: string
-          domain?: string
-          id?: string
-          label?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
-      sitecue_drafts: {
-        Row: {
-          content: string | null
-          created_at: string
-          id: string
-          metadata: Json | null
-          tags: string[] | null
-          template_id: string | null
-          title: string | null
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          content?: string | null
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          tags?: string[] | null
-          template_id?: string | null
-          title?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Update: {
-          content?: string | null
-          created_at?: string
-          id?: string
-          metadata?: Json | null
-          tags?: string[] | null
-          template_id?: string | null
-          title?: string | null
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "sitecue_drafts_template_id_fkey"
-            columns: ["template_id"]
-            isOneToOne: false
-            referencedRelation: "sitecue_templates"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      sitecue_links: {
-        Row: {
-          created_at: string
-          domain: string
-          id: string
-          label: string
-          target_url: string
-          type: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          domain: string
-          id?: string
-          label: string
-          target_url: string
-          type: string
-          user_id?: string
-        }
-        Update: {
-          created_at?: string
-          domain?: string
-          id?: string
-          label?: string
-          target_url?: string
-          type?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
-      sitecue_notes: {
-        Row: {
-          content: string
-          created_at: string
-          draft_id: string | null
-          id: string
-          is_expanded: boolean
-          is_favorite: boolean
-          is_pinned: boolean
-          is_resolved: boolean
-          note_type: string
-          scope: string
-          sort_order: number
-          tags: string[] | null
-          updated_at: string
-          url_pattern: string
-          user_id: string
-        }
-        Insert: {
-          content: string
-          created_at?: string
-          draft_id?: string | null
-          id?: string
-          is_expanded?: boolean
-          is_favorite?: boolean
-          is_pinned?: boolean
-          is_resolved?: boolean
-          note_type?: string
-          scope?: string
-          sort_order?: number
-          tags?: string[] | null
-          updated_at?: string
-          url_pattern: string
-          user_id: string
-        }
-        Update: {
-          content?: string
-          created_at?: string
-          draft_id?: string | null
-          id?: string
-          is_expanded?: boolean
-          is_favorite?: boolean
-          is_pinned?: boolean
-          is_resolved?: boolean
-          note_type?: string
-          scope?: string
-          sort_order?: number
-          tags?: string[] | null
-          updated_at?: string
-          url_pattern?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "sitecue_notes_draft_id_fkey"
-            columns: ["draft_id"]
-            isOneToOne: false
-            referencedRelation: "sitecue_drafts"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-      sitecue_pinned_sites: {
-        Row: {
-          created_at: string
-          id: string
-          title: string
-          url: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          title: string
-          url: string
-          user_id?: string
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          title?: string
-          url?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
-      sitecue_profiles: {
-        Row: {
-          ai_usage_count: number
-          ai_usage_reset_at: string | null
-          created_at: string
-          id: string
-          plan: string
-        }
-        Insert: {
-          ai_usage_count?: number
-          ai_usage_reset_at?: string | null
-          created_at?: string
-          id: string
-          plan?: string
-        }
-        Update: {
-          ai_usage_count?: number
-          ai_usage_reset_at?: string | null
-          created_at?: string
-          id?: string
-          plan?: string
-        }
-        Relationships: []
-      }
-      sitecue_templates: {
-        Row: {
-          boilerplate: string | null
-          created_at: string
-          icon: string | null
-          id: string
-          max_length: number | null
-          name: string
-          updated_at: string
-          user_id: string
-          weave_prompt: string | null
-        }
-        Insert: {
-          boilerplate?: string | null
-          created_at?: string
-          icon?: string | null
-          id?: string
-          max_length?: number | null
-          name: string
-          updated_at?: string
-          user_id: string
-          weave_prompt?: string | null
-        }
-        Update: {
-          boilerplate?: string | null
-          created_at?: string
-          icon?: string | null
-          id?: string
-          max_length?: number | null
-          name?: string
-          updated_at?: string
-          user_id?: string
-          weave_prompt?: string | null
-        }
-        Relationships: []
-      }
-      todo01_profiles: {
-        Row: {
-          created_at: string
-          display_name: string | null
-          id: string
-          updated_at: string
-        }
-        Insert: {
-          created_at?: string
-          display_name?: string | null
-          id: string
-          updated_at?: string
-        }
-        Update: {
-          created_at?: string
-          display_name?: string | null
-          id?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
-      todo01_tasks: {
-        Row: {
-          created_at: string
-          id: string
-          is_complete: boolean | null
-          title: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          id?: string
-          is_complete?: boolean | null
-          title: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          id?: string
-          is_complete?: boolean | null
-          title?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "todo01_tasks_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "todo01_profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      check_array_elements_length: {
-        Args: { arr: string[]; max_len: number }
-        Returns: boolean
-      }
-      get_dashboard_domain_activity: {
-        Args: { p_limit?: number; p_user_id: string }
-        Returns: Json
-      }
-      get_drafts_by_date: {
-        Args: { p_date: string; p_user_id: string }
-        Returns: {
-          content: string | null
-          created_at: string
-          id: string
-          metadata: Json | null
-          tags: string[] | null
-          template_id: string | null
-          title: string | null
-          updated_at: string
-          user_id: string
-        }[]
-        SetofOptions: {
-          from: "*"
-          to: "sitecue_drafts"
-          isOneToOne: false
-          isSetofReturn: true
-        }
-      }
-      get_matching_notes: {
-        Args: { p_domain: string; p_exact: string }
-        Returns: {
-          content: string
-          created_at: string
-          draft_id: string | null
-          id: string
-          is_expanded: boolean
-          is_favorite: boolean
-          is_pinned: boolean
-          is_resolved: boolean
-          note_type: string
-          scope: string
-          sort_order: number
-          tags: string[] | null
-          updated_at: string
-          url_pattern: string
-          user_id: string
-        }[]
-        SetofOptions: {
-          from: "*"
-          to: "sitecue_notes"
-          isOneToOne: false
-          isSetofReturn: true
-        }
-      }
-      get_notes_by_date: {
-        Args: { p_date: string; p_user_id: string }
-        Returns: {
-          content: string
-          created_at: string
-          draft_id: string | null
-          id: string
-          is_expanded: boolean
-          is_favorite: boolean
-          is_pinned: boolean
-          is_resolved: boolean
-          note_type: string
-          scope: string
-          sort_order: number
-          tags: string[] | null
-          updated_at: string
-          url_pattern: string
-          user_id: string
-        }[]
-        SetofOptions: {
-          from: "*"
-          to: "sitecue_notes"
-          isOneToOne: false
-          isSetofReturn: true
-        }
-      }
-      search_drafts: {
-        Args: { search_query: string }
-        Returns: {
-          content: string | null
-          created_at: string
-          id: string
-          metadata: Json | null
-          tags: string[] | null
-          template_id: string | null
-          title: string | null
-          updated_at: string
-          user_id: string
-        }[]
-        SetofOptions: {
-          from: "*"
-          to: "sitecue_drafts"
-          isOneToOne: false
-          isSetofReturn: true
-        }
-      }
-      search_notes: {
-        Args: { search_query: string }
-        Returns: {
-          content: string
-          created_at: string
-          draft_id: string | null
-          id: string
-          is_expanded: boolean
-          is_favorite: boolean
-          is_pinned: boolean
-          is_resolved: boolean
-          note_type: string
-          scope: string
-          sort_order: number
-          tags: string[] | null
-          updated_at: string
-          url_pattern: string
-          user_id: string
-        }[]
-        SetofOptions: {
-          from: "*"
-          to: "sitecue_notes"
-          isOneToOne: false
-          isSetofReturn: true
-        }
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+	graphql_public: {
+		Tables: {
+			[_ in never]: never;
+		};
+		Views: {
+			[_ in never]: never;
+		};
+		Functions: {
+			graphql: {
+				Args: {
+					extensions?: Json;
+					operationName?: string;
+					query?: string;
+					variables?: Json;
+				};
+				Returns: Json;
+			};
+		};
+		Enums: {
+			[_ in never]: never;
+		};
+		CompositeTypes: {
+			[_ in never]: never;
+		};
+	};
+	public: {
+		Tables: {
+			sitecue_diaries: {
+				Row: {
+					content: string;
+					created_at: string;
+					date: string;
+					topics: string[];
+					updated_at: string;
+					user_id: string;
+				};
+				Insert: {
+					content?: string;
+					created_at?: string;
+					date: string;
+					topics?: string[];
+					updated_at?: string;
+					user_id: string;
+				};
+				Update: {
+					content?: string;
+					created_at?: string;
+					date?: string;
+					topics?: string[];
+					updated_at?: string;
+					user_id?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_domain_settings: {
+				Row: {
+					color: string | null;
+					created_at: string;
+					domain: string;
+					id: string;
+					label: string | null;
+					updated_at: string;
+					user_id: string;
+				};
+				Insert: {
+					color?: string | null;
+					created_at?: string;
+					domain: string;
+					id?: string;
+					label?: string | null;
+					updated_at?: string;
+					user_id: string;
+				};
+				Update: {
+					color?: string | null;
+					created_at?: string;
+					domain?: string;
+					id?: string;
+					label?: string | null;
+					updated_at?: string;
+					user_id?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_drafts: {
+				Row: {
+					content: string | null;
+					created_at: string;
+					id: string;
+					metadata: Json | null;
+					tags: string[] | null;
+					template_id: string | null;
+					title: string | null;
+					updated_at: string;
+					user_id: string;
+				};
+				Insert: {
+					content?: string | null;
+					created_at?: string;
+					id?: string;
+					metadata?: Json | null;
+					tags?: string[] | null;
+					template_id?: string | null;
+					title?: string | null;
+					updated_at?: string;
+					user_id?: string;
+				};
+				Update: {
+					content?: string | null;
+					created_at?: string;
+					id?: string;
+					metadata?: Json | null;
+					tags?: string[] | null;
+					template_id?: string | null;
+					title?: string | null;
+					updated_at?: string;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "sitecue_drafts_template_id_fkey";
+						columns: ["template_id"];
+						isOneToOne: false;
+						referencedRelation: "sitecue_templates";
+						referencedColumns: ["id"];
+					},
+				];
+			};
+			sitecue_links: {
+				Row: {
+					created_at: string;
+					domain: string;
+					id: string;
+					label: string;
+					target_url: string;
+					type: string;
+					user_id: string;
+				};
+				Insert: {
+					created_at?: string;
+					domain: string;
+					id?: string;
+					label: string;
+					target_url: string;
+					type: string;
+					user_id?: string;
+				};
+				Update: {
+					created_at?: string;
+					domain?: string;
+					id?: string;
+					label?: string;
+					target_url?: string;
+					type?: string;
+					user_id?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_notes: {
+				Row: {
+					content: string;
+					created_at: string;
+					draft_id: string | null;
+					id: string;
+					is_expanded: boolean;
+					is_favorite: boolean;
+					is_pinned: boolean;
+					is_resolved: boolean;
+					note_type: string;
+					scope: string;
+					sort_order: number;
+					tags: string[] | null;
+					updated_at: string;
+					url_pattern: string;
+					user_id: string;
+				};
+				Insert: {
+					content: string;
+					created_at?: string;
+					draft_id?: string | null;
+					id?: string;
+					is_expanded?: boolean;
+					is_favorite?: boolean;
+					is_pinned?: boolean;
+					is_resolved?: boolean;
+					note_type?: string;
+					scope?: string;
+					sort_order?: number;
+					tags?: string[] | null;
+					updated_at?: string;
+					url_pattern: string;
+					user_id: string;
+				};
+				Update: {
+					content?: string;
+					created_at?: string;
+					draft_id?: string | null;
+					id?: string;
+					is_expanded?: boolean;
+					is_favorite?: boolean;
+					is_pinned?: boolean;
+					is_resolved?: boolean;
+					note_type?: string;
+					scope?: string;
+					sort_order?: number;
+					tags?: string[] | null;
+					updated_at?: string;
+					url_pattern?: string;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "sitecue_notes_draft_id_fkey";
+						columns: ["draft_id"];
+						isOneToOne: false;
+						referencedRelation: "sitecue_drafts";
+						referencedColumns: ["id"];
+					},
+				];
+			};
+			sitecue_pinned_sites: {
+				Row: {
+					created_at: string;
+					id: string;
+					title: string;
+					url: string;
+					user_id: string;
+				};
+				Insert: {
+					created_at?: string;
+					id?: string;
+					title: string;
+					url: string;
+					user_id?: string;
+				};
+				Update: {
+					created_at?: string;
+					id?: string;
+					title?: string;
+					url?: string;
+					user_id?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_profiles: {
+				Row: {
+					ai_usage_count: number;
+					ai_usage_reset_at: string | null;
+					created_at: string;
+					id: string;
+					plan: string;
+				};
+				Insert: {
+					ai_usage_count?: number;
+					ai_usage_reset_at?: string | null;
+					created_at?: string;
+					id: string;
+					plan?: string;
+				};
+				Update: {
+					ai_usage_count?: number;
+					ai_usage_reset_at?: string | null;
+					created_at?: string;
+					id?: string;
+					plan?: string;
+				};
+				Relationships: [];
+			};
+			sitecue_templates: {
+				Row: {
+					boilerplate: string | null;
+					created_at: string;
+					icon: string | null;
+					id: string;
+					max_length: number | null;
+					name: string;
+					updated_at: string;
+					user_id: string;
+					weave_prompt: string | null;
+				};
+				Insert: {
+					boilerplate?: string | null;
+					created_at?: string;
+					icon?: string | null;
+					id?: string;
+					max_length?: number | null;
+					name: string;
+					updated_at?: string;
+					user_id: string;
+					weave_prompt?: string | null;
+				};
+				Update: {
+					boilerplate?: string | null;
+					created_at?: string;
+					icon?: string | null;
+					id?: string;
+					max_length?: number | null;
+					name?: string;
+					updated_at?: string;
+					user_id?: string;
+					weave_prompt?: string | null;
+				};
+				Relationships: [];
+			};
+			todo01_profiles: {
+				Row: {
+					created_at: string;
+					display_name: string | null;
+					id: string;
+					updated_at: string;
+				};
+				Insert: {
+					created_at?: string;
+					display_name?: string | null;
+					id: string;
+					updated_at?: string;
+				};
+				Update: {
+					created_at?: string;
+					display_name?: string | null;
+					id?: string;
+					updated_at?: string;
+				};
+				Relationships: [];
+			};
+			todo01_tasks: {
+				Row: {
+					created_at: string;
+					id: string;
+					is_complete: boolean | null;
+					title: string;
+					user_id: string;
+				};
+				Insert: {
+					created_at?: string;
+					id?: string;
+					is_complete?: boolean | null;
+					title: string;
+					user_id: string;
+				};
+				Update: {
+					created_at?: string;
+					id?: string;
+					is_complete?: boolean | null;
+					title?: string;
+					user_id?: string;
+				};
+				Relationships: [
+					{
+						foreignKeyName: "todo01_tasks_user_id_fkey";
+						columns: ["user_id"];
+						isOneToOne: false;
+						referencedRelation: "todo01_profiles";
+						referencedColumns: ["id"];
+					},
+				];
+			};
+		};
+		Views: {
+			[_ in never]: never;
+		};
+		Functions: {
+			check_array_elements_length: {
+				Args: { arr: string[]; max_len: number };
+				Returns: boolean;
+			};
+			get_dashboard_domain_activity: {
+				Args: { p_limit?: number; p_user_id: string };
+				Returns: Json;
+			};
+			get_drafts_by_date: {
+				Args: { p_date: string; p_user_id: string };
+				Returns: {
+					content: string | null;
+					created_at: string;
+					id: string;
+					metadata: Json | null;
+					tags: string[] | null;
+					template_id: string | null;
+					title: string | null;
+					updated_at: string;
+					user_id: string;
+				}[];
+				SetofOptions: {
+					from: "*";
+					to: "sitecue_drafts";
+					isOneToOne: false;
+					isSetofReturn: true;
+				};
+			};
+			get_matching_notes: {
+				Args: { p_domain: string; p_exact: string };
+				Returns: {
+					content: string;
+					created_at: string;
+					draft_id: string | null;
+					id: string;
+					is_expanded: boolean;
+					is_favorite: boolean;
+					is_pinned: boolean;
+					is_resolved: boolean;
+					note_type: string;
+					scope: string;
+					sort_order: number;
+					tags: string[] | null;
+					updated_at: string;
+					url_pattern: string;
+					user_id: string;
+				}[];
+				SetofOptions: {
+					from: "*";
+					to: "sitecue_notes";
+					isOneToOne: false;
+					isSetofReturn: true;
+				};
+			};
+			get_notes_by_date: {
+				Args: { p_date: string; p_user_id: string };
+				Returns: {
+					content: string;
+					created_at: string;
+					draft_id: string | null;
+					id: string;
+					is_expanded: boolean;
+					is_favorite: boolean;
+					is_pinned: boolean;
+					is_resolved: boolean;
+					note_type: string;
+					scope: string;
+					sort_order: number;
+					tags: string[] | null;
+					updated_at: string;
+					url_pattern: string;
+					user_id: string;
+				}[];
+				SetofOptions: {
+					from: "*";
+					to: "sitecue_notes";
+					isOneToOne: false;
+					isSetofReturn: true;
+				};
+			};
+			search_drafts: {
+				Args: { search_query: string };
+				Returns: {
+					content: string | null;
+					created_at: string;
+					id: string;
+					metadata: Json | null;
+					tags: string[] | null;
+					template_id: string | null;
+					title: string | null;
+					updated_at: string;
+					user_id: string;
+				}[];
+				SetofOptions: {
+					from: "*";
+					to: "sitecue_drafts";
+					isOneToOne: false;
+					isSetofReturn: true;
+				};
+			};
+			search_notes: {
+				Args: { search_query: string };
+				Returns: {
+					content: string;
+					created_at: string;
+					draft_id: string | null;
+					id: string;
+					is_expanded: boolean;
+					is_favorite: boolean;
+					is_pinned: boolean;
+					is_resolved: boolean;
+					note_type: string;
+					scope: string;
+					sort_order: number;
+					tags: string[] | null;
+					updated_at: string;
+					url_pattern: string;
+					user_id: string;
+				}[];
+				SetofOptions: {
+					from: "*";
+					to: "sitecue_notes";
+					isOneToOne: false;
+					isSetofReturn: true;
+				};
+			};
+		};
+		Enums: {
+			[_ in never]: never;
+		};
+		CompositeTypes: {
+			[_ in never]: never;
+		};
+	};
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<
+	keyof Database,
+	"public"
+>];
 
 export type Tables<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-    : never = never,
+	DefaultSchemaTableNameOrOptions extends
+		| keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+		| { schema: keyof DatabaseWithoutInternals },
+	TableName extends DefaultSchemaTableNameOrOptions extends {
+		schema: keyof DatabaseWithoutInternals;
+	}
+		? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+				DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+		: never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+	schema: keyof DatabaseWithoutInternals;
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
-    }
-    ? R
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
-      }
-      ? R
-      : never
-    : never
+	? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+			DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+			Row: infer R;
+		}
+		? R
+		: never
+	: DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+				DefaultSchema["Views"])
+		? (DefaultSchema["Tables"] &
+				DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+				Row: infer R;
+			}
+			? R
+			: never
+		: never;
 
 export type TablesInsert<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+	DefaultSchemaTableNameOrOptions extends
+		| keyof DefaultSchema["Tables"]
+		| { schema: keyof DatabaseWithoutInternals },
+	TableName extends DefaultSchemaTableNameOrOptions extends {
+		schema: keyof DatabaseWithoutInternals;
+	}
+		? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+		: never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+	schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
-    }
-    ? I
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
-      }
-      ? I
-      : never
-    : never
+	? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+			Insert: infer I;
+		}
+		? I
+		: never
+	: DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+		? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+				Insert: infer I;
+			}
+			? I
+			: never
+		: never;
 
 export type TablesUpdate<
-  DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
-    | { schema: keyof DatabaseWithoutInternals },
-  TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
+	DefaultSchemaTableNameOrOptions extends
+		| keyof DefaultSchema["Tables"]
+		| { schema: keyof DatabaseWithoutInternals },
+	TableName extends DefaultSchemaTableNameOrOptions extends {
+		schema: keyof DatabaseWithoutInternals;
+	}
+		? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+		: never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+	schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
-    }
-    ? U
-    : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
-      }
-      ? U
-      : never
-    : never
+	? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+			Update: infer U;
+		}
+		? U
+		: never
+	: DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+		? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+				Update: infer U;
+			}
+			? U
+			: never
+		: never;
 
 export type Enums<
-  DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
-    | { schema: keyof DatabaseWithoutInternals },
-  EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
+	DefaultSchemaEnumNameOrOptions extends
+		| keyof DefaultSchema["Enums"]
+		| { schema: keyof DatabaseWithoutInternals },
+	EnumName extends DefaultSchemaEnumNameOrOptions extends {
+		schema: keyof DatabaseWithoutInternals;
+	}
+		? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+		: never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+	schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+	? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+	: DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+		? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+		: never;
 
 export type CompositeTypes<
-  PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
-    | { schema: keyof DatabaseWithoutInternals },
-  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
-  }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never,
+	PublicCompositeTypeNameOrOptions extends
+		| keyof DefaultSchema["CompositeTypes"]
+		| { schema: keyof DatabaseWithoutInternals },
+	CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+		schema: keyof DatabaseWithoutInternals;
+	}
+		? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+		: never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+	schema: keyof DatabaseWithoutInternals;
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+	? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+	: PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+		? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+		: never;
 
 export const Constants = {
-  graphql_public: {
-    Enums: {},
-  },
-  public: {
-    Enums: {},
-  },
-} as const
-
+	graphql_public: {
+		Enums: {},
+	},
+	public: {
+		Enums: {},
+	},
+} as const;

--- a/packages/shared/src/utils/limits.test.ts
+++ b/packages/shared/src/utils/limits.test.ts
@@ -4,26 +4,41 @@ import { describe, expect, it } from "vitest";
 import { SHARED_LIMITS } from "./limits";
 
 describe("Limits & DB Schema / Migration Consistency Test", () => {
-  it("SHARED_LIMITS の Pro/Free 上限値と DB の CHECK制約 / トリガーの数値が完全一致すること", () => {
-    const migrationPath = path.resolve(
-      __dirname,
-      "../../../../supabase/migrations/20260722000000_update_content_len_checks.sql",
-    );
-    const sqlContent = fs.readFileSync(migrationPath, "utf-8");
+	it("SHARED_LIMITS の Pro/Free 上限値と DB の CHECK制約 / トリガーの数値が完全一致すること", () => {
+		const migrationPath = path.resolve(
+			__dirname,
+			"../../../../supabase/migrations/20260722000000_update_content_len_checks.sql",
+		);
+		const sqlContent = fs.readFileSync(migrationPath, "utf-8");
 
-    // sitecue_notes CHECK制約 (30000)
-    const notesCheck = sqlContent.match(/sitecue_notes_content_len_check.*<=?\s*(\d+)/i);
-    expect(notesCheck).not.toBeNull();
-    if (notesCheck) expect(Number.parseInt(notesCheck[1], 10)).toBe(SHARED_LIMITS.NOTE_LENGTH.PRO);
+		// sitecue_notes CHECK制約 (30000)
+		const notesCheck = sqlContent.match(
+			/sitecue_notes_content_len_check.*<=?\s*(\d+)/i,
+		);
+		expect(notesCheck).not.toBeNull();
+		if (notesCheck)
+			expect(Number.parseInt(notesCheck[1], 10)).toBe(
+				SHARED_LIMITS.NOTE_LENGTH.PRO,
+			);
 
-    // sitecue_diaries CHECK制約 (100000)
-    const diariesCheck = sqlContent.match(/sitecue_diaries_content_len_check.*<=?\s*(\d+)/i);
-    expect(diariesCheck).not.toBeNull();
-    if (diariesCheck) expect(Number.parseInt(diariesCheck[1], 10)).toBe(SHARED_LIMITS.DIARY_LENGTH.PRO);
+		// sitecue_diaries CHECK制約 (100000)
+		const diariesCheck = sqlContent.match(
+			/sitecue_diaries_content_len_check.*<=?\s*(\d+)/i,
+		);
+		expect(diariesCheck).not.toBeNull();
+		if (diariesCheck)
+			expect(Number.parseInt(diariesCheck[1], 10)).toBe(
+				SHARED_LIMITS.DIARY_LENGTH.PRO,
+			);
 
-    // check_note_content_length トリガー内 Free上限 (10000)
-    const noteTrigger = sqlContent.match(/char_length\(NEW\.content\)\s*>\s*(\d+)/i);
-    expect(noteTrigger).not.toBeNull();
-    if (noteTrigger) expect(Number.parseInt(noteTrigger[1], 10)).toBe(SHARED_LIMITS.NOTE_LENGTH.FREE);
-  });
+		// check_note_content_length トリガー内 Free上限 (10000)
+		const noteTrigger = sqlContent.match(
+			/char_length\(NEW\.content\)\s*>\s*(\d+)/i,
+		);
+		expect(noteTrigger).not.toBeNull();
+		if (noteTrigger)
+			expect(Number.parseInt(noteTrigger[1], 10)).toBe(
+				SHARED_LIMITS.NOTE_LENGTH.FREE,
+			);
+	});
 });

--- a/packages/shared/src/utils/url.test.ts
+++ b/packages/shared/src/utils/url.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	buildNoteContextHref,
 	getSafeUrl,
 	getScopeUrls,
 	normalizeUrl,
@@ -34,5 +35,45 @@ describe("URL Utilities", () => {
 			domain: "sitecue.app",
 			exact: "sitecue.app/notes",
 		});
+	});
+});
+
+describe("buildNoteContextHref", () => {
+	it("generates correct URL for inbox scope", () => {
+		const href = buildNoteContextHref({ id: "note-1", scope: "inbox" });
+		expect(href).toBe("/notes?view=inbox&noteId=note-1");
+	});
+
+	it("generates correct URL with exact=all for domain scope", () => {
+		const href = buildNoteContextHref({
+			id: "note-2",
+			scope: "domain",
+			url_pattern: "127.0.0.1:3000",
+		});
+		expect(href).toBe(
+			"/notes?domain=127.0.0.1%3A3000&view=domains&exact=all&noteId=note-2",
+		);
+	});
+
+	it("generates correct URL with exact parameter for exact page scope", () => {
+		const href = buildNoteContextHref({
+			id: "note-3",
+			scope: "exact",
+			url_pattern: "example.com/blog/1",
+		});
+		expect(href).toBe(
+			`/notes?domain=example.com&view=domains&exact=${encodeURIComponent("example.com/blog/1")}&noteId=note-3`,
+		);
+	});
+
+	it("extracts domain correctly when url_pattern includes http protocol", () => {
+		const href = buildNoteContextHref({
+			id: "note-4",
+			scope: "exact",
+			url_pattern: "https://qiita.com/stock-feed",
+		});
+		expect(href).toBe(
+			`/notes?domain=qiita.com&view=domains&exact=${encodeURIComponent("https://qiita.com/stock-feed")}&noteId=note-4`,
+		);
 	});
 });

--- a/packages/shared/src/utils/url.ts
+++ b/packages/shared/src/utils/url.ts
@@ -22,7 +22,7 @@ export function normalizeUrlForGrouping(url: string): string {
 }
 
 export function normalizeUrl(url: string, scope: "domain" | "exact"): string {
-	const safeUrl = getSafeUrl(url);
+	const safeUrl = getSafeUrl(url.startsWith("http") ? url : `https://${url}`);
 	if (!safeUrl) {
 		return normalizeUrlForGrouping(url);
 	}
@@ -47,4 +47,34 @@ export function getScopeUrls(currentUrl: string): {
 		domain: normalizeUrl(currentUrl, "domain"),
 		exact: normalizeUrl(currentUrl, "exact"),
 	};
+}
+
+export interface BuildNoteContextHrefInput {
+	id: string;
+	scope?: "exact" | "domain" | "inbox" | string;
+	url_pattern?: string;
+}
+
+/**
+ * ノートのコンテキストに応じた詳細遷移URL (/notes?...) を統一生成する純粋関数。
+ */
+export function buildNoteContextHref(note: BuildNoteContextHrefInput): string {
+	const { id, scope, url_pattern = "" } = note;
+
+	if (scope === "inbox") {
+		return `/notes?view=inbox&noteId=${encodeURIComponent(id)}`;
+	}
+
+	if (scope === "domain") {
+		const domain = normalizeUrl(url_pattern, "domain") || "inbox";
+		return `/notes?domain=${encodeURIComponent(domain)}&view=domains&exact=all&noteId=${encodeURIComponent(id)}`;
+	}
+
+	if (scope === "exact") {
+		const domain = normalizeUrl(url_pattern, "domain") || "inbox";
+		return `/notes?domain=${encodeURIComponent(domain)}&view=domains&exact=${encodeURIComponent(url_pattern)}&noteId=${encodeURIComponent(id)}`;
+	}
+
+	// デフォルトフォールバック
+	return `/notes?view=inbox&noteId=${encodeURIComponent(id)}`;
 }

--- a/supabase/migrations/20260727000000_update_dashboard_domain_activity_resolved.sql
+++ b/supabase/migrations/20260727000000_update_dashboard_domain_activity_resolved.sql
@@ -1,0 +1,115 @@
+CREATE OR REPLACE FUNCTION "public"."get_dashboard_domain_activity"("p_user_id" "uuid", "p_limit" integer DEFAULT 6) RETURNS json
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    AS $_$
+DECLARE
+  result json;
+BEGIN
+  IF auth.uid() IS NOT NULL AND auth.uid() <> p_user_id THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  WITH note_with_domain AS (
+    SELECT
+      *,
+      regexp_replace(url_pattern, '^(?:https?://)?(?:www\.)?([^/]+).*$', '\1') AS domain_name
+    FROM public.sitecue_notes
+    WHERE user_id = p_user_id AND scope IN ('domain', 'exact')
+  ),
+  
+  top_domains AS (
+    SELECT
+      domain_name,
+      count(*) AS total_count
+    FROM note_with_domain
+    GROUP BY domain_name
+    ORDER BY total_count DESC, domain_name ASC
+    LIMIT p_limit
+  ),
+  
+  domain_latest_notes AS (
+    SELECT
+      td.domain_name,
+      COALESCE(
+        json_agg(json_build_object('id', ln.id, 'content', ln.content, 'is_resolved', ln.is_resolved) ORDER BY ln.created_at DESC) 
+        FILTER (WHERE ln.id IS NOT NULL), 
+        '[]'::json
+      ) AS domain_notes
+    FROM top_domains td
+    LEFT JOIN LATERAL (
+      SELECT id, content, is_resolved, created_at
+      FROM note_with_domain n2
+      WHERE n2.domain_name = td.domain_name AND n2.scope = 'domain'
+      ORDER BY n2.created_at DESC
+      LIMIT 2
+    ) ln ON TRUE
+    GROUP BY td.domain_name
+  ),
+  
+  page_ranking AS (
+    SELECT
+      n.domain_name,
+      n.url_pattern AS page_url,
+      count(*) AS page_count,
+      row_number() OVER (PARTITION BY n.domain_name ORDER BY count(*) DESC, n.url_pattern ASC) as rank
+    FROM note_with_domain n
+    WHERE n.scope = 'exact'
+    GROUP BY n.domain_name, n.url_pattern
+  ),
+  
+  top_pages_filtered AS (
+    SELECT domain_name, page_url, page_count
+    FROM page_ranking
+    WHERE rank <= 3
+  ),
+  
+  page_latest_notes AS (
+    SELECT
+      tp.domain_name,
+      tp.page_url,
+      COALESCE(
+        json_agg(json_build_object('id', lpn.id, 'content', lpn.content, 'is_resolved', lpn.is_resolved) ORDER BY lpn.created_at DESC)
+        FILTER (WHERE lpn.id IS NOT NULL),
+        '[]'::json
+      ) AS page_notes
+    FROM top_pages_filtered tp
+    LEFT JOIN LATERAL (
+      SELECT id, content, is_resolved, created_at
+      FROM note_with_domain n2
+      WHERE n2.domain_name = tp.domain_name AND n2.url_pattern = tp.page_url AND n2.scope = 'exact'
+      ORDER BY n2.created_at DESC
+      LIMIT 2
+    ) lpn ON TRUE
+    GROUP BY tp.domain_name, tp.page_url
+  ),
+  
+  domain_pages_json AS (
+    SELECT
+      tp.domain_name,
+      json_agg(
+        json_build_object(
+          'page_url', tp.page_url,
+          'page_title', NULL,
+          'page_count', tp.page_count,
+          'page_notes', COALESCE(pn.page_notes, '[]'::json)
+        ) ORDER BY tp.page_count DESC, tp.page_url ASC
+      ) AS top_pages
+    FROM top_pages_filtered tp
+    LEFT JOIN page_latest_notes pn ON pn.domain_name = tp.domain_name AND pn.page_url = tp.page_url
+    GROUP BY tp.domain_name
+  )
+  
+  SELECT json_agg(
+    json_build_object(
+      'domain', td.domain_name,
+      'total_count', td.total_count,
+      'domain_notes', COALESCE(dn.domain_notes, '[]'::json),
+      'top_pages', COALESCE(dp.top_pages, '[]'::json)
+    ) ORDER BY td.total_count DESC, td.domain_name ASC
+  ) INTO result
+  FROM top_domains td
+  LEFT JOIN domain_latest_notes dn ON dn.domain_name = td.domain_name
+  LEFT JOIN domain_pages_json dp ON dp.domain_name = td.domain_name;
+  
+  RETURN COALESCE(result, '[]'::json);
+END;
+$_$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -179,7 +179,6 @@ CREATE OR REPLACE FUNCTION "public"."get_dashboard_domain_activity"("p_user_id" 
 DECLARE
   result json;
 BEGIN
-  -- セキュリティチェック：認証ユーザーは自身のデータのみ操作可能
   IF auth.uid() IS NOT NULL AND auth.uid() <> p_user_id THEN
     RAISE EXCEPTION 'Access denied';
   END IF;
@@ -206,13 +205,13 @@ BEGIN
     SELECT
       td.domain_name,
       COALESCE(
-        json_agg(json_build_object('id', ln.id, 'content', ln.content) ORDER BY ln.created_at DESC) 
+        json_agg(json_build_object('id', ln.id, 'content', ln.content, 'is_resolved', ln.is_resolved) ORDER BY ln.created_at DESC) 
         FILTER (WHERE ln.id IS NOT NULL), 
         '[]'::json
       ) AS domain_notes
     FROM top_domains td
     LEFT JOIN LATERAL (
-      SELECT id, content, created_at
+      SELECT id, content, is_resolved, created_at
       FROM note_with_domain n2
       WHERE n2.domain_name = td.domain_name AND n2.scope = 'domain'
       ORDER BY n2.created_at DESC
@@ -243,13 +242,13 @@ BEGIN
       tp.domain_name,
       tp.page_url,
       COALESCE(
-        json_agg(json_build_object('id', lpn.id, 'content', lpn.content) ORDER BY lpn.created_at DESC)
+        json_agg(json_build_object('id', lpn.id, 'content', lpn.content, 'is_resolved', lpn.is_resolved) ORDER BY lpn.created_at DESC)
         FILTER (WHERE lpn.id IS NOT NULL),
         '[]'::json
       ) AS page_notes
     FROM top_pages_filtered tp
     LEFT JOIN LATERAL (
-      SELECT id, content, created_at
+      SELECT id, content, is_resolved, created_at
       FROM note_with_domain n2
       WHERE n2.domain_name = tp.domain_name AND n2.url_pattern = tp.page_url AND n2.scope = 'exact'
       ORDER BY n2.created_at DESC
@@ -264,7 +263,6 @@ BEGIN
       json_agg(
         json_build_object(
           'page_url', tp.page_url,
-          -- スキーマに title が存在しないため NULL を返し、フロントの getSafeUrl フォールバックへ確実に渡す
           'page_title', NULL,
           'page_count', tp.page_count,
           'page_notes', COALESCE(pn.page_notes, '[]'::json)


### PR DESCRIPTION
… interactivity

Why:
- Eliminate initial blank screen lag, stale dates, and top-level SSR blocking on the dashboard page during PWA startup.
- Improve activity tracking visibility by displaying resolved notes with strikethrough styling across dashboard cards.
- Fix broken favicons on local development URLs with ports (e.g., `127.0.0.1:3000`) caused by external API fallbacks.
- Prevent inconsistent drill-down routing parameters by centralizing note context URL generation.
- Ensure real-time dashboard data refresh immediately after creating notes or diaries via the global modal.

What:
- Update Service Worker (`sw.js`) to Network-First for HTML documents and add silent `sw.update()` / `router.refresh()` triggers on window focus in `ServiceWorkerRegister.tsx`.
- Configure `export const dynamic = "force-dynamic"` and section-level `<Suspense>` streaming boundaries in `app/(dashboard)/page.tsx`.
- Update DB RPC `get_dashboard_domain_activity` and `DashboardSnippetNote` type to return `is_resolved` status.
- Implement `buildNoteContextHref` helper in `@sitecue/shared` and apply across `DomainDashboardCard`, `ContributionTimeline`, and `RadialActivityChart`.
- Update `DomainFavicon` to parse hostnames without ports and fallback to `Laptop` icon for local URLs.
- Add Recent Items preview section to `RadialActivityChart` with vertical center alignment when empty.
- Add `router.refresh()` call upon successful saving in `GlobalNewNoteDialog` for real-time RSC cache revalidation.
- Update Vitest component and utility tests to verify `is_resolved` styles, `exact=all` routing links, and router refresh.