### PR TITLE
refactor(shared): optimize dashboard DAL query by in-memory extraction

### DIFF
--- a/packages/shared/src/dal/dashboard.test.ts
+++ b/packages/shared/src/dal/dashboard.test.ts
@@ -2,38 +2,69 @@ import { describe, expect, it, vi } from "vitest";
 import { fetchDashboardOverviewData } from "./dashboard";
 
 describe("fetchDashboardOverviewData DAL", () => {
-	it("fetches dashboard data without calling non-existent RPC get_user_contribution_activity", async () => {
-		const mockBuilder = {
-			select: vi.fn().mockReturnThis(),
-			eq: vi.fn().mockReturnThis(),
-			order: vi.fn().mockReturnThis(),
-			limit: vi.fn().mockReturnThis(),
-			gte: vi.fn().mockReturnThis(),
-			// biome-ignore lint/suspicious/noThenProperty: Supabase mock
-			then: vi.fn().mockImplementation((onFulfilled) =>
-				Promise.resolve(
-					onFulfilled({
-						count: 1,
-						data: [
-							{
-								id: "n-1",
-								content: "Test note",
-								is_resolved: false,
-								scope: "inbox",
-								url_pattern: "inbox",
-								created_at: new Date().toISOString(),
-								note_type: "info",
-							},
-						],
-						error: null,
+	it("7日間のデータが5件以上ある場合、追加フェッチなしでインメモリからrecentNotes/recentDraftsを抽出すること", async () => {
+		const mockNotes7d = Array.from({ length: 6 }, (_, i) => ({
+			id: `n-${i}`,
+			content: `Note ${i}`,
+			is_resolved: false,
+			scope: "inbox",
+			url_pattern: "inbox",
+			created_at: new Date(Date.now() - i * 1000).toISOString(),
+			note_type: "info",
+		}));
+
+		const mockDrafts7d = Array.from({ length: 6 }, (_, i) => ({
+			id: `d-${i}`,
+			title: `Draft ${i}`,
+			content: `Content ${i}`,
+			created_at: new Date(Date.now() - i * 1000).toISOString(),
+		}));
+
+		const mockFrom = vi.fn().mockImplementation((table) => {
+			if (table === "sitecue_notes") {
+				return {
+					select: vi.fn().mockReturnValue({
+						eq: vi.fn().mockReturnValue({
+							gte: vi.fn().mockImplementation((_, dateVal) => {
+								if (typeof dateVal === "string" && dateVal.includes("T00:00:00")) {
+									return Promise.resolve({ count: 1, error: null });
+								}
+								return {
+									order: vi.fn().mockResolvedValue({
+										data: mockNotes7d,
+										error: null,
+									}),
+								};
+							}),
+						}),
 					}),
-				),
-			),
-		};
+				};
+			}
+			if (table === "sitecue_drafts") {
+				return {
+					select: vi.fn().mockReturnValue({
+						eq: vi.fn().mockReturnValue({
+							gte: vi.fn().mockImplementation((_, dateVal) => {
+								if (typeof dateVal === "string" && dateVal.includes("T00:00:00")) {
+									return Promise.resolve({ count: 1, error: null });
+								}
+								return {
+									order: vi.fn().mockResolvedValue({
+										data: mockDrafts7d,
+										error: null,
+									}),
+								};
+							}),
+						}),
+					}),
+				};
+			}
+			return {};
+		});
 
 		const mockRpc = vi.fn().mockResolvedValue({ data: [], error: null });
 		const mockSupabase = {
-			from: vi.fn().mockReturnValue(mockBuilder),
+			from: mockFrom,
 			rpc: mockRpc,
 		};
 
@@ -44,12 +75,108 @@ describe("fetchDashboardOverviewData DAL", () => {
 			"user-123",
 		);
 
-		expect(result.notes7d).toBeDefined();
-		expect(result.notes7d.length).toBeGreaterThan(0);
-		// get_user_contribution_activity RPCが一切呼び出されていないことを厳密にアサート
+		expect(result.notes7d.length).toBe(6);
+		expect(result.recentNotes.length).toBe(5);
+		expect(result.recentNotes[0].id).toBe("n-0");
+		expect(result.recentDrafts.length).toBe(5);
+		expect(result.recentDrafts[0].id).toBe("d-0");
+		// RPC呼び出しなしの確認
 		expect(mockRpc).not.toHaveBeenCalledWith(
 			"get_user_contribution_activity",
 			expect.anything(),
 		);
+	});
+
+	it("7日間のデータが5件未満の場合、フォールバックとして全期間の直近5件を取得すること", async () => {
+		const mockNotes7d = [
+			{
+				id: "n-0",
+				content: "Note 0",
+				is_resolved: false,
+				scope: "inbox",
+				url_pattern: "inbox",
+				created_at: new Date().toISOString(),
+				note_type: "info",
+			},
+		];
+
+		const mockFallbackNotes = Array.from({ length: 5 }, (_, i) => ({
+			id: `fb-n-${i}`,
+			content: `Fallback Note ${i}`,
+			is_resolved: false,
+			scope: "inbox",
+			url_pattern: "inbox",
+			created_at: new Date(Date.now() - (i + 10) * 86400000).toISOString(),
+		}));
+
+		const mockFrom = vi.fn().mockImplementation((table) => {
+			if (table === "sitecue_notes") {
+				return {
+					select: vi.fn().mockReturnValue({
+						eq: vi.fn().mockReturnValue({
+							gte: vi.fn().mockImplementation((_, dateVal) => {
+								if (typeof dateVal === "string" && dateVal.includes("T00:00:00")) {
+									return Promise.resolve({ count: 1, error: null });
+								}
+								return {
+									order: vi.fn().mockResolvedValue({
+										data: mockNotes7d,
+										error: null,
+									}),
+								};
+							}),
+							order: vi.fn().mockReturnValue({
+								limit: vi.fn().mockResolvedValue({
+									data: mockFallbackNotes,
+									error: null,
+								}),
+							}),
+						}),
+					}),
+				};
+			}
+			if (table === "sitecue_drafts") {
+				return {
+					select: vi.fn().mockReturnValue({
+						eq: vi.fn().mockReturnValue({
+							gte: vi.fn().mockImplementation((_, dateVal) => {
+								if (typeof dateVal === "string" && dateVal.includes("T00:00:00")) {
+									return Promise.resolve({ count: 0, error: null });
+								}
+								return {
+									order: vi.fn().mockResolvedValue({
+										data: [],
+										error: null,
+									}),
+								};
+							}),
+							order: vi.fn().mockReturnValue({
+								limit: vi.fn().mockResolvedValue({
+									data: [],
+									error: null,
+								}),
+							}),
+						}),
+					}),
+				};
+			}
+			return {};
+		});
+
+		const mockSupabase = {
+			from: mockFrom,
+			rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
+		};
+
+		const result = await fetchDashboardOverviewData(
+			mockSupabase as unknown as Parameters<
+				typeof fetchDashboardOverviewData
+			>[0],
+			"user-123",
+		);
+
+		expect(result.notes7d.length).toBe(1);
+		expect(result.recentNotes.length).toBe(5);
+		expect(result.recentNotes[0].id).toBe("fb-n-0");
 	});
 });

--- a/packages/shared/src/dal/dashboard.ts
+++ b/packages/shared/src/dal/dashboard.ts
@@ -60,13 +60,12 @@ export async function fetchDashboardOverviewData(
 	sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 	const dateStr = sevenDaysAgo.toISOString();
 
+	// 重複クエリ（全期間のrecentNotes/recentDrafts）を排除し、初期並列クエリを5つに一元化
 	const [
 		{ count: todayNotes },
 		{ count: todayDrafts },
 		{ data: notes7dData },
 		{ data: drafts7dData },
-		{ data: recentNotes },
-		{ data: recentDrafts },
 		domainActivities,
 	] = await Promise.all([
 		supabase
@@ -93,20 +92,35 @@ export async function fetchDashboardOverviewData(
 			.eq("user_id", userId)
 			.gte("created_at", dateStr)
 			.order("created_at", { ascending: false }),
-		supabase
+		fetchDashboardDomainActivity(supabase, userId, 6),
+	]);
+
+	const notes7d = (notes7dData as DashboardOverviewData["notes7d"]) ?? [];
+	const drafts7d = (drafts7dData as DashboardOverviewData["drafts7d"]) ?? [];
+
+	// 過去7日間のデータからインメモリで直近5件を取得
+	let recentNotes: DashboardOverviewData["recentNotes"] = notes7d.slice(0, 5);
+	// 過去7日間のデータが5件未満の場合は、全期間の直近5件をフォールバックフェッチ
+	if (notes7d.length < 5) {
+		const { data: fallbackNotes } = await supabase
 			.from("sitecue_notes")
 			.select("id, content, is_resolved, scope, url_pattern, created_at")
 			.eq("user_id", userId)
 			.order("created_at", { ascending: false })
-			.limit(5),
-		supabase
+			.limit(5);
+		recentNotes = (fallbackNotes as DashboardOverviewData["recentNotes"]) ?? [];
+	}
+
+	let recentDrafts: DashboardOverviewData["recentDrafts"] = drafts7d.slice(0, 5);
+	if (drafts7d.length < 5) {
+		const { data: fallbackDrafts } = await supabase
 			.from("sitecue_drafts")
 			.select("id, title, content, created_at")
 			.eq("user_id", userId)
 			.order("created_at", { ascending: false })
-			.limit(5),
-		fetchDashboardDomainActivity(supabase, userId, 6),
-	]);
+			.limit(5);
+		recentDrafts = (fallbackDrafts as DashboardOverviewData["recentDrafts"]) ?? [];
+	}
 
 	return {
 		todayTotal: (todayNotes ?? 0) + (todayDrafts ?? 0),
@@ -124,12 +138,12 @@ export async function fetchDashboardOverviewData(
 			.toUpperCase(),
 		currentYear: year.toString(),
 		currentMonth: month,
-		noteCount7d: notes7dData?.length ?? 0,
-		draftCount7d: drafts7dData?.length ?? 0,
-		recentNotes: (recentNotes as DashboardOverviewData["recentNotes"]) ?? [],
-		recentDrafts: (recentDrafts as DashboardOverviewData["recentDrafts"]) ?? [],
+		noteCount7d: notes7d.length,
+		draftCount7d: drafts7d.length,
+		recentNotes,
+		recentDrafts,
 		domainActivities: domainActivities ?? [],
-		notes7d: (notes7dData as DashboardOverviewData["notes7d"]) ?? [],
-		drafts7d: (drafts7dData as DashboardOverviewData["drafts7d"]) ?? [],
+		notes7d,
+		drafts7d,
 	};
 }


### PR DESCRIPTION
- fetchDashboardOverviewData 内の重複クエリ（recentNotes/recentDrafts）を削除し初期並列通信を削減
- 過去7日間データからのインメモリ抽出（slice(0, 5)）へ集約
- 7日間のデータが5件未満の場合のみ全期間の直近データを取得するフォールバック処理を導入