### PR TITLE
refactor(app): fix NoteCard sticky header positioning and pane scroll…

### DIFF
--- a/apps/app/src/app/(dashboard)/_components/DraftEditor.test.tsx
+++ b/apps/app/src/app/(dashboard)/_components/DraftEditor.test.tsx
@@ -182,4 +182,27 @@ describe("DraftEditor - Error Handling & Architecture", () => {
 			expect(mockRefresh).not.toHaveBeenCalled();
 		});
 	});
+
+	it("タブ切替（SELF REVIEW ⇔ GLOBAL MATERIALS）が即座にトグル可能であること", async () => {
+		const queryClient = createTestQueryClient();
+		const user = userEvent.setup();
+		render(
+			<QueryClientProvider client={queryClient}>
+				<DraftEditor />
+			</QueryClientProvider>,
+		);
+
+		const reviewTab = screen.getAllByRole("button", { name: "SELF REVIEW" })[0];
+		const materialsTab = screen.getAllByRole("button", {
+			name: "GLOBAL MATERIALS",
+		})[0];
+
+		expect(reviewTab).toBeInTheDocument();
+		expect(materialsTab).toBeInTheDocument();
+
+		await user.click(materialsTab);
+		expect(
+			screen.getAllByPlaceholderText(/search.*materials/i)[0],
+		).toBeInTheDocument();
+	});
 });

--- a/apps/app/src/app/(dashboard)/_components/DraftEditor.tsx
+++ b/apps/app/src/app/(dashboard)/_components/DraftEditor.tsx
@@ -81,8 +81,11 @@ export default function DraftEditor({
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const supabase = createClient();
-	const activePane =
+	const initialPane =
 		searchParams.get("tab") === "materials" ? "materials" : "review";
+	const [activePane, setActivePane] = useState<"review" | "materials">(
+		initialPane,
+	);
 	const [isPanelOpen, setIsPanelOpen] = useState(false);
 
 	const togglePanel = () => {
@@ -316,6 +319,22 @@ export default function DraftEditor({
 		setHasUnsavedNotesChanges(true);
 	};
 
+	const handleUpdateNoteType = (id: string, newType: NoteType) => {
+		setReviewNotes((prev) =>
+			prev.map((n) => (n.id === id ? { ...n, note_type: newType } : n)),
+		);
+		setHasUnsavedNotesChanges(true);
+	};
+
+	const handleToggleNoteResolved = (id: string) => {
+		setReviewNotes((prev) =>
+			prev.map((n) =>
+				n.id === id ? { ...n, is_resolved: !n.is_resolved } : n,
+			),
+		);
+		setHasUnsavedNotesChanges(true);
+	};
+
 	const handleDeleteNote = (id: string) => {
 		const noteToDelete = reviewNotes.find((n) => n.id === id);
 		if (noteToDelete?.draft_id) {
@@ -351,9 +370,12 @@ export default function DraftEditor({
 		// Save current state before weave
 		pushToHistory(content);
 
+		// 未解決のノート（!is_resolved）のみを Weave の対象とする
+		const activeReviewNotes = reviewNotes.filter((n) => !n.is_resolved);
+
 		const { newContent, planError, error } = await generateWeave(
 			content,
-			reviewNotes,
+			activeReviewNotes,
 			activeTemplate,
 		);
 
@@ -370,12 +392,12 @@ export default function DraftEditor({
 			setContent(newContent);
 			pushToHistory(newContent);
 
-			// Auto-Consume Review Notes
-			const noteIdsToDelete = reviewNotes.map((note) => note.id);
+			// Auto-Consume only active review notes used in Weave
+			const noteIdsToDelete = activeReviewNotes.map((note) => note.id);
 			if (noteIdsToDelete.length > 0) {
 				deleteNotesMutation.mutate(noteIdsToDelete);
 			}
-			setReviewNotes([]);
+			setReviewNotes((prev) => prev.filter((n) => n.is_resolved));
 		}
 	};
 
@@ -522,11 +544,13 @@ export default function DraftEditor({
 		}
 	};
 
-	const updatePane = (pane: string) => {
-		const params = new URLSearchParams(searchParams.toString());
-		params.set("tab", pane);
+	const updatePane = (pane: "review" | "materials") => {
+		setActivePane(pane);
 		setIsPanelOpen(true);
-		router.replace(`?${params.toString()}`);
+		// Passive URL sync without trigger router re-render
+		const params = new URLSearchParams(window.location.search);
+		params.set("tab", pane);
+		window.history.replaceState(null, "", `?${params.toString()}`);
 	};
 
 	const handleTemplateSaved = async (newTemplate: Template) => {
@@ -706,6 +730,8 @@ export default function DraftEditor({
 									isLoadingReview={isLoadingReview}
 									onAddNote={handleAddNote}
 									onUpdateNote={handleUpdateNote}
+									onUpdateNoteType={handleUpdateNoteType}
+									onToggleNoteResolved={handleToggleNoteResolved}
 									onDeleteNote={handleDeleteNote}
 									onDeleteAllNotes={handleDeleteAllNotes}
 									onReorderNotes={handleReorderNotes}
@@ -931,6 +957,8 @@ export default function DraftEditor({
 										isLoadingReview={isLoadingReview}
 										onAddNote={handleAddNote}
 										onUpdateNote={handleUpdateNote}
+										onUpdateNoteType={handleUpdateNoteType}
+										onToggleNoteResolved={handleToggleNoteResolved}
 										onDeleteNote={handleDeleteNote}
 										onDeleteAllNotes={handleDeleteAllNotes}
 										onReorderNotes={handleReorderNotes}
@@ -1033,6 +1061,8 @@ export default function DraftEditor({
 											isLoadingReview={isLoadingReview}
 											onAddNote={handleAddNote}
 											onUpdateNote={handleUpdateNote}
+											onUpdateNoteType={handleUpdateNoteType}
+											onToggleNoteResolved={handleToggleNoteResolved}
 											onDeleteNote={handleDeleteNote}
 											onDeleteAllNotes={handleDeleteAllNotes}
 											onReorderNotes={handleReorderNotes}

--- a/apps/app/src/app/(dashboard)/_components/NoteEditor.test.tsx
+++ b/apps/app/src/app/(dashboard)/_components/NoteEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import NoteEditor from "./NoteEditor";
@@ -51,18 +51,18 @@ describe("NoteEditor Progressive Warning", () => {
 		render(<NoteEditor onSubmit={vi.fn()} />);
 		const input = screen.getByPlaceholderText(/Write down your thoughts/i);
 
-		// 90%以上の文字を入力 (90文字)
-		const nearLimitText = "a".repeat(90);
-		await userEvent.type(input, nearLimitText);
+		// 90%以上の文字を入力 (9000文字)
+		const nearLimitText = "a".repeat(9000);
+		fireEvent.change(input, { target: { value: nearLimitText } });
 
-		expect(screen.getByText(/90 \/ 100/)).toBeInTheDocument();
+		expect(screen.getByText(/9,000 \/ 10,000/)).toBeInTheDocument();
 
-		// 超過入力 (101文字)
-		const overLimitText = "a".repeat(11);
-		await userEvent.type(input, overLimitText);
+		// 超過入力 (10,001文字)
+		const overLimitText = "a".repeat(10001);
+		fireEvent.change(input, { target: { value: overLimitText } });
 
 		const submitButton = screen.getByRole("button", { name: /Save note/i });
 		expect(submitButton).toBeDisabled();
-		expect(screen.getByText(/101 \/ 100/)).toBeInTheDocument();
+		expect(screen.getByText(/10,001 \/ 10,000/)).toBeInTheDocument();
 	});
 });

--- a/apps/app/src/app/(dashboard)/_components/NoteEditor.tsx
+++ b/apps/app/src/app/(dashboard)/_components/NoteEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { APP_LIMITS } from "@sitecue/shared";
+import { SHARED_LIMITS } from "@sitecue/shared";
 import { AlertTriangle, Info, Lightbulb, Send } from "lucide-react";
 import { useState } from "react";
 import toast from "react-hot-toast";
@@ -16,14 +16,20 @@ interface NoteEditorProps {
 }
 
 export default function NoteEditor({ onSubmit }: NoteEditorProps) {
+	const planState = useUserStore((state) => state.plan);
+	const userPlan = typeof planState === "string" ? planState : "free";
 	const openPaywall = useUserStore((state) => state.openPaywall);
 	const [content, setContent] = useState("");
 	const [noteType, setNoteType] = useState<NoteType>("info");
 	const [isSaving, setIsSaving] = useState(false);
 
+	const maxNoteLength =
+		SHARED_LIMITS.NOTE_LENGTH[userPlan.toUpperCase() as "FREE" | "PRO"] ||
+		SHARED_LIMITS.NOTE_LENGTH.FREE;
+
 	const charCount = content.length;
-	const isNearLimit = charCount >= APP_LIMITS.MAX_NOTE_LENGTH * 0.9;
-	const isOverLimit = charCount > APP_LIMITS.MAX_NOTE_LENGTH;
+	const isNearLimit = charCount >= maxNoteLength * 0.9;
+	const isOverLimit = charCount > maxNoteLength;
 
 	const handleSave = async (e?: React.FormEvent) => {
 		e?.preventDefault();
@@ -66,7 +72,7 @@ export default function NoteEditor({ onSubmit }: NoteEditorProps) {
 								: "text-neutral-400 hover-safe:text-note-info hover-safe:bg-neutral-100/50",
 						)}
 					>
-						<Info className="h-3 w-3" aria-hidden="true" />
+						<Info aria-hidden="true" className="h-3 w-3" />
 						Info
 					</FilterBadge>
 					<FilterBadge
@@ -79,7 +85,7 @@ export default function NoteEditor({ onSubmit }: NoteEditorProps) {
 								: "text-neutral-400 hover-safe:text-note-alert hover-safe:bg-neutral-100/50",
 						)}
 					>
-						<AlertTriangle className="h-3 w-3" aria-hidden="true" />
+						<AlertTriangle aria-hidden="true" className="h-3 w-3" />
 						Alert
 					</FilterBadge>
 					<FilterBadge
@@ -92,7 +98,7 @@ export default function NoteEditor({ onSubmit }: NoteEditorProps) {
 								: "text-neutral-400 hover-safe:text-note-idea hover-safe:bg-neutral-100/50",
 						)}
 					>
-						<Lightbulb className="h-3 w-3" aria-hidden="true" />
+						<Lightbulb aria-hidden="true" className="h-3 w-3" />
 						Idea
 					</FilterBadge>
 				</div>
@@ -112,24 +118,25 @@ export default function NoteEditor({ onSubmit }: NoteEditorProps) {
 					aria-label="Save note"
 					className="absolute right-2 bottom-2 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-action text-action-text shadow-lg transition-all hover:scale-105 active:scale-95 disabled:opacity-30 disabled:hover:scale-100 cursor-pointer"
 				>
-					<Send className="h-4 w-4" aria-hidden="true" />
+					<Send aria-hidden="true" className="h-4 w-4" />
 				</button>
 			</div>
 			<div className="flex justify-between items-center">
 				<p className="text-[10px] text-gray-400">
 					{isSaving ? "Saving..." : "Markdown supported"}
 				</p>
-				{isNearLimit && (
-					<span
-						className={cn(
-							"text-[10px] font-bold transition-opacity duration-300",
-							isOverLimit ? "text-note-alert" : "text-note-idea",
-						)}
-					>
-						{charCount.toLocaleString()} /{" "}
-						{APP_LIMITS.MAX_NOTE_LENGTH.toLocaleString()}
-					</span>
-				)}
+				<span
+					className={cn(
+						"text-[10px] font-mono font-bold transition-opacity duration-300",
+						isOverLimit
+							? "text-note-alert"
+							: isNearLimit
+								? "text-note-idea"
+								: "text-neutral-400",
+					)}
+				>
+					{charCount.toLocaleString()} / {maxNoteLength.toLocaleString()}
+				</span>
 			</div>
 		</div>
 	);

--- a/apps/app/src/app/(dashboard)/diaries/[date]/_components/DiaryMaterialsPane.test.tsx
+++ b/apps/app/src/app/(dashboard)/diaries/[date]/_components/DiaryMaterialsPane.test.tsx
@@ -1,121 +1,56 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
-import React from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { DiaryMaterialsPane } from "./DiaryMaterialsPane";
 
-// Supabaseクライアントのモック
-const mockGetUser = vi
-	.fn()
-	.mockResolvedValue({ data: { user: { id: "user-123" } } });
 vi.mock("@/utils/supabase/client", () => ({
 	createClient: () => ({
-		auth: { getUser: mockGetUser },
+		auth: {
+			getUser: vi.fn().mockResolvedValue({ data: { user: { id: "u-1" } } }),
+		},
 	}),
 }));
 
-// DAL関数のモック
-vi.mock("@sitecue/shared", () => ({
-	fetchNotesByDate: vi.fn().mockResolvedValue([
-		{
-			id: "note-1",
-			content: "Note Content Markdown",
-			created_at: "2026-06-28T17:45:00Z",
-			scope: "exact",
-			note_type: "idea",
-		},
-	]),
-	fetchDraftsByDate: vi.fn().mockResolvedValue([]),
-}));
-
-// 本家 NoteCard コンポーネントをテスト環境用に安全に擬似レンダリングモック化
-vi.mock("../../../studio/_components/NoteCard", () => ({
-	default: ({
-		note,
-		onInsert,
-		showTimeOnly,
-	}: {
-		note: { content: string };
-		onInsert?: (content: string) => void;
-		showTimeOnly?: boolean;
-	}) =>
-		React.createElement(
-			"div",
-			{ "data-testid": "mock-note-card" },
-			React.createElement("span", null, note.content),
-			React.createElement(
-				"span",
-				null,
-				showTimeOnly ? "time-mode" : "date-mode",
-			),
-			onInsert &&
-				React.createElement(
-					"button",
-					{ type: "button", onClick: () => onInsert(note.content) },
-					"Insert",
-				),
-		),
-}));
-
-describe("DiaryMaterialsPane - Integrated Architecture Validation", () => {
-	let queryClient: QueryClient;
-
-	beforeEach(() => {
-		vi.clearAllMocks();
-		queryClient = new QueryClient({
-			defaultOptions: {
-				queries: {
-					retry: false,
-				},
+vi.mock("@sitecue/shared", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@sitecue/shared")>();
+	return {
+		...actual,
+		fetchNotesByDate: vi.fn().mockResolvedValue([
+			{
+				id: "note-1",
+				content: "Test Diary Note Content",
+				note_type: "info",
+				created_at: "2026-08-06T10:00:00Z",
+				updated_at: "2026-08-06T10:00:00Z",
+				url_pattern: "example.com",
+				user_id: "u-1",
+				is_expanded: false,
+				is_favorite: false,
+				is_pinned: false,
+				is_resolved: false,
+				sort_order: 0,
+				scope: "exact",
+				draft_id: null,
 			},
+		]),
+		fetchDraftsByDate: vi.fn().mockResolvedValue([]),
+	};
+});
+
+describe("DiaryMaterialsPane Component", () => {
+	it("ノートカードが表示され、Insert to Editor ボタンが存在しないこと", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
 		});
-	});
-
-	it("初期ロード中も固定ヘッダーが表示され、リスト領域のみがスケルトン表示されること", async () => {
 		render(
-			React.createElement(
-				QueryClientProvider,
-				{ client: queryClient },
-				React.createElement(DiaryMaterialsPane, { date: "2026-08-05" }),
-			),
+			<QueryClientProvider client={queryClient}>
+				<DiaryMaterialsPane date="2026-08-06" />
+			</QueryClientProvider>,
 		);
 
-		// ヘッダー枠組みが0msで存在することを確認
-		expect(screen.getByText(/Materials of the Day/i)).toBeInTheDocument();
-
-		// データ着信後のカード表示を確認
-		const card = await screen.findByTestId("mock-note-card");
-		expect(card).toBeInTheDocument();
-	});
-
-	it("データロード完了後、一本化された本家NoteCardがshowTimeOnlyモードで正しく呼び出されること", async () => {
-		render(
-			React.createElement(
-				QueryClientProvider,
-				{ client: queryClient },
-				React.createElement(DiaryMaterialsPane, { date: "2026-06-28" }),
-			),
-		);
-		const card = await screen.findByTestId("mock-note-card");
-		expect(card).toBeInTheDocument();
-		expect(card).toHaveTextContent("Note Content Markdown");
-		expect(card).toHaveTextContent("time-mode");
-	});
-
-	it("素材カード内のインサート処理が親コンポーネントのコールバックへ正確にプロキシされること", async () => {
-		const handleInsert = vi.fn();
-		render(
-			React.createElement(
-				QueryClientProvider,
-				{ client: queryClient },
-				React.createElement(DiaryMaterialsPane, {
-					date: "2026-06-28",
-					onInsert: handleInsert,
-				}),
-			),
-		);
-		const insertBtn = await screen.findByRole("button", { name: /Insert/i });
-		fireEvent.click(insertBtn);
-		expect(handleInsert).toHaveBeenCalledWith("Note Content Markdown");
+		expect(
+			await screen.findByText("Test Diary Note Content"),
+		).toBeInTheDocument();
+		expect(screen.queryByTitle("Insert to Editor")).not.toBeInTheDocument();
 	});
 });

--- a/apps/app/src/app/(dashboard)/diaries/[date]/_components/DiaryMaterialsPane.tsx
+++ b/apps/app/src/app/(dashboard)/diaries/[date]/_components/DiaryMaterialsPane.tsx
@@ -4,6 +4,7 @@ import type { Note } from "@sitecue/shared";
 import { fetchDraftsByDate, fetchNotesByDate } from "@sitecue/shared";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft, Calendar } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { createClient } from "@/utils/supabase/client";
 import NoteCard from "../../../studio/_components/NoteCard";
 
@@ -36,15 +37,16 @@ export function DiaryMaterialsPane({ date, onInsert }: Props) {
 
 	return (
 		<div className="w-full h-full flex flex-col overflow-hidden bg-base-surface">
-			{/* 💡 固定ヘッダー: 0ms で常時即時表示 */}
+			{/* 1. 固定ヘッダー (shrink-0) */}
 			<div className="p-4 border-b border-base-border shrink-0 bg-base-surface/50 h-14 flex items-center">
 				<h2 className="text-xs font-bold text-action uppercase tracking-widest font-mono flex items-center gap-2">
 					<Calendar className="w-3.5 h-3.5 text-neutral-400" />
-					Materials of the Day ({isLoading ? "..." : notes.length + drafts.length})
+					Materials of the Day (
+					{isLoading ? "..." : notes.length + drafts.length})
 				</h2>
 			</div>
 
-			{/* 独立スクロール領域 */}
+			{/* 2. 独立スクロール領域 (flex-1 overflow-y-auto min-h-0) */}
 			<div className="flex-1 overflow-y-auto p-4 space-y-4 min-h-0 custom-scrollbar">
 				{isLoading ? (
 					/* 💡 取得中: 枠組みを崩さずリスト領域内のみにスケルトンを表示 */
@@ -73,7 +75,7 @@ export function DiaryMaterialsPane({ date, onInsert }: Props) {
 										<NoteCard
 											key={note.id}
 											note={note}
-											onInsert={onInsert}
+											onInsert={undefined}
 											showTimeOnly={true}
 										/>
 									))}
@@ -113,17 +115,19 @@ export function DiaryMaterialsPane({ date, onInsert }: Props) {
 											showTimeOnly={true}
 											rightAction={
 												onInsert && (
-													<button
+													<Button
 														type="button"
 														onClick={() => onInsert(draft.content || "")}
-														className="p-1 text-neutral-400 hover-safe:text-action hover-safe:bg-neutral-100 rounded-md transition-colors"
+														radius="full"
+														size="icon-sm"
+														variant="ghost"
 														title="Insert to Editor"
 													>
 														<ArrowLeft
 															className="w-3.5 h-3.5"
 															aria-hidden="true"
 														/>
-													</button>
+													</Button>
 												)
 											}
 										/>

--- a/apps/app/src/app/(dashboard)/diaries/[date]/page.test.tsx
+++ b/apps/app/src/app/(dashboard)/diaries/[date]/page.test.tsx
@@ -10,6 +10,7 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/hooks/useDiariesQuery", () => ({
 	useFetchDiaries: vi.fn(() => ({ data: [] })),
+	useFetchDiaryByDate: vi.fn(() => ({ data: null, isLoading: false })),
 	useUpdateDiary: () => ({ mutateAsync: vi.fn() }),
 }));
 
@@ -57,10 +58,10 @@ describe("DiaryStudioClient - AppShell Asset Reuse Validation", () => {
 			}),
 		);
 
-		expect(screen.getByText("Diary Studio")).toBeInTheDocument();
-		expect(screen.getByText("2026-06-21")).toBeInTheDocument();
-		expect(screen.getByText("Save Diary")).toBeInTheDocument();
-		expect(screen.getByText("5 chars")).toBeInTheDocument();
+		expect(screen.getAllByText("Diary Studio")[0]).toBeInTheDocument();
+		expect(screen.getAllByText("2026-06-21")[0]).toBeInTheDocument();
+		expect(screen.getAllByText("Save Diary")[0]).toBeInTheDocument();
+		expect(screen.getAllByText("5 chars")[0]).toBeInTheDocument();
 	});
 
 	it("メインの執筆キャンバスが読み込まれ、グレー背景ではなくメイン背景（bg-base-bg）が担保されていること", () => {
@@ -80,7 +81,7 @@ describe("DiaryStudioClient - AppShell Asset Reuse Validation", () => {
 			}),
 		);
 
-		const editor = screen.getByTestId("mock-code-editor");
+		const editor = screen.getAllByTestId("mock-code-editor")[0];
 		expect(editor).toBeInTheDocument();
 
 		// bg-base-bg がレイアウトに付与されていることの検証

--- a/apps/app/src/app/(dashboard)/notes/_components/SearchModal.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/SearchModal.test.tsx
@@ -18,7 +18,7 @@ vi.mock("@/hooks/useNotesQuery", () => ({
 	useFetchNoteContents: () => ({ mutate: mockFetchNoteContents }),
 }));
 
-const mockFetchDiaries = vi.fn(() => ({ data: [] as any[] }));
+const mockFetchDiaries = vi.fn(() => ({ data: [] as unknown[] }));
 vi.mock("@/hooks/useDiariesQuery", () => ({
 	useFetchDiaries: () => mockFetchDiaries(),
 	useAppendDiary: () => ({ mutate: vi.fn() }),

--- a/apps/app/src/app/(dashboard)/studio/_components/DraftEditorHeader.tsx
+++ b/apps/app/src/app/(dashboard)/studio/_components/DraftEditorHeader.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeft, Check, MoreHorizontal } from "lucide-react";
-import { CustomLink } from "@/components/ui/custom-link";
 import { Button } from "@/components/ui/button";
+import { CustomLink } from "@/components/ui/custom-link";
 import {
 	Popover,
 	PopoverContent,

--- a/apps/app/src/app/(dashboard)/studio/_components/NoteCard.tsx
+++ b/apps/app/src/app/(dashboard)/studio/_components/NoteCard.tsx
@@ -1,78 +1,159 @@
 "use client";
 
-import type { Note } from "@sitecue/shared";
+import type { Note, ViewScope as NoteScope, NoteType } from "@sitecue/shared";
+import { SHARED_LIMITS } from "@sitecue/shared";
 import {
-	AlertTriangle,
 	ArrowLeft,
 	Check,
 	ChevronDown,
-	ChevronUp,
-	FileText,
-	Info,
-	Lightbulb,
+	Copy,
+	GripVertical,
 	Pencil,
 	Trash2,
 	X,
 } from "lucide-react";
-import { memo, useEffect, useRef, useState } from "react";
+import React, { memo, useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
 import TextareaAutosize from "react-textarea-autosize";
 import MarkdownRenderer from "@/components/MarkdownRenderer";
+import { Button } from "@/components/ui/button";
+import { FilterBadge } from "@/components/ui/filter-badge";
+import { NoteStatusBadge } from "@/components/ui/note-status-badge";
+import { useMarkdownAssist } from "@/hooks/useMarkdownAssist";
 import { cn } from "@/lib/utils";
+import { useUserStore } from "@/store/useUserStore";
 
-interface NoteCardProps {
+const COLLAPSE_THRESHOLD = 160;
+
+const MemoizedMarkdown = React.memo(
+	function MemoizedMarkdown({ content }: { content: string }) {
+		return (
+			<MarkdownRenderer
+				className="prose-headings:text-sm prose-headings:font-bold break-words [overflow-wrap:anywhere] [&_p]:[overflow-wrap:anywhere] [&_a]:break-all [&_a]:[overflow-wrap:anywhere] [&_code]:[overflow-wrap:anywhere]"
+				content={content}
+			/>
+		);
+	},
+	(prevProps, nextProps) => prevProps.content === nextProps.content,
+);
+
+export interface NoteCardProps {
 	note: Note;
 	onUpdate?: (id: string, content: string) => void;
+	onUpdateType?: (id: string, noteType: NoteType) => void;
+	onUpdateScope?: (id: string, scope: NoteScope) => void;
+	onToggleResolved?: (id: string) => void;
 	onDelete?: (id: string) => void;
 	onInsert?: (content: string) => void;
+	dragHandleProps?: React.HTMLAttributes<HTMLDivElement>;
 	showTimeOnly?: boolean;
 	isDraft?: boolean;
+	hideScopeSelect?: boolean;
 	rightAction?: React.ReactNode;
 }
 
 function NoteCardBase({
 	note,
 	onUpdate,
+	onUpdateType,
+	onUpdateScope,
+	onToggleResolved,
 	onDelete,
 	onInsert,
+	dragHandleProps,
 	showTimeOnly = false,
 	isDraft = false,
+	hideScopeSelect = false,
 	rightAction,
 }: NoteCardProps) {
+	const planState = useUserStore((state) => state.plan);
+	const userPlan = typeof planState === "string" ? planState : "free";
+	const maxNoteLength =
+		SHARED_LIMITS.NOTE_LENGTH[userPlan.toUpperCase() as "FREE" | "PRO"] ||
+		SHARED_LIMITS.NOTE_LENGTH.FREE;
+
 	const [isEditing, setIsEditing] = useState(false);
 	const [editContent, setEditContent] = useState(note.content);
+	const [editType, setEditType] = useState<NoteType>(
+		(note.note_type as NoteType) || "info",
+	);
+	const [editScope, setEditScope] = useState<NoteScope>(note.scope || "draft");
+	const [isCopied, setIsCopied] = useState(false);
 
 	const [isExpanded, setIsExpanded] = useState(false);
-	const [hasOverflow, setHasOverflow] = useState(false);
+	const [isOverflowing, setIsOverflowing] = useState(() => {
+		return (note.content ?? "").length > 120;
+	});
+
+	const isCollapsed = isOverflowing && !isExpanded;
 	const contentRef = useRef<HTMLDivElement>(null);
+	const cardRef = useRef<HTMLDivElement>(null);
+	const prevExpandedRef = useRef(isExpanded);
+	const { onKeyDown, onPaste } = useMarkdownAssist();
+
+	const charCount = editContent.length;
+	const isOverLimit = charCount > maxNoteLength;
 
 	useEffect(() => {
-		const element = contentRef.current;
-		if (!element || isEditing) return;
+		if (prevExpandedRef.current && !isExpanded) {
+			if (
+				cardRef.current &&
+				typeof cardRef.current.scrollIntoView === "function"
+			) {
+				cardRef.current.scrollIntoView({
+					behavior: "smooth",
+					block: "nearest",
+				});
+			}
+		}
+		prevExpandedRef.current = isExpanded;
+	}, [isExpanded]);
 
-		const _content = note.content;
-
-		const checkOverflow = () => {
-			const isOverflowing = element.scrollHeight > 76;
-			setHasOverflow(isOverflowing);
-		};
-
-		checkOverflow();
-
-		const observer = new ResizeObserver(checkOverflow);
-		observer.observe(element);
-		return () => observer.disconnect();
+	useEffect(() => {
+		const el = contentRef.current;
+		if (!el || isEditing) return;
+		if (note.content && el.scrollHeight > 0) {
+			setIsOverflowing(el.scrollHeight > COLLAPSE_THRESHOLD);
+		}
 	}, [note.content, isEditing]);
 
 	const handleSave = () => {
-		if (onUpdate) {
-			onUpdate(note.id, editContent);
+		if (isOverLimit || !editContent.trim()) return;
+		if (onUpdate) onUpdate(note.id, editContent);
+		if (onUpdateType && editType !== note.note_type) {
+			onUpdateType(note.id, editType);
+		}
+		if (onUpdateScope && editScope !== note.scope) {
+			onUpdateScope(note.id, editScope);
 		}
 		setIsEditing(false);
 	};
 
 	const handleCancel = () => {
 		setEditContent(note.content);
+		setEditType((note.note_type as NoteType) || "info");
+		setEditScope(note.scope || "draft");
 		setIsEditing(false);
+	};
+
+	const handleBadgeClick = () => {
+		if (onToggleResolved) {
+			onToggleResolved(note.id);
+		} else if (onUpdateType) {
+			const types: NoteType[] = ["info", "alert", "idea"];
+			const currentIndex = types.indexOf(
+				(note.note_type as NoteType) || "info",
+			);
+			const nextType = types[(currentIndex + 1) % types.length];
+			onUpdateType(note.id, nextType);
+		}
+	};
+
+	const handleCopy = () => {
+		navigator.clipboard.writeText(note.content);
+		setIsCopied(true);
+		toast("Copied to clipboard");
+		setTimeout(() => setIsCopied(false), 2000);
 	};
 
 	const timeStr = note.created_at
@@ -84,147 +165,297 @@ function NoteCardBase({
 		: "";
 
 	return (
-		<div className="group cursor-default rounded-xl border border-base-border bg-base-bg p-4 transition-all hover:border-neutral-400 min-w-0 w-full overflow-hidden">
-			<div className="mb-2 flex items-center justify-between">
-				<div className="flex items-center gap-2">
-					<span
-						className={cn(
-							"flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide w-fit",
-							isDraft
-								? "bg-neutral-100 text-neutral-600"
-								: note.note_type === "alert"
-									? "bg-note-alert/10 text-note-alert"
-									: note.note_type === "idea"
-										? "bg-note-idea/10 text-note-idea"
-										: "bg-note-info/10 text-note-info",
-						)}
-					>
-						{isDraft ? (
-							<FileText className="w-3.5 h-3.5" aria-hidden="true" />
-						) : note.note_type === "alert" ? (
-							<AlertTriangle className="w-3.5 h-3.5" aria-hidden="true" />
-						) : note.note_type === "idea" ? (
-							<Lightbulb className="w-3.5 h-3.5" aria-hidden="true" />
-						) : (
-							<Info className="w-3.5 h-3.5" aria-hidden="true" />
-						)}
-						{isDraft ? "Draft" : note.note_type || "info"}
-					</span>
-					<span className="text-[10px] font-mono text-neutral-400 font-bold">
-						{showTimeOnly
-							? timeStr
-							: note.created_at
-								? note.created_at.split("T")[0]
-								: ""}
-					</span>
-				</div>
-
-				{!isEditing && (
-					<div className="flex items-center gap-1 opacity-100 pointer-fine:opacity-0 group-hover-safe:opacity-100 transition-opacity">
-						{rightAction}
-						{onInsert && (
-							<button
-								type="button"
-								onClick={() => onInsert(note.content)}
-								className="p-1 text-neutral-400 hover-safe:text-action hover-safe:bg-neutral-100 rounded-md transition-colors"
-								title="Insert to Editor"
-							>
-								<ArrowLeft className="w-3.5 h-3.5" aria-hidden="true" />
-							</button>
-						)}
-						{onUpdate && (
-							<button
-								type="button"
-								onClick={() => setIsEditing(true)}
-								className="p-1 text-neutral-400 hover-safe:text-action hover-safe:bg-neutral-100 rounded-md transition-colors"
-								title="Edit Note"
-							>
-								<Pencil className="w-3.5 h-3.5" aria-hidden="true" />
-							</button>
-						)}
-						{onDelete && (
-							<button
-								type="button"
-								onClick={() => onDelete(note.id)}
-								className="p-1 text-neutral-400 hover-safe:text-red-500 hover-safe:bg-red-50 rounded-md transition-colors"
-								title="Delete Note"
-							>
-								<Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
-							</button>
-						)}
-					</div>
-				)}
-			</div>
-
+		/* 🚨最外殻: Sticky動作を保護するため、overflow-hidden を絶対指定しないこと */
+		<div
+			ref={cardRef}
+			className={cn(
+				"group cursor-default rounded-xl border border-base-border bg-base-bg relative flex flex-col transition-all hover:border-neutral-400 min-w-0 w-full overflow-visible",
+				note.is_resolved && "opacity-60 bg-neutral-50/50",
+			)}
+		>
 			{isEditing ? (
-				<div className="space-y-2">
-					<TextareaAutosize
-						autoFocus
-						value={editContent}
-						onChange={(e) => setEditContent(e.target.value)}
-						className="w-full resize-none bg-transparent text-sm leading-snug text-neutral-900 border-none focus:ring-0 p-0"
-						placeholder="Edit note content..."
-					/>
-					<div className="flex items-center justify-end gap-2 pt-2 border-t border-neutral-100">
-						<button
-							type="button"
-							onClick={handleCancel}
-							className="p-1.5 text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100 rounded-md flex items-center gap-1 text-[10px] font-bold uppercase"
-						>
-							<X className="w-3 h-3" aria-hidden="true" />
-							Cancel
-						</button>
-						<button
-							type="button"
-							onClick={handleSave}
-							className="p-1.5 text-blue-600 hover:bg-blue-50 rounded-md flex items-center gap-1 text-[10px] font-bold uppercase"
-						>
-							<Check className="w-3 h-3" aria-hidden="true" />
-							Save
-						</button>
+				<div className="space-y-3 flex flex-col flex-1 min-w-0 relative animate-fadeIn p-3.5">
+					<div className="sticky top-0 z-10 bg-base-bg rounded-t-xl flex flex-col gap-0 shrink-0 select-none border-b border-base-border/20 pb-2">
+						<div className="flex items-center justify-between w-full min-h-[36px]">
+							<span className="text-xs font-bold text-neutral-400 uppercase tracking-wider">
+								Editing note...
+							</span>
+							<div className="flex items-center gap-1.5">
+								<Button
+									type="button"
+									onClick={handleCancel}
+									radius="full"
+									size="xs"
+									variant="ghost"
+								>
+									<X aria-hidden="true" className="w-3.5 h-3.5" />
+									Cancel
+								</Button>
+								<Button
+									type="button"
+									onClick={handleSave}
+									disabled={isOverLimit || !editContent.trim()}
+									radius="full"
+									size="xs"
+									variant="default"
+								>
+									<Check aria-hidden="true" className="w-3.5 h-3.5" />
+									Save
+								</Button>
+							</div>
+						</div>
+
+						<div className="flex items-center justify-between w-full pt-2 border-t border-base-border/30">
+							{!hideScopeSelect ? (
+								<div className="relative flex items-center shrink-0 px-3 py-1 bg-base-surface rounded-full border border-base-border/50">
+									<select
+										value={editScope}
+										onChange={(e) => setEditScope(e.target.value as NoteScope)}
+										className="cursor-pointer appearance-none bg-transparent pr-4 py-0 text-xs font-bold text-neutral-800 focus:outline-none select-none border-none ring-0 focus:ring-0"
+									>
+										<option value="draft">Draft Note</option>
+										<option value="exact">Page Note</option>
+										<option value="domain">Domain Note</option>
+										<option value="inbox">Inbox Note</option>
+									</select>
+									<div className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-neutral-400 text-[9px] select-none">
+										▼
+									</div>
+								</div>
+							) : (
+								<div />
+							)}
+
+							<div className="flex p-0.5 rounded-full bg-base-surface border border-base-border/50 shrink-0">
+								<FilterBadge
+									isActive={editType === "info"}
+									onClick={() => setEditType("info")}
+									className="px-2 py-0.5 text-[10px] uppercase"
+								>
+									Info
+								</FilterBadge>
+								<FilterBadge
+									isActive={editType === "alert"}
+									onClick={() => setEditType("alert")}
+									className="px-2 py-0.5 text-[10px] uppercase"
+								>
+									Alert
+								</FilterBadge>
+								<FilterBadge
+									isActive={editType === "idea"}
+									onClick={() => setEditType("idea")}
+									className="px-2 py-0.5 text-[10px] uppercase"
+								>
+									Idea
+								</FilterBadge>
+							</div>
+						</div>
 					</div>
-				</div>
-			) : (
-				<div className="min-w-0 w-full overflow-hidden space-y-1.5">
-					<div
-						ref={contentRef}
-						className={cn(
-							"min-w-0 w-full overflow-hidden transition-all duration-200",
-							!isExpanded && !isEditing && "max-h-[72px]",
-						)}
-					>
-						<MarkdownRenderer
-							content={note.content}
-							className="text-sm leading-snug text-neutral-600 group-hover:text-neutral-900 [&_p]:[overflow-wrap:anywhere] [&_a]:break-all [&_a]:[overflow-wrap:anywhere] [&_code]:[overflow-wrap:anywhere]"
+
+					<div className="flex-1 min-w-0 w-full pt-1">
+						<TextareaAutosize
+							autoFocus
+							value={editContent}
+							onChange={(e) => setEditContent(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.nativeEvent.isComposing) return;
+								if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+									e.preventDefault();
+									if (editContent.trim() && !isOverLimit) {
+										handleSave();
+									}
+								} else {
+									onKeyDown(e);
+								}
+							}}
+							onPaste={onPaste}
+							className="w-full border border-base-border rounded-xl p-2.5 text-sm bg-base-bg text-neutral-800 antialiased font-mono leading-relaxed focus:outline-none focus:ring-0 resize-none"
+							placeholder="Edit note content..."
 						/>
 					</div>
 
-					{hasOverflow && (
-						<div className="flex justify-start pt-0.5">
-							<button
-								type="button"
-								onClick={() => setIsExpanded(!isExpanded)}
-								className="text-[10px] font-bold text-neutral-400 hover:text-action flex items-center gap-0.5 uppercase tracking-wider transition-colors cursor-pointer"
-							>
-								{isExpanded ? (
-									<>
-										<ChevronUp className="w-3 h-3" aria-hidden="true" /> Show
-										less
-									</>
-								) : (
-									<>
-										<ChevronDown className="w-3 h-3" aria-hidden="true" /> Read
-										more
-									</>
+					<div className="flex items-center justify-end text-[10px] font-mono font-bold">
+						<span
+							className={cn(
+								isOverLimit ? "text-note-alert" : "text-neutral-400",
+							)}
+						>
+							{charCount.toLocaleString()} / {maxNoteLength.toLocaleString()}
+						</span>
+					</div>
+				</div>
+			) : (
+				<div className="flex flex-col flex-1 min-w-0">
+					{/* Sticky Header: 親スクロールコンテナに対して確実に吸着動作 */}
+					<div className="sticky top-0 z-10 bg-base-bg rounded-t-xl flex flex-col gap-0 select-none border-b border-base-border/20 px-3.5 pt-3 pb-2">
+						<div className="flex items-center justify-between w-full min-h-[32px] gap-2">
+							<div className="flex items-center gap-1.5 min-w-0">
+								{dragHandleProps && (
+									<div
+										{...dragHandleProps}
+										className="cursor-grab active:cursor-grabbing p-0.5 text-neutral-300 hover:text-neutral-600 rounded touch-none shrink-0"
+										title="Drag to reorder"
+									>
+										<GripVertical aria-hidden="true" className="w-4 h-4" />
+									</div>
 								)}
-							</button>
+								{isDraft ? (
+									<span className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide bg-neutral-100 text-neutral-600 shrink-0">
+										Draft
+									</span>
+								) : (
+									<NoteStatusBadge
+										type={note.note_type || "info"}
+										isResolved={note.is_resolved}
+										onClick={
+											onToggleResolved || onUpdateType
+												? handleBadgeClick
+												: undefined
+										}
+									/>
+								)}
+								<span className="text-[10px] font-mono text-neutral-400 font-bold truncate">
+									{showTimeOnly
+										? timeStr
+										: note.created_at
+											? note.created_at.split("T")[0]
+											: ""}
+								</span>
+							</div>
+
+							<div className="flex items-center gap-1 shrink-0 opacity-100 pointer-fine:opacity-0 group-hover-safe:opacity-100 transition-opacity">
+								{rightAction}
+								{onInsert && (
+									<Button
+										type="button"
+										onClick={() => onInsert(note.content)}
+										radius="full"
+										size="icon-sm"
+										variant="ghost"
+										title="Insert to Editor"
+									>
+										<ArrowLeft aria-hidden="true" className="w-3.5 h-3.5" />
+									</Button>
+								)}
+								{onUpdate && (
+									<Button
+										type="button"
+										onClick={() => {
+											setEditContent(note.content);
+											setEditType((note.note_type as NoteType) || "info");
+											setEditScope(note.scope || "draft");
+											setIsEditing(true);
+										}}
+										radius="full"
+										size="icon-sm"
+										variant="ghost"
+										title="Edit Note"
+									>
+										<Pencil aria-hidden="true" className="w-3.5 h-3.5" />
+									</Button>
+								)}
+								<Button
+									type="button"
+									onClick={handleCopy}
+									radius="full"
+									size="icon-sm"
+									variant="ghost"
+									title="Copy note"
+								>
+									{isCopied ? (
+										<Check
+											aria-hidden="true"
+											className="w-3.5 h-3.5 text-emerald-500"
+										/>
+									) : (
+										<Copy aria-hidden="true" className="w-3.5 h-3.5" />
+									)}
+								</Button>
+								{onDelete && (
+									<Button
+										type="button"
+										onClick={() => onDelete(note.id)}
+										radius="full"
+										size="icon-sm"
+										variant="ghost"
+										title="Delete Note"
+										className="hover-safe:text-red-500 hover-safe:bg-red-50"
+									>
+										<Trash2 aria-hidden="true" className="w-3.5 h-3.5" />
+									</Button>
+								)}
+							</div>
 						</div>
-					)}
+
+						{/* Sticky Show less button floating below header */}
+						{isOverflowing && isExpanded && (
+							<div className="absolute top-11 left-1/2 -translate-x-1/2 z-20 pointer-events-auto">
+								<button
+									type="button"
+									onClick={(e) => {
+										e.stopPropagation();
+										setIsExpanded(false);
+									}}
+									className="cursor-pointer text-[10px] font-bold text-neutral-500 hover:text-action hover:bg-base-surface px-2.5 py-1 rounded-full flex items-center gap-1 transition-all border border-base-border/50 bg-base-bg/90 shadow-sm"
+								>
+									<ChevronDown
+										aria-hidden="true"
+										className="w-3.5 h-3.5 shrink-0 rotate-180"
+									/>
+									<span>Show less</span>
+								</button>
+							</div>
+						)}
+					</div>
+
+					{/* Content Area: 本文直近で横膨張を防止（min-w-0 w-full break-words） */}
+					<div className="px-3.5 py-2.5 flex-1 min-w-0 w-full overflow-hidden">
+						<div
+							className={cn(
+								"relative w-full min-w-0",
+								isCollapsed && "max-h-40 overflow-hidden pb-8",
+							)}
+						>
+							<div
+								ref={contentRef}
+								className={cn(
+									"text-sm leading-relaxed min-w-0 w-full break-words [overflow-wrap:anywhere]",
+									note.is_resolved
+										? "line-through text-neutral-400"
+										: "text-neutral-700 group-hover:text-neutral-900",
+								)}
+							>
+								<MemoizedMarkdown content={note.content} />
+							</div>
+
+							{isCollapsed && (
+								<>
+									<div className="absolute bottom-0 left-0 w-full h-16 bg-gradient-to-t from-base-bg via-base-bg/80 to-transparent pointer-events-none" />
+									<div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-20">
+										<button
+											type="button"
+											onClick={(e) => {
+												e.stopPropagation();
+												setIsExpanded(true);
+											}}
+											className="cursor-pointer text-[10px] font-bold text-neutral-500 hover:text-action bg-base-bg hover:bg-base-surface px-2.5 py-1 rounded-full shadow-sm flex items-center gap-1 transition-colors border border-base-border"
+										>
+											<ChevronDown
+												aria-hidden="true"
+												className="w-3.5 h-3.5 shrink-0"
+											/>
+											<span>Read more</span>
+										</button>
+									</div>
+								</>
+							)}
+						</div>
+					</div>
 				</div>
 			)}
 
 			{note.url_pattern && !note.url_pattern.startsWith("sitecue://") && (
-				<p className="mt-2 text-[10px] text-neutral-400 truncate">
+				<p className="px-3.5 pb-2 text-[10px] text-neutral-400 truncate">
 					{note.url_pattern}
 				</p>
 			)}
@@ -232,5 +463,35 @@ function NoteCardBase({
 	);
 }
 
-export const NoteCard = memo(NoteCardBase);
+function arePropsEqual(prevProps: NoteCardProps, nextProps: NoteCardProps) {
+	const prevNote = prevProps.note;
+	const nextNote = nextProps.note;
+
+	const isNoteEqual =
+		prevNote === nextNote ||
+		(prevNote.id === nextNote.id &&
+			prevNote.content === nextNote.content &&
+			prevNote.is_expanded === nextNote.is_expanded &&
+			prevNote.is_favorite === nextNote.is_favorite &&
+			prevNote.is_pinned === nextNote.is_pinned &&
+			prevNote.is_resolved === nextNote.is_resolved &&
+			prevNote.note_type === nextNote.note_type &&
+			prevNote.scope === nextNote.scope);
+
+	return (
+		isNoteEqual &&
+		prevProps.showTimeOnly === nextProps.showTimeOnly &&
+		prevProps.isDraft === nextProps.isDraft &&
+		prevProps.hideScopeSelect === nextProps.hideScopeSelect &&
+		prevProps.onUpdate === nextProps.onUpdate &&
+		prevProps.onUpdateType === nextProps.onUpdateType &&
+		prevProps.onUpdateScope === nextProps.onUpdateScope &&
+		prevProps.onToggleResolved === nextProps.onToggleResolved &&
+		prevProps.onDelete === nextProps.onDelete &&
+		prevProps.onInsert === nextProps.onInsert &&
+		prevProps.dragHandleProps === nextProps.dragHandleProps
+	);
+}
+
+export const NoteCard = memo(NoteCardBase, arePropsEqual);
 export default NoteCard;

--- a/apps/app/src/app/(dashboard)/studio/_components/StudioMaterialsPane.tsx
+++ b/apps/app/src/app/(dashboard)/studio/_components/StudioMaterialsPane.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { Note } from "@sitecue/shared";
+import { SWRBoundary } from "@/components/ui/swr-boundary";
 import NoteCard from "./NoteCard";
 import StudioSearchInput from "./StudioSearchInput";
 
@@ -21,8 +22,8 @@ export default function StudioMaterialsPane({
 }: StudioMaterialsPaneProps) {
 	return (
 		<div className="flex h-full flex-col bg-neutral-50/10 min-w-0 w-full overflow-hidden">
-			{/* Search Bar */}
-			<div className="p-4 border-b border-neutral-200 bg-white/50 sticky top-0 z-10 backdrop-blur-md shrink-0">
+			{/* 1. Search Bar: 固定上部ヘッダー (shrink-0) */}
+			<div className="p-4 border-b border-neutral-200 bg-white/50 z-10 backdrop-blur-md shrink-0">
 				<StudioSearchInput
 					searchKeyword={searchKeyword}
 					onSearchKeywordChange={onSearchKeywordChange}
@@ -30,36 +31,43 @@ export default function StudioMaterialsPane({
 				/>
 			</div>
 
-			{/* Search Results */}
-			<div className="flex-1 p-4 overflow-y-auto pb-safe w-full min-w-0 overflow-x-hidden">
-				<div className="grid grid-cols-[minmax(0,1fr)] gap-3 w-full min-w-0 overflow-hidden">
-					{isSearching ? (
-						Array.from({ length: 3 }).map((_, i) => (
-							<div
-								key={`skeleton-search-${
-									// biome-ignore lint/suspicious/noArrayIndexKey: Skeletons are static
-									i
-								}`}
-								className="h-24 animate-pulse rounded-xl border border-neutral-100 bg-neutral-100/50"
-							/>
-						))
-					) : searchResults.length === 0 ? (
-						<div className="flex h-40 flex-col items-center justify-center rounded-xl border border-dashed border-neutral-200 px-4 py-8 text-center text-neutral-400">
-							<p className="text-sm font-medium">No materials found.</p>
-							<p className="mt-1 text-[10px]">
-								Enter keywords to search your past notes
-								<br />
-								and saved pages.
-							</p>
+			{/* 2. Search Results: 独立スクロール領域 (flex-1 overflow-y-auto min-h-0) */}
+			<div className="flex-1 p-4 overflow-y-auto pb-safe w-full min-w-0 min-h-0">
+				<SWRBoundary
+					data={searchResults}
+					isLoading={isSearching}
+					fallback={
+						<div className="grid grid-cols-[minmax(0,1fr)] gap-3 w-full min-w-0 overflow-hidden">
+							{["skel-1", "skel-2", "skel-3"].map((skelKey) => (
+								<div
+									key={skelKey}
+									className="h-24 animate-pulse rounded-xl border border-neutral-100 bg-neutral-100/50"
+								/>
+							))}
 						</div>
-					) : (
-						searchResults.map((note) => (
-							<div key={note.id} className="min-w-0 w-full overflow-hidden">
-								<NoteCard note={note} />
-							</div>
-						))
+					}
+				>
+					{(notes) => (
+						<div className="grid grid-cols-[minmax(0,1fr)] gap-3 w-full min-w-0">
+							{notes.length === 0 ? (
+								<div className="flex h-40 flex-col items-center justify-center rounded-xl border border-dashed border-neutral-200 px-4 py-8 text-center text-neutral-400">
+									<p className="text-sm font-medium">No materials found.</p>
+									<p className="mt-1 text-[10px]">
+										Enter keywords to search your past notes
+										<br />
+										and saved pages.
+									</p>
+								</div>
+							) : (
+								notes.map((note) => (
+									<div key={note.id} className="min-w-0 w-full">
+										<NoteCard note={note} />
+									</div>
+								))
+							)}
+						</div>
 					)}
-				</div>
+				</SWRBoundary>
 			</div>
 		</div>
 	);

--- a/apps/app/src/app/(dashboard)/studio/_components/StudioReviewPane.test.tsx
+++ b/apps/app/src/app/(dashboard)/studio/_components/StudioReviewPane.test.tsx
@@ -1,10 +1,39 @@
+import type { Note } from "@sitecue/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import StudioReviewPane from "./StudioReviewPane";
 
-describe("StudioReviewPane - AI Review", () => {
+vi.mock("@/store/useUserStore", () => ({
+	// biome-ignore lint/suspicious/noExplicitAny: mock state
+	useUserStore: (selector?: (state: any) => any) => {
+		const state = { plan: "free", openPaywall: vi.fn() };
+		return selector ? selector(state) : state;
+	},
+}));
+
+describe("StudioReviewPane Component", () => {
+	const mockNotes: Note[] = [
+		{
+			id: "note-1",
+			content: "Test Review Note",
+			note_type: "info",
+			scope: "draft",
+			url_pattern: "sitecue://draft/d-1",
+			user_id: "u-1",
+			created_at: "2026-06-01T00:00:00.000Z",
+			updated_at: "2026-06-01T00:00:00.000Z",
+			is_expanded: false,
+			is_favorite: false,
+			is_pinned: false,
+			is_resolved: false,
+			sort_order: 0,
+			draft_id: "d-1",
+			tags: null,
+		},
+	];
+
 	it("should call onGenerateReview when AI Review button is clicked", async () => {
 		const user = userEvent.setup();
 		const mockGenerate = vi.fn().mockResolvedValue(undefined);
@@ -39,5 +68,71 @@ describe("StudioReviewPane - AI Review", () => {
 		await user.click(aiButton);
 
 		expect(mockGenerate).toHaveBeenCalledTimes(1);
+	});
+
+	it("レビューノート一覧とタイプ切り替え操作が正しくレンダリングされること", () => {
+		const handleUpdateNote = vi.fn();
+		const handleUpdateNoteType = vi.fn();
+
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
+		});
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<StudioReviewPane
+					reviewNotes={mockNotes}
+					isLoadingReview={false}
+					isWeaving={false}
+					onAddNote={vi.fn()}
+					onDeleteAllNotes={vi.fn()}
+					onDeleteNote={vi.fn()}
+					onGenerateReview={vi.fn()}
+					onInsertToEditor={vi.fn()}
+					onReorderNotes={vi.fn()}
+					onUpdateNote={handleUpdateNote}
+					onUpdateNoteType={handleUpdateNoteType}
+					onWeave={vi.fn()}
+					isGeneratingReview={false}
+				/>
+			</QueryClientProvider>,
+		);
+
+		expect(screen.getByText("Review Notes (1)")).toBeInTheDocument();
+		expect(screen.getByText("Test Review Note")).toBeInTheDocument();
+	});
+
+	it("グラブアイコンが存在し、ドラッグ領域が独立して提供されていること", () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
+		});
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<StudioReviewPane
+					reviewNotes={mockNotes}
+					isLoadingReview={false}
+					isWeaving={false}
+					onAddNote={vi.fn()}
+					onDeleteAllNotes={vi.fn()}
+					onDeleteNote={vi.fn()}
+					onGenerateReview={vi.fn()}
+					onInsertToEditor={vi.fn()}
+					onReorderNotes={vi.fn()}
+					onUpdateNote={vi.fn()}
+					onWeave={vi.fn()}
+					isGeneratingReview={false}
+				/>
+			</QueryClientProvider>,
+		);
+
+		expect(screen.getByTitle("Drag to reorder")).toBeInTheDocument();
+		expect(screen.getByText("Test Review Note")).toBeInTheDocument();
 	});
 });

--- a/apps/app/src/app/(dashboard)/studio/_components/StudioReviewPane.tsx
+++ b/apps/app/src/app/(dashboard)/studio/_components/StudioReviewPane.tsx
@@ -15,7 +15,7 @@ import {
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import type { Note } from "@sitecue/shared";
+import type { Note, NoteType } from "@sitecue/shared";
 import { Loader2, Sparkles } from "lucide-react";
 import {
 	AlertDialog,
@@ -33,13 +33,13 @@ import { cn } from "@/lib/utils";
 import NoteEditor from "../../_components/NoteEditor";
 import NoteCard from "./NoteCard";
 
-type NoteType = "info" | "alert" | "idea";
-
 interface StudioReviewPaneProps {
 	reviewNotes: Note[];
 	isLoadingReview: boolean;
 	onAddNote: (content: string, type: NoteType) => Promise<void>;
 	onUpdateNote: (id: string, content: string) => void;
+	onUpdateNoteType?: (id: string, noteType: NoteType) => void;
+	onToggleNoteResolved?: (id: string) => void;
 	onDeleteNote: (id: string) => void;
 	onDeleteAllNotes: () => void;
 	onReorderNotes: (newOrder: Note[]) => void;
@@ -55,6 +55,8 @@ export default function StudioReviewPane({
 	isLoadingReview,
 	onAddNote,
 	onUpdateNote,
+	onUpdateNoteType,
+	onToggleNoteResolved,
 	onDeleteNote,
 	onDeleteAllNotes,
 	onReorderNotes,
@@ -84,125 +86,122 @@ export default function StudioReviewPane({
 	};
 
 	return (
-		<div className="relative flex h-full flex-col bg-neutral-50/30">
-			<div className="flex-1 overflow-y-auto">
-				{/* Note Form */}
-				<div className="sticky top-0 z-20 p-4 border-b border-neutral-200 bg-white/80 backdrop-blur-md">
-					<div className="flex justify-between items-center mb-3">
-						<span className="text-xs font-bold text-neutral-400 uppercase tracking-widest">
-							Add Notes
-						</span>
-						<Button
-							type="button"
-							/* variant="ghost" を明示して大元のソリッドな背景定義をパージ */
-							variant="ghost"
-							size="sm"
-							onClick={onGenerateReview}
-							disabled={isGeneratingReview}
-							className={cn(
-								"h-7 text-xs font-bold uppercase gap-1.5 rounded-full border-transparent shadow-none cursor-pointer transition-all duration-100 select-none text-action",
-								/* 通常時の10%の淡い輝き */
-								"bg-gradient-to-r from-purple-500/10 via-blue-500/10 to-pink-500/10",
-								/* 大元のグレーホバーを完全に上書きし、20%の滑らかな不透明度とスケールで極上の手触りを実現 */
-								"hover-safe:bg-gradient-to-r hover-safe:from-purple-500/20 hover-safe:to-pink-500/20 hover-safe:scale-[1.01]",
-								"active:scale-95",
-							)}
-						>
-							{isGeneratingReview ? (
-								<Loader2 className="w-3 h-3 animate-spin" />
-							) : (
-								<Sparkles className="w-3 h-3" />
-							)}
-							AI Review
-						</Button>
-					</div>
-					<NoteEditor onSubmit={onAddNote} />
+		<div className="relative flex h-full flex-col bg-neutral-50/30 overflow-hidden">
+			{/* 1. Add Notes フォーム: 独立した固定上部ヘッダー (shrink-0) */}
+			<div className="shrink-0 p-4 border-b border-neutral-200 bg-white/80 backdrop-blur-md z-20">
+				<div className="flex justify-between items-center mb-3">
+					<span className="text-xs font-bold text-neutral-400 uppercase tracking-widest">
+						Add Notes
+					</span>
+					<Button
+						type="button"
+						variant="ghost"
+						size="sm"
+						onClick={onGenerateReview}
+						disabled={isGeneratingReview}
+						className={cn(
+							"h-7 text-xs font-bold uppercase gap-1.5 rounded-full border-transparent shadow-none cursor-pointer transition-all duration-100 select-none text-action",
+							"bg-gradient-to-r from-purple-500/10 via-blue-500/10 to-pink-500/10",
+							"hover-safe:bg-gradient-to-r hover-safe:from-purple-500/20 hover-safe:to-pink-500/20 hover-safe:scale-[1.01]",
+							"active:scale-95",
+						)}
+					>
+						{isGeneratingReview ? (
+							<Loader2 className="w-3 h-3 animate-spin" />
+						) : (
+							<Sparkles className="w-3 h-3" />
+						)}
+						AI Review
+					</Button>
+				</div>
+				<NoteEditor onSubmit={onAddNote} />
+			</div>
+
+			{/* 2. Review Notes リスト: 独立したスクロール領域 (flex-1 overflow-y-auto) */}
+			<div className="flex-1 overflow-y-auto p-4 min-h-0">
+				<div className="flex justify-between items-center mb-3">
+					<span className="text-xs font-bold text-neutral-400 uppercase tracking-widest">
+						Review Notes ({reviewNotes.length})
+					</span>
+					{reviewNotes.length > 0 && (
+						<AlertDialog>
+							<AlertDialogTrigger
+								render={
+									<Button
+										variant="ghost"
+										size="sm"
+										className="text-note-alert hover:bg-note-alert/10 hover:text-note-alert h-6 px-2 text-xs font-bold uppercase"
+									>
+										Delete All
+									</Button>
+								}
+							/>
+							<AlertDialogContent>
+								<AlertDialogHeader>
+									<AlertDialogTitle>Delete all notes?</AlertDialogTitle>
+									<AlertDialogDescription>
+										This will remove all comments from this draft. You must
+										click "Save" to apply these changes to the server.
+									</AlertDialogDescription>
+								</AlertDialogHeader>
+								<AlertDialogFooter>
+									<AlertDialogCancel>Cancel</AlertDialogCancel>
+									<AlertDialogAction
+										onClick={onDeleteAllNotes}
+										className="bg-note-alert hover:bg-note-alert/90 text-white font-bold"
+									>
+										Delete
+									</AlertDialogAction>
+								</AlertDialogFooter>
+							</AlertDialogContent>
+						</AlertDialog>
+					)}
 				</div>
 
-				{/* Note List */}
-				<div className="p-4">
-					<div className="flex justify-between items-center mb-3">
-						<span className="text-xs font-bold text-neutral-400 uppercase tracking-widest">
-							Review Notes ({reviewNotes.length})
-						</span>
-						{reviewNotes.length > 0 && (
-							<AlertDialog>
-								<AlertDialogTrigger
-									render={
-										<Button
-											variant="ghost"
-											size="sm"
-											className="text-note-alert hover:bg-note-alert/10 hover:text-note-alert h-6 px-2 text-xs font-bold uppercase"
-										>
-											Delete All
-										</Button>
-									}
-								/>
-								<AlertDialogContent>
-									<AlertDialogHeader>
-										<AlertDialogTitle>Delete all notes?</AlertDialogTitle>
-										<AlertDialogDescription>
-											This will remove all comments from this draft. You must
-											click "Save" to apply these changes to the server.
-										</AlertDialogDescription>
-									</AlertDialogHeader>
-									<AlertDialogFooter>
-										<AlertDialogCancel>Cancel</AlertDialogCancel>
-										<AlertDialogAction
-											onClick={onDeleteAllNotes}
-											className="bg-note-alert hover:bg-note-alert/90 text-white font-bold"
-										>
-											Delete
-										</AlertDialogAction>
-									</AlertDialogFooter>
-								</AlertDialogContent>
-							</AlertDialog>
-						)}
-					</div>
-
-					<div className="grid gap-3">
-						{isLoadingReview ? (
-							["skel-1", "skel-2", "skel-3"].map((skelKey) => (
-								<div
-									key={skelKey}
-									className="h-24 animate-pulse rounded-xl border border-neutral-100 bg-neutral-100/50"
-								/>
-							))
-						) : reviewNotes.length === 0 ? (
-							<div className="flex h-40 flex-col items-center justify-center rounded-xl border border-dashed border-neutral-200 px-4 py-8 text-center text-neutral-400">
-								<p className="text-sm font-medium">
-									No notes for this draft yet.
-								</p>
-								<p className="mt-1 text-[10px]">
-									Use the form above to capture your thoughts.
-								</p>
-							</div>
-						) : (
-							<DndContext
-								id="studio-review-dnd"
-								sensors={sensors}
-								collisionDetection={closestCenter}
-								onDragEnd={handleDragEnd}
+				<div className="grid gap-3">
+					{isLoadingReview ? (
+						["skel-1", "skel-2", "skel-3"].map((skelKey) => (
+							<div
+								key={skelKey}
+								className="h-24 animate-pulse rounded-xl border border-neutral-100 bg-neutral-100/50"
+							/>
+						))
+					) : reviewNotes.length === 0 ? (
+						<div className="flex h-40 flex-col items-center justify-center rounded-xl border border-dashed border-neutral-200 px-4 py-8 text-center text-neutral-400">
+							<p className="text-sm font-medium">
+								No notes for this draft yet.
+							</p>
+							<p className="mt-1 text-[10px]">
+								Use the form above to capture your thoughts.
+							</p>
+						</div>
+					) : (
+						<DndContext
+							id="studio-review-dnd"
+							sensors={sensors}
+							collisionDetection={closestCenter}
+							onDragEnd={handleDragEnd}
+						>
+							<SortableContext
+								items={reviewNotes.map((n) => n.id)}
+								strategy={verticalListSortingStrategy}
 							>
-								<SortableContext
-									items={reviewNotes.map((n) => n.id)}
-									strategy={verticalListSortingStrategy}
-								>
-									<div className="grid gap-3">
-										{reviewNotes.map((note) => (
-											<SortableNoteCard
-												key={note.id}
-												note={note}
-												onUpdate={onUpdateNote}
-												onDelete={onDeleteNote}
-												onInsert={onInsertToEditor}
-											/>
-										))}
-									</div>
-								</SortableContext>
-							</DndContext>
-						)}
-					</div>
+								<div className="grid gap-3">
+									{reviewNotes.map((note) => (
+										<SortableNoteCard
+											key={note.id}
+											note={note}
+											onUpdate={onUpdateNote}
+											onUpdateType={onUpdateNoteType}
+											onToggleResolved={onToggleNoteResolved}
+											onDelete={onDeleteNote}
+											onInsert={onInsertToEditor}
+										/>
+									))}
+								</div>
+							</SortableContext>
+						</DndContext>
+					)}
 				</div>
 			</div>
 
@@ -227,7 +226,6 @@ export default function StudioReviewPane({
 									aria-hidden="true"
 								/>
 							) : (
-								/* text-transparentの伝播によるアイコン消失を防ぐため、輝きに馴染むソリッドな有彩色を指定 */
 								<Sparkles
 									className="h-5 w-5 text-indigo-200 shrink-0"
 									aria-hidden="true"
@@ -254,11 +252,15 @@ export default function StudioReviewPane({
 function SortableNoteCard({
 	note,
 	onUpdate,
+	onUpdateType,
+	onToggleResolved,
 	onDelete,
 	onInsert,
 }: {
 	note: Note;
 	onUpdate: (id: string, content: string) => void;
+	onUpdateType?: (id: string, noteType: NoteType) => void;
+	onToggleResolved?: (id: string) => void;
 	onDelete: (id: string) => void;
 	onInsert: (content: string) => void;
 }) {
@@ -281,12 +283,16 @@ function SortableNoteCard({
 	};
 
 	return (
-		<div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+		<div ref={setNodeRef} style={style}>
 			<NoteCard
 				note={note}
 				onUpdate={onUpdate}
+				onUpdateType={onUpdateType}
+				onToggleResolved={onToggleResolved}
 				onDelete={onDelete}
 				onInsert={onInsert}
+				hideScopeSelect={true}
+				dragHandleProps={{ ...attributes, ...listeners }}
 			/>
 		</div>
 	);

--- a/apps/app/src/components/editor/StudioEditor.tsx
+++ b/apps/app/src/components/editor/StudioEditor.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import {
 	Prec,
 	type StateCommand,
@@ -18,7 +19,6 @@ import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { type EditorProps, editorExtensions } from "./EditorBase";
 import { sitecueTheme } from "./sitecueTheme";
 
-// propsに onGenerateHint を追加
 interface StudioEditorProps extends EditorProps {
 	onGenerateHint?: (
 		context: string,
@@ -59,17 +59,25 @@ const hintField = StateField.define<DecorationSet>({
 				]);
 			}
 		}
-		if (tr.docChanged) return Decoration.none; // ユーザーが入力したらヒントを消す
+		if (tr.docChanged) return Decoration.none;
 		return nextHints;
 	},
 	provide: (f) => EditorView.decorations.from(f),
 });
 
-// basicSetup のオブジェクトをコンポーネントの外に出し、参照を完全に固定する
 const basicSetupConfig = {
 	lineNumbers: false,
 	foldGutter: false,
 };
+
+const studioScrollPaddingTheme = EditorView.theme({
+	".cm-scroller": {
+		paddingBottom: "40vh",
+	},
+	".cm-content": {
+		paddingBottom: "40vh",
+	},
+});
 
 export const StudioEditor = ({
 	value,
@@ -85,10 +93,8 @@ export const StudioEditor = ({
 		onGenerateHintRef.current = onGenerateHint;
 	}, [onGenerateHint]);
 
-	// 依存配列を「完全に空」にして、拡張機能自体は一度しか作られないようにする
 	const hintExtension = useMemo(() => {
 		const requestHint = (view: EditorView) => {
-			// 実行時にRefの中身を確認する（拡張機能自体を作り直す必要はない）
 			if (!onGenerateHintRef.current) return false;
 
 			const pos = view.state.selection.main.head;
@@ -139,8 +145,8 @@ export const StudioEditor = ({
 			Prec.highest(
 				keymap.of([
 					{ key: "Mod-j", run: requestHint, preventDefault: true },
-					{ key: "Alt-j", run: requestHint, preventDefault: true }, // Windows Fallback
-					{ key: "Tab", run: acceptHint }, // Tabでヒントを受け入れる
+					{ key: "Alt-j", run: requestHint, preventDefault: true },
+					{ key: "Tab", run: acceptHint },
 					{
 						key: "Escape",
 						run: ({ state, dispatch }) => {
@@ -153,11 +159,11 @@ export const StudioEditor = ({
 		];
 	}, []);
 
-	// すべての extensions を一つの安定した配列にまとめる
 	const extensions = React.useMemo(
 		() => [
 			...editorExtensions,
 			...(Array.isArray(sitecueTheme) ? sitecueTheme : [sitecueTheme]),
+			studioScrollPaddingTheme,
 			...hintExtension,
 		],
 		[hintExtension],

--- a/apps/app/src/components/ui/note-status-badge.test.tsx
+++ b/apps/app/src/components/ui/note-status-badge.test.tsx
@@ -4,32 +4,30 @@ import { describe, expect, it, vi } from "vitest";
 import { NoteStatusBadge } from "./note-status-badge";
 
 describe("NoteStatusBadge", () => {
-	it("renders correctly with unresolved state", () => {
-		render(<NoteStatusBadge type="info" isResolved={false} />);
-		const button = screen.getByRole("button", { name: /info/i });
-		expect(button).toBeInTheDocument();
-		expect(button).toHaveAttribute("title", "Mark as resolved");
-		expect(button).toHaveClass("text-note-info");
-	});
-
-	it("renders correctly with resolved state", () => {
-		render(<NoteStatusBadge type="alert" isResolved={true} />);
-		const button = screen.getByRole("button", { name: /alert/i });
-		expect(button).toBeInTheDocument();
-		expect(button).toHaveAttribute("title", "Mark as unresolved");
-		expect(button).toHaveClass("text-note-alert");
-	});
-
-	it("calls onClick handler when clicked", async () => {
-		const handleClick = vi.fn();
+	it("Unresolved状態で正しくレンダリングされ、クリック時にバブリングを遮断してonClickが発火すること", async () => {
 		const user = userEvent.setup();
+		const handleClick = vi.fn();
 		render(
-			<NoteStatusBadge type="idea" isResolved={false} onClick={handleClick} />,
+			<NoteStatusBadge isResolved={false} onClick={handleClick} type="info" />,
 		);
 
-		const button = screen.getByRole("button", { name: /idea/i });
-		await user.click(button);
+		const button = screen.getByRole("button", { name: /info/i });
+		expect(button).toBeInTheDocument();
+		expect(button).toHaveAttribute("title", "Type: Info (Click to toggle)");
 
+		await user.click(button);
 		expect(handleClick).toHaveBeenCalledTimes(1);
+	});
+
+	it("onClick無しのUnresolved状態で title が Mark as resolved になること", () => {
+		render(<NoteStatusBadge isResolved={false} type="info" />);
+		const button = screen.getByRole("button", { name: /info/i });
+		expect(button).toHaveAttribute("title", "Mark as resolved");
+	});
+
+	it("onClick無しのResolved状態で title が Mark as unresolved になること", () => {
+		render(<NoteStatusBadge isResolved={true} type="alert" />);
+		const button = screen.getByRole("button", { name: /alert/i });
+		expect(button).toHaveAttribute("title", "Mark as unresolved");
 	});
 });

--- a/apps/app/src/components/ui/note-status-badge.tsx
+++ b/apps/app/src/components/ui/note-status-badge.tsx
@@ -47,36 +47,45 @@ export function NoteStatusBadge({
 	return (
 		<button
 			type="button"
-			onClick={onClick}
+			onClick={(e) => {
+				e.stopPropagation();
+				onClick?.(e);
+			}}
 			className={cn(
-				"group/badge relative inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase transition-colors overflow-hidden cursor-pointer pointer-events-auto",
+				"group/badge relative inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-bold tracking-wide uppercase transition-colors overflow-hidden cursor-pointer pointer-events-auto shrink-0",
 				bgClass,
 				textClass,
 				className,
 			)}
-			title={isResolved ? "Mark as unresolved" : "Mark as resolved"}
+			title={
+				onClick
+					? `Type: ${label} (Click to toggle)`
+					: isResolved
+						? "Mark as unresolved"
+						: "Mark as resolved"
+			}
 		>
 			<div className="relative w-3.5 h-3.5 flex items-center justify-center shrink-0 overflow-hidden">
 				{!isResolved ? (
 					<>
 						<BaseIcon
-							className="absolute inset-0 w-full h-full transition-all duration-300 group-hover/badge:-translate-y-full group-hover/badge:opacity-0"
 							aria-hidden="true"
+							className="absolute inset-0 w-full h-full transition-all duration-300 group-hover/badge:-translate-y-full group-hover/badge:opacity-0"
 						/>
 						<Check
-							className="absolute inset-0 w-full h-full translate-y-full opacity-0 transition-all duration-300 group-hover/badge:translate-y-0 group-hover/badge:opacity-100"
 							aria-hidden="true"
+							className="absolute inset-0 w-full h-full translate-y-full opacity-0 transition-all duration-300 group-hover/badge:translate-y-0 group-hover/badge:opacity-100"
 						/>
 					</>
 				) : (
 					<>
 						<Check
-							className="absolute inset-0 w-full h-full text-emerald-500 transition-all duration-300 group-hover/badge:-translate-y-full group-hover/badge:opacity-0"
 							aria-hidden="true"
+							className="absolute inset-0 w-full h-full text-emerald-500 transition-all duration-300 group-hover/badge:-translate-y-full group-hover/badge:opacity-0"
 						/>
 						<RotateCcw
-							className="absolute inset-0 w-full h-full translate-y-full opacity-0 transition-all duration-300 group-hover/badge:translate-y-0 group-hover/badge:opacity-100"
 							aria-hidden="true"
+							className="absolute inset-0 w-full h-full translate-y-full opacity-0 transition-all duration-300 group-hover/badge:translate-y-0 group-hover/badge:opacity-100"
 						/>
 					</>
 				)}

--- a/apps/app/src/hooks/useMarkdownAssist.ts
+++ b/apps/app/src/hooks/useMarkdownAssist.ts
@@ -1,0 +1,327 @@
+import type React from "react";
+
+export function useMarkdownAssist() {
+	const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+		if (e.nativeEvent.isComposing) return;
+
+		const textarea = e.currentTarget;
+		const { value, selectionStart, selectionEnd } = textarea;
+
+		const insertText = (
+			text: string,
+			start: number,
+			end: number,
+			selectStart: number,
+			selectEnd: number,
+			isDelete = false,
+		) => {
+			textarea.setSelectionRange(start, end);
+			let success = false;
+			const command = isDelete ? "delete" : "insertText";
+
+			if (document.queryCommandSupported(command)) {
+				success = document.execCommand(
+					command,
+					false,
+					isDelete ? undefined : text,
+				);
+			}
+			if (!success) {
+				textarea.setRangeText(text, start, end, "end");
+				textarea.dispatchEvent(new Event("input", { bubbles: true }));
+			}
+			textarea.setSelectionRange(selectStart, selectEnd);
+		};
+
+		// 1. Tabキーによるインデント補助 (スペース2つ)
+		if (e.key === "Tab" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+			e.preventDefault();
+			const isShift = e.shiftKey;
+
+			if (selectionStart !== selectionEnd) {
+				const startOfSelection =
+					value.lastIndexOf("\n", selectionStart - 1) + 1;
+				const endOfSelection = value.indexOf("\n", selectionEnd);
+				const targetEnd = endOfSelection === -1 ? value.length : endOfSelection;
+				const selectedChunk = value.slice(startOfSelection, targetEnd);
+				const lines = selectedChunk.split("\n");
+
+				let diffStart = 0;
+				let diffEnd = 0;
+
+				const newLines = lines.map((line, idx) => {
+					if (isShift) {
+						let removed = 0;
+						let newLine = line;
+						if (line.startsWith("  ")) {
+							removed = 2;
+							newLine = line.slice(2);
+						} else if (line.startsWith(" ") || line.startsWith("\t")) {
+							removed = 1;
+							newLine = line.slice(1);
+						}
+						if (idx === 0) diffStart -= removed;
+						diffEnd -= removed;
+						return newLine;
+					}
+					if (idx === 0) diffStart += 2;
+					diffEnd += 2;
+					return `  ${line}`;
+				});
+
+				const newChunk = newLines.join("\n");
+				insertText(
+					newChunk,
+					startOfSelection,
+					targetEnd,
+					Math.max(startOfSelection, selectionStart + diffStart),
+					Math.max(startOfSelection, selectionEnd + diffEnd),
+				);
+			} else {
+				const currentLineStart =
+					value.lastIndexOf("\n", selectionStart - 1) + 1;
+				const currentLineEnd = value.indexOf("\n", selectionStart);
+				const targetLineEnd =
+					currentLineEnd === -1 ? value.length : currentLineEnd;
+				const fullLine = value.slice(currentLineStart, targetLineEnd);
+				const currentLineToCursor = value.slice(
+					currentLineStart,
+					selectionStart,
+				);
+
+				const hasListMarker = /^[ \t]*(?:[-*]|\d+\.)\s/.test(fullLine);
+
+				if (hasListMarker) {
+					if (isShift) {
+						const match = fullLine.match(/^( {1,2}|\t)/);
+						if (match) {
+							const removeLen = match[0].length;
+							insertText(
+								"",
+								currentLineStart,
+								currentLineStart + removeLen,
+								selectionStart - removeLen,
+								selectionStart - removeLen,
+								true,
+							);
+						}
+					} else {
+						insertText(
+							"  ",
+							currentLineStart,
+							currentLineStart,
+							selectionStart + 2,
+							selectionStart + 2,
+						);
+					}
+				} else {
+					if (isShift) {
+						const match = currentLineToCursor.match(/^( {1,2}|\t)/);
+						if (match) {
+							const removeLen = match[0].length;
+							insertText(
+								"",
+								currentLineStart,
+								currentLineStart + removeLen,
+								selectionStart - removeLen,
+								selectionStart - removeLen,
+								true,
+							);
+						}
+					} else {
+						insertText(
+							"  ",
+							selectionStart,
+							selectionStart,
+							selectionStart + 2,
+							selectionStart + 2,
+						);
+					}
+				}
+			}
+			return;
+		}
+
+		// 2. Enterキーによるオートバレット・自動改行インデント
+		if (
+			e.key === "Enter" &&
+			!e.shiftKey &&
+			!e.ctrlKey &&
+			!e.metaKey &&
+			!e.altKey
+		) {
+			const currentLineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
+			const currentLine = value.slice(currentLineStart, selectionStart);
+
+			const indentMatch = currentLine.match(/^[ \t]+/);
+			const indent = indentMatch ? indentMatch[0] : "";
+			const lineWithoutIndent = currentLine.slice(indent.length);
+
+			const bulletMatch = lineWithoutIndent.match(/^(?:[-*]|\d+\.)\s/);
+
+			if (bulletMatch) {
+				e.preventDefault();
+				const marker = bulletMatch[0];
+				const contentAfterMarker = lineWithoutIndent
+					.slice(marker.length)
+					.trim();
+
+				if (contentAfterMarker === "") {
+					insertText(
+						"\n",
+						currentLineStart,
+						selectionStart,
+						currentLineStart + 1,
+						currentLineStart + 1,
+					);
+					return;
+				}
+
+				let nextMarker = marker;
+				const numMatch = marker.match(/^(\d+)\.\s/);
+				if (numMatch) {
+					const nextNum = Number.parseInt(numMatch[1], 10) + 1;
+					nextMarker = `${nextNum}. `;
+				}
+
+				insertText(
+					`\n${indent}${nextMarker}`,
+					selectionStart,
+					selectionStart,
+					selectionStart + indent.length + nextMarker.length + 1,
+					selectionStart + indent.length + nextMarker.length + 1,
+				);
+				return;
+			}
+
+			if (indent.length > 0) {
+				e.preventDefault();
+				if (indent === currentLine) {
+					insertText(
+						"\n",
+						currentLineStart,
+						selectionStart,
+						currentLineStart + 1,
+						currentLineStart + 1,
+					);
+				} else {
+					insertText(
+						`\n${indent}`,
+						selectionStart,
+						selectionStart,
+						selectionStart + indent.length + 1,
+						selectionStart + indent.length + 1,
+					);
+				}
+				return;
+			}
+		}
+
+		// 3. ブラケット・ペア・クローズ
+		const bracketPairs: Record<string, string> = {
+			"[": "]",
+			"(": ")",
+			'"': '"',
+			"'": "'",
+			"*": "*",
+			_: "_",
+		};
+
+		const closeChars = ["]", ")", '"', "'", "*", "_"];
+
+		if (closeChars.includes(e.key) && !e.ctrlKey && !e.metaKey && !e.altKey) {
+			const nextChar = value.charAt(selectionStart);
+			if (nextChar === e.key) {
+				e.preventDefault();
+				textarea.setSelectionRange(selectionStart + 1, selectionStart + 1);
+				return;
+			}
+		}
+
+		if (
+			bracketPairs[e.key] !== undefined &&
+			!e.ctrlKey &&
+			!e.metaKey &&
+			!e.altKey
+		) {
+			const char = e.key;
+			const closeChar = bracketPairs[char];
+
+			e.preventDefault();
+			if (selectionStart !== selectionEnd) {
+				const selectedText = value.slice(selectionStart, selectionEnd);
+				insertText(
+					`${char}${selectedText}${closeChar}`,
+					selectionStart,
+					selectionEnd,
+					selectionStart + 1,
+					selectionEnd + 1,
+				);
+			} else {
+				insertText(
+					`${char}${closeChar}`,
+					selectionStart,
+					selectionStart,
+					selectionStart + 1,
+					selectionStart + 1,
+				);
+			}
+			return;
+		}
+
+		// 4. 連動削除
+		if (
+			e.key === "Backspace" &&
+			selectionStart === selectionEnd &&
+			selectionStart > 0
+		) {
+			const prevChar = value.charAt(selectionStart - 1);
+			const nextChar = value.charAt(selectionStart);
+			const matchingPairs = ["()", "[]", '""', "''", "**", "__"];
+
+			if (matchingPairs.includes(prevChar + nextChar)) {
+				e.preventDefault();
+				insertText(
+					"",
+					selectionStart - 1,
+					selectionStart + 1,
+					selectionStart - 1,
+					selectionStart - 1,
+					true,
+				);
+			}
+		}
+	};
+
+	const onPaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+		const textarea = e.currentTarget;
+		const { value, selectionStart, selectionEnd } = textarea;
+
+		if (selectionStart !== selectionEnd) {
+			const pastedText = e.clipboardData.getData("text");
+			const isUrl = /^https?:\/\/[^\s$.?#].[^\s]*$/i.test(pastedText.trim());
+
+			if (isUrl) {
+				e.preventDefault();
+				const selectedText = value.slice(selectionStart, selectionEnd);
+				const mdLink = `[${selectedText}](${pastedText.trim()})`;
+
+				textarea.setSelectionRange(selectionStart, selectionEnd);
+				let success = false;
+				if (document.queryCommandSupported("insertText")) {
+					success = document.execCommand("insertText", false, mdLink);
+				}
+				if (!success) {
+					textarea.setRangeText(mdLink, selectionStart, selectionEnd, "end");
+					textarea.dispatchEvent(new Event("input", { bubbles: true }));
+				}
+				textarea.setSelectionRange(
+					selectionStart,
+					selectionStart + mdLink.length,
+				);
+			}
+		}
+	};
+
+	return { onKeyDown, onPaste };
+}


### PR DESCRIPTION
… boundaries

Why:

* NoteCard headers failed to stick properly during scrolling due to `overflow-hidden` on the card root and shared scroll containers across Studio and Diary panes.
* Collapsing long notes via "Show less" left the viewport out of sync, causing the user to lose card context.
* Action buttons in NoteCard lacked visual consistency with Basecamp's Capsule UI system.

What:

* Removed `overflow-hidden` from NoteCard's outermost wrapper, delegating text overflow containment to the Markdown container via `[overflow-wrap:anywhere]`.
* Refactored `StudioReviewPane`, `StudioMaterialsPane`, and `DiaryMaterialsPane` to separate top fixed headers (`shrink-0`) from independent scroll containers (`flex-1 overflow-y-auto min-h-0`).
* Added smooth `scrollIntoView` auto-adjustment when collapsing NoteCard (`isExpanded` -> `false`).
* Unified NoteCard action buttons using Basecamp's shared `<Button>` (`radius="full"`, `size="icon-sm"`, `variant="ghost"`).
* Suppressed the "Insert to editor" button rendering in Diary view by explicitly checking `onInsert`.