### PR TITLE
fix(app/diary): resolve TypeError e.some is not a function on consecu…

### DIFF
--- a/apps/app/src/app/(dashboard)/diaries/[date]/_components/DiaryStudioClient.test.tsx
+++ b/apps/app/src/app/(dashboard)/diaries/[date]/_components/DiaryStudioClient.test.tsx
@@ -1,5 +1,12 @@
+import type { Diary } from "@sitecue/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { DiaryStudioClient } from "./DiaryStudioClient";
@@ -10,14 +17,34 @@ vi.mock("next/navigation", () => ({
 	useSearchParams: () => new URLSearchParams(),
 }));
 
-vi.mock("@/hooks/useDiariesQuery", () => ({
-	useUpdateDiary: () => ({ mutateAsync: vi.fn() }),
-	useFetchDiaries: () => ({ data: undefined, isLoading: false }),
-	useFetchDiaryByDate: (_date?: string, initialData?: unknown) => ({
-		data: initialData ?? undefined,
-		isLoading: false,
+// Supabaseクライアントのモック
+vi.mock("@/utils/supabase/client", () => ({
+	createClient: () => ({
+		auth: {
+			getUser: vi.fn().mockResolvedValue({
+				data: { user: { id: "u1" } },
+			}),
+		},
 	}),
 }));
+
+// shared DAL のモック
+vi.mock("@sitecue/shared", async () => {
+	const actual = await vi.importActual("@sitecue/shared");
+	return {
+		...actual,
+		updateDiaryContent: vi
+			.fn()
+			.mockImplementation(async (_sp, _uid, date, text, topics) => ({
+				user_id: "u1",
+				date,
+				content: text,
+				topics: topics || [],
+				created_at: "2026-06-28T00:00:00Z",
+				updated_at: new Date().toISOString(),
+			})),
+	};
+});
 
 // useMediaQuery のモック化 (デスクトップ表示をシミュレート)
 vi.mock("@/hooks/use-media-query", () => ({
@@ -59,11 +86,18 @@ vi.mock("./DiaryMaterialsPane", () => ({
 }));
 
 describe("DiaryStudioClient", () => {
-	const queryClient = new QueryClient();
+	const createTestQueryClient = () =>
+		new QueryClient({
+			defaultOptions: {
+				queries: { retry: false },
+			},
+		});
+
 	const setup = (
 		initialDiary: Parameters<typeof DiaryStudioClient>[0]["initialDiary"],
-	) =>
-		render(
+	) => {
+		const queryClient = createTestQueryClient();
+		return render(
 			React.createElement(
 				QueryClientProvider,
 				{ client: queryClient },
@@ -73,6 +107,7 @@ describe("DiaryStudioClient", () => {
 				}),
 			),
 		);
+	};
 
 	it("初期状態（変更なし）ではSaveボタンが非活性であること", () => {
 		setup({
@@ -133,5 +168,80 @@ describe("DiaryStudioClient", () => {
 			"mock-editor",
 		)[0] as HTMLTextAreaElement;
 		expect(editor.value).toBe("Original\n\nInserted Text");
+	});
+});
+
+describe("DiaryStudioClient - キャッシュ型不整合修復検証", () => {
+	it("配列キャッシュと詳細オブジェクトキャッシュが混在する状態で保存した際、e.some is not a function エラーを出さずにキャッシュが同期されること", async () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false },
+			},
+		});
+
+		const initialList: Diary[] = [
+			{
+				user_id: "u1",
+				date: "2026-06-28",
+				content: "Initial Content",
+				topics: [],
+				created_at: "",
+				updated_at: "",
+			},
+		];
+
+		const initialDetail: Diary = {
+			user_id: "u1",
+			date: "2026-06-28",
+			content: "Initial Content",
+			topics: [],
+			created_at: "",
+			updated_at: "",
+		};
+
+		// 意図的に一覧キャッシュ (Array) と 詳細キャッシュ (Object) の双方をキャッシュにセット
+		queryClient.setQueryData(["diaries"], initialList);
+		queryClient.setQueryData(["diaries", "2026-06-28"], initialDetail);
+
+		render(
+			React.createElement(
+				QueryClientProvider,
+				{ client: queryClient },
+				React.createElement(DiaryStudioClient, {
+					initialDiary: initialDetail,
+					date: "2026-06-28",
+				}),
+			),
+		);
+
+		const editor = screen.getAllByTestId("mock-editor")[0];
+		fireEvent.change(editor, {
+			target: { value: "Updated Content Second Save" },
+		});
+
+		const saveBtn = screen.getAllByRole("button", { name: /Save Diary/i })[0];
+		expect(saveBtn).not.toBeDisabled();
+
+		// 保存ボタンクリック
+		await act(async () => {
+			fireEvent.click(saveBtn);
+		});
+
+		// Saved ステータスへ正常遷移すること（エラーが出ないこと）を検証
+		await waitFor(() => {
+			expect(
+				screen.getAllByRole("button", { name: /Saved/i })[0],
+			).toBeInTheDocument();
+		});
+
+		// キャッシュが正しく更新されているか検証
+		const updatedDetail = queryClient.getQueryData<Diary>([
+			"diaries",
+			"2026-06-28",
+		]);
+		expect(updatedDetail?.content).toBe("Updated Content Second Save");
+
+		const updatedList = queryClient.getQueryData<Diary[]>(["diaries"]);
+		expect(updatedList?.[0]?.content).toBe("Updated Content Second Save");
 	});
 });

--- a/apps/app/src/hooks/useDiariesQuery.ts
+++ b/apps/app/src/hooks/useDiariesQuery.ts
@@ -70,15 +70,37 @@ export function useAppendDiary() {
 			return appendDiaryLog(supabase, user.id, date, text, topics);
 		},
 		onSuccess: (newDiary) => {
-			// プレフィックス一致を用いて関連キャッシュを一括同期
-			queryClient.setQueriesData<Diary[]>({ queryKey: ["diaries"] }, (old) => {
-				if (!old) return [newDiary];
-				const exists = old.some((d) => d.date === newDiary.date);
-				if (exists) {
-					return old.map((d) => (d.date === newDiary.date ? newDiary : d));
-				}
-				return [newDiary, ...old].sort((a, b) => b.date.localeCompare(a.date));
-			});
+			// 1. 詳細キャッシュの明示的ハイドレーション
+			queryClient.setQueryData<Diary | null>(
+				["diaries", newDiary.date],
+				newDiary,
+			);
+
+			// 2. プレフィックス一致を用いて関連キャッシュを一括同期（配列 vs オブジェクトの型分岐）
+			queryClient.setQueriesData<Diary[] | Diary | null>(
+				{ queryKey: ["diaries"] },
+				(old) => {
+					if (!old) return old;
+
+					// 配列キャッシュ（一覧: ["diaries"]）の更新
+					if (Array.isArray(old)) {
+						const exists = old.some((d) => d.date === newDiary.date);
+						if (exists) {
+							return old.map((d) => (d.date === newDiary.date ? newDiary : d));
+						}
+						return [newDiary, ...old].sort((a, b) =>
+							b.date.localeCompare(a.date),
+						);
+					}
+
+					// 単一オブジェクトキャッシュ（詳細: ["diaries", date]）の更新
+					if (typeof old === "object" && "date" in old) {
+						return old.date === newDiary.date ? newDiary : old;
+					}
+
+					return old;
+				},
+			);
 		},
 	});
 }
@@ -104,14 +126,37 @@ export function useUpdateDiary() {
 			return updateDiaryContent(supabase, user.id, date, text, topics);
 		},
 		onSuccess: (newDiary) => {
-			queryClient.setQueriesData<Diary[]>({ queryKey: ["diaries"] }, (old) => {
-				if (!old) return [newDiary];
-				const exists = old.some((d) => d.date === newDiary.date);
-				if (exists) {
-					return old.map((d) => (d.date === newDiary.date ? newDiary : d));
-				}
-				return [newDiary, ...old].sort((a, b) => b.date.localeCompare(a.date));
-			});
+			// 1. 詳細キャッシュの明示的ハイドレーション
+			queryClient.setQueryData<Diary | null>(
+				["diaries", newDiary.date],
+				newDiary,
+			);
+
+			// 2. プレフィックス一致を用いて関連キャッシュを一括同期（配列 vs オブジェクトの型分岐）
+			queryClient.setQueriesData<Diary[] | Diary | null>(
+				{ queryKey: ["diaries"] },
+				(old) => {
+					if (!old) return old;
+
+					// 配列キャッシュ（一覧: ["diaries"]）の更新
+					if (Array.isArray(old)) {
+						const exists = old.some((d) => d.date === newDiary.date);
+						if (exists) {
+							return old.map((d) => (d.date === newDiary.date ? newDiary : d));
+						}
+						return [newDiary, ...old].sort((a, b) =>
+							b.date.localeCompare(a.date),
+						);
+					}
+
+					// 単一オブジェクトキャッシュ（詳細: ["diaries", date]）の更新
+					if (typeof old === "object" && "date" in old) {
+						return old.date === newDiary.date ? newDiary : old;
+					}
+
+					return old;
+				},
+			);
 		},
 	});
 }


### PR DESCRIPTION
…tive saves

- Background / Purpose: Fix a runtime error caused by TanStack Query cache type mismatch during consecutive updates/appends on the Diary Studio page (/diaries/[date]).
- What was done:
  - Added Array.isArray checks in setQueriesData within useUpdateDiary and useAppendDiary to prevent executing .some() on single-object caches.
  - Ensured explicit cache synchronization via setQueryData for specific date keys.
  - Maintained zero-flicker UI/UX by relying solely on in-memory updates without router.refresh().