### PR TITLE
perf(app): implement transition-based navigation and cache-first rend…

### DIFF
--- a/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneList.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneList.test.tsx
@@ -335,6 +335,7 @@ describe("MiddlePaneList Tab and Search Interactions", () => {
 		await user.click(domainsTab);
 		expect(mockPush).toHaveBeenCalledWith(
 			expect.stringContaining("view=domains"),
+			{ scroll: false },
 		);
 
 		// mockPushとmockReplaceの履歴をクリア
@@ -373,14 +374,15 @@ describe("MiddlePaneList Tab and Search Interactions", () => {
 		await user.click(inboxTab);
 
 		// mockPush should be called with ONLY view=inbox
-		const pushCall = mockPush.mock.calls[0][0];
-		const resultParams = new URLSearchParams(pushCall.split("?")[1]);
+		const pushCall = mockPush.mock.calls[0];
+		const resultParams = new URLSearchParams(pushCall[0].split("?")[1]);
 
 		expect(resultParams.get("view")).toBe("inbox");
 		expect(resultParams.has("domain")).toBe(false);
 		expect(resultParams.has("exact")).toBe(false);
 		expect(resultParams.has("noteId")).toBe(false);
 		expect(resultParams.has("q")).toBe(false);
+		expect(pushCall[1]).toEqual({ scroll: false });
 	});
 
 	it("clears search input when clear button is clicked", async () => {
@@ -582,11 +584,10 @@ describe("MiddlePaneList Back Button", () => {
 		const backBtn = screen.getByTitle("Go back");
 		await user.click(backBtn);
 
-		const pushCall = mockPush.mock.calls[0][0];
-		const resultParams = new URLSearchParams(pushCall.split("?")[1]);
-
-		expect(resultParams.get("domain")).toBe("example.com");
-		expect(resultParams.has("exact")).toBe(false);
+		const pushCall = mockPush.mock.calls[0];
+		expect(pushCall[0]).toContain("domain=example.com");
+		expect(pushCall[0]).not.toContain("exact=");
+		expect(pushCall[1]).toEqual({ scroll: false });
 	});
 
 	it("removes 'domain' parameter and sets view=domains when clicking back from domain view", async () => {
@@ -610,11 +611,10 @@ describe("MiddlePaneList Back Button", () => {
 		const backBtn = screen.getByTitle("Go back");
 		await user.click(backBtn);
 
-		const pushCall = mockPush.mock.calls[0][0];
-		const resultParams = new URLSearchParams(pushCall.split("?")[1]);
-
-		expect(resultParams.has("exact")).toBe(false);
-		expect(resultParams.get("view")).toBe("domains");
+		const pushCall = mockPush.mock.calls[0];
+		expect(pushCall[0]).not.toContain("exact=");
+		expect(pushCall[0]).toContain("view=domains");
+		expect(pushCall[1]).toEqual({ scroll: false });
 	});
 
 	it("renders years list in diaries view when year is not selected", async () => {

--- a/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneList.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneList.tsx
@@ -30,7 +30,7 @@ import {
 	Trash2,
 } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import toast from "react-hot-toast";
 import { AnimatedIconButton } from "@/components/ui/animated-icon-button";
 import { Button } from "@/components/ui/button";
@@ -92,6 +92,7 @@ export function MiddlePaneList(props: Props) {
 	const searchParams = useSearchParams();
 	const router = useRouter();
 	const pathname = usePathname();
+	const [_isPending, startTransition] = useTransition();
 	const diaries = items.filter(
 		(item): item is Diary => "date" in item && !("note_type" in item),
 	);
@@ -166,14 +167,18 @@ export function MiddlePaneList(props: Props) {
 			params.delete("month");
 		}
 
-		router.push(`${pathname}?${params.toString()}`);
+		startTransition(() => {
+			router.push(`${pathname}?${params.toString()}`, { scroll: false });
+		});
 	};
 
 	const updateParams = (key: string, value: string) => {
 		const params = new URLSearchParams(searchParams.toString());
 		if (value) params.set(key, value);
 		else params.delete(key);
-		router.push(`${pathname}?${params.toString()}`);
+		startTransition(() => {
+			router.push(`${pathname}?${params.toString()}`, { scroll: false });
+		});
 	};
 
 	const handleBack = () => {
@@ -194,7 +199,9 @@ export function MiddlePaneList(props: Props) {
 				params.set("view", "domains");
 			}
 		}
-		router.push(`${pathname}?${params.toString()}`);
+		startTransition(() => {
+			router.push(`${pathname}?${params.toString()}`, { scroll: false });
+		});
 	};
 
 	const [localItems, setLocalItems] = useState<(Note | Draft | Diary)[]>(items);

--- a/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.tsx
@@ -66,11 +66,28 @@ export function NotesContainer() {
 	);
 
 	// クエリデータの準備完了状態（対象ビューに必要なデータが準備できているか判定）
+	// 💡 キャッシュデータが存在する場合は isLoading によるブロッキングをスキップし、手元データを0ms最優先描画する
 	const isTabReady = useMemo(() => {
-		if (effectiveView === "drafts") return !isDraftsLoading;
-		if (effectiveView === "diaries") return !isDiariesLoading;
-		return !isNotesLoading && !isDraftsLoading;
-	}, [effectiveView, isDraftsLoading, isDiariesLoading, isNotesLoading]);
+		if (effectiveView === "drafts") {
+			return drafts.length > 0 || !isDraftsLoading;
+		}
+		if (effectiveView === "diaries") {
+			return diaries.length > 0 || !isDiariesLoading;
+		}
+		return (
+			notes.length > 0 ||
+			drafts.length > 0 ||
+			(!isNotesLoading && !isDraftsLoading)
+		);
+	}, [
+		effectiveView,
+		drafts,
+		isDraftsLoading,
+		diaries,
+		isDiariesLoading,
+		notes,
+		isNotesLoading,
+	]);
 
 	const groupedNotes = useMemo(() => {
 		if (isNotesLoading || isDraftsLoading) return null;

--- a/apps/app/src/app/(dashboard)/notes/_components/SearchInput.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/SearchInput.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useRef, useState } from "react";
+import { Suspense, useRef, useState } from "react";
 import { SearchInputBase } from "@/components/ui/search-input-base";
 import { useEditorStore } from "@/store/useEditorStore";
 
@@ -9,18 +9,28 @@ function SearchInputInner() {
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
 
-	// Recover initial value from URL (combine q and tags for display)
-	const initialQ = searchParams.get("q") || "";
-	const initialTags = searchParams.get("tags")
+	// URLから期待される表示文字列を算出
+	const currentQ = searchParams.get("q") || "";
+	const currentTags = searchParams.get("tags")
 		? (searchParams.get("tags") ?? "")
 				.split(",")
 				.map((t) => `#${t}`)
 				.join(" ")
 		: "";
-	const [inputValue, setInputValue] = useState(
-		`${initialTags} ${initialQ}`.trim(),
-	);
+	const expectedValue = `${currentTags} ${currentQ}`.trim();
+
+	const [prevExpected, setPrevExpected] = useState(expectedValue);
+	const [inputValue, setInputValue] = useState(expectedValue);
 	const inputRef = useRef<HTMLInputElement>(null);
+
+	// レンダー中に searchParams の変更を検知して同次同期（レンダーパスの追加を回避）
+	if (prevExpected !== expectedValue) {
+		setPrevExpected(expectedValue);
+		// ユーザーが入力中でない場合のみ上書きする
+		if (!inputRef.current || document.activeElement !== inputRef.current) {
+			setInputValue(expectedValue);
+		}
+	}
 
 	const isDirty = useEditorStore((state) => state.isDirty);
 
@@ -57,24 +67,6 @@ function SearchInputInner() {
 		const targetPath = pathname === "/notes" ? pathname : "/notes";
 		router.push(`${targetPath}?${params.toString()}`, { scroll: false });
 	};
-
-	// 外部からのURL変更（Inboxクリック等）に inputValue を追従させるだけの一方向同期
-	useEffect(() => {
-		// ユーザーが入力中の場合（IME変換中など）は、URLからの強制上書きをスキップする
-		if (inputRef.current && document.activeElement === inputRef.current) {
-			return;
-		}
-
-		const currentQ = searchParams.get("q") || "";
-		const currentTags = searchParams.get("tags")
-			? (searchParams.get("tags") ?? "")
-					.split(",")
-					.map((t) => `#${t}`)
-					.join(" ")
-			: "";
-		const expected = `${currentTags} ${currentQ}`.trim();
-		setInputValue(expected);
-	}, [searchParams]);
 
 	const handleClear = () => {
 		setInputValue("");


### PR DESCRIPTION
…ering for notes

Why:
- Synchronous navigation via `router.push()` in the `/notes` dashboard caused visible switching delays, address bar flickering, and unwanted browser hard-reload indicators during tab switches and drill-down operations.
- Server-side auth checks (`requireUser`) in `page.tsx` blocked instant UI updates, hindering a native-like seamless experience.

What:
- Wrapped `router.push()` calls in `React.useTransition` (`startTransition`) with `{ scroll: false }` option in `MiddlePaneList.tsx` to enforce 0ms SPA navigation.
- Relaxed `isTabReady` blocking in `NotesContainer.tsx` to prioritize rendering in-memory TanStack Query cache data immediately.
- Refactored `SearchInput.tsx` to use render-time state adjustment instead of `useEffect` for URL param synchronization, eliminating redundant render passes.
- Updated test suites in `MiddlePaneList.test.tsx`, `NotesContainer.test.tsx`, and `SearchInput.test.tsx` to validate transition wrappers and scroll options.