### PR TITLE
feat(app): refactor GlobalNewNoteDialog with capsule UI and slide-out…

### DIFF
--- a/apps/app/src/components/dialogs/GlobalNewNoteDialog.test.tsx
+++ b/apps/app/src/components/dialogs/GlobalNewNoteDialog.test.tsx
@@ -1,17 +1,36 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import toast from "react-hot-toast";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useEditorStore } from "@/store/useEditorStore";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useLayoutStore } from "@/store/useLayoutStore";
 import { useUserStore } from "@/store/useUserStore";
 import { GlobalNewNoteDialog } from "./GlobalNewNoteDialog";
 
-// next/navigation のモック
+// CodeMirror モック
+vi.mock("@uiw/react-codemirror", () => ({
+	default: ({
+		value,
+		onChange,
+		placeholder,
+	}: {
+		value: string;
+		onChange: (v: string) => void;
+		placeholder?: string;
+	}) => (
+		<textarea
+			data-testid="codemirror-mock"
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+			placeholder={placeholder}
+		/>
+	),
+}));
+
+// next/navigation モック
 const mockPush = vi.fn();
 const mockReplace = vi.fn();
 const mockRefresh = vi.fn();
-const mockUseSearchParams = vi.fn();
+const mockUseSearchParams = vi.fn(() => new URLSearchParams());
 vi.mock("next/navigation", () => ({
 	useRouter: () => ({
 		push: mockPush,
@@ -21,54 +40,65 @@ vi.mock("next/navigation", () => ({
 	useSearchParams: () => mockUseSearchParams(),
 }));
 
+// Toast モック
 vi.mock("react-hot-toast", () => ({
 	default: { error: vi.fn(), success: vi.fn() },
 }));
 
-// カスタムフックのモック
-const mockMutateAsync = vi.fn().mockRejectedValue({
-	message: "note storage limit reached",
-	code: "P0001",
-});
-
+// Mutation フック モック
+const mockCreateMutate = vi.fn();
+const mockAppendMutate = vi.fn();
 vi.mock("@/hooks/useNotesQuery", () => ({
 	useCreateNote: () => ({
-		mutateAsync: mockMutateAsync,
+		mutate: mockCreateMutate,
 	}),
 }));
-
 vi.mock("@/hooks/useDiariesQuery", () => ({
 	useFetchDiaries: vi.fn(() => ({ data: [] })),
 	useAppendDiary: () => ({
-		mutateAsync: vi.fn().mockResolvedValue({}),
+		mutate: mockAppendMutate,
 	}),
 }));
 
-// NotesEditor のモック
+// NotesEditor モック
 vi.mock("@/components/editor/NotesEditor", () => ({
 	NotesEditor: ({
 		onChange,
 		value,
+		onSave,
 	}: {
 		onChange: (val: string) => void;
 		value: string;
+		onSave?: () => void;
 	}) => (
-		<textarea
-			data-testid="notes-editor"
-			value={value}
-			onChange={(e) => onChange(e.target.value)}
-		/>
+		<div>
+			<textarea
+				data-testid="notes-editor"
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+			/>
+			<button type="button" data-testid="trigger-onsave" onClick={onSave}>
+				Trigger OnSave
+			</button>
+		</div>
 	),
 }));
 
-describe("GlobalNewNoteDialog (Zustand In-Memory Context)", () => {
-	let queryClient: QueryClient;
+function renderWithProviders(ui: React.ReactElement) {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+	);
+}
 
+describe("GlobalNewNoteDialog Component", () => {
 	beforeEach(() => {
+		vi.useFakeTimers();
 		vi.clearAllMocks();
-		queryClient = new QueryClient({
-			defaultOptions: { queries: { retry: false } },
-		});
+		mockCreateMutate.mockReset();
+		mockAppendMutate.mockReset();
 		useUserStore.setState({ isPaywallOpen: false });
 		useLayoutStore.setState({
 			globalNewModal: { isOpen: false, mode: "gate" },
@@ -76,195 +106,65 @@ describe("GlobalNewNoteDialog (Zustand In-Memory Context)", () => {
 		mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
 	});
 
-	it("ZustandストアがOpenの時にダイアログが正常にマウントされ、初期ゲート画面が表示されること", async () => {
-		useLayoutStore.getState().openGlobalNewModal("gate");
-
-		render(
-			<QueryClientProvider client={queryClient}>
-				<GlobalNewNoteDialog />
-			</QueryClientProvider>,
-		);
-
-		expect(screen.getByText("What would you like to capture?")).toBeDefined();
-		expect(screen.getByText("Quick Note")).toBeDefined();
-		expect(screen.getByText("Daily Diary")).toBeDefined();
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
-	it("インメモリでのモード切り替え（Note）がスムーズに行われること", async () => {
-		useLayoutStore.getState().openGlobalNewModal("gate");
-
-		render(
-			<QueryClientProvider client={queryClient}>
-				<GlobalNewNoteDialog />
-			</QueryClientProvider>,
-		);
-
-		const quickNoteButton = screen.getByText("Quick Note");
-		fireEvent.click(quickNoteButton);
-
-		expect(screen.getByText("Quick Note Mode")).toBeDefined();
-		expect(screen.getByText("Scope")).toBeDefined();
-	});
-
-	it("closes itself and opens paywall when limit reached error occurs", async () => {
-		useLayoutStore.getState().openGlobalNewModal("note");
-
-		render(
-			<QueryClientProvider client={queryClient}>
-				<GlobalNewNoteDialog />
-			</QueryClientProvider>,
-		);
-
-		const editor = screen.getByTestId("notes-editor");
-		fireEvent.change(editor, { target: { value: "Test note" } });
-
-		const saveButton = screen.getByRole("button", { name: "Save Note" });
-		fireEvent.click(saveButton);
-
-		await waitFor(() => {
-			// 1. ZustandのModalがクローズされること
-			expect(useLayoutStore.getState().globalNewModal.isOpen).toBe(false);
-			// 2. Paywall が開くこと
-			expect(useUserStore.getState().isPaywallOpen).toBe(true);
-			expect(useUserStore.getState().paywallType).toBe("notes");
-			// 3. 汎用エラーが出ないこと
-			expect(toast.error).not.toHaveBeenCalled();
-		});
-	});
-
-	it("sanitizes 'all' reserved words from search parameters via passive sync", async () => {
-		const params = new URLSearchParams(
-			"globalNew=note&intent=note&exact=all&domain=all",
-		);
-		mockUseSearchParams.mockReturnValue(params);
-
-		render(
-			<QueryClientProvider client={queryClient}>
-				<GlobalNewNoteDialog />
-			</QueryClientProvider>,
-		);
-
-		// Passive sync should open the modal in note mode
-		expect(useLayoutStore.getState().globalNewModal.isOpen).toBe(true);
-		expect(useLayoutStore.getState().globalNewModal.mode).toBe("note");
-
-		// Inbox状態なのでURLのInput自体が存在しないことを確認
-		expect(
-			screen.queryByPlaceholderText(
-				"[example.com/page](https://example.com/page)",
-			),
-		).not.toBeInTheDocument();
-
-		const inboxButton = screen.getByRole("button", { name: "inbox" });
-		expect(inboxButton).toHaveClass("capitalize");
-	});
-
-	it("falls back to domain scope when domain is valid and not 'all' via passive sync", async () => {
-		const params = new URLSearchParams(
-			"globalNew=note&intent=note&domain=example.com",
-		);
-		mockUseSearchParams.mockReturnValue(params);
-
-		render(
-			<QueryClientProvider client={queryClient}>
-				<GlobalNewNoteDialog />
-			</QueryClientProvider>,
-		);
-
-		expect(
-			screen.getByPlaceholderText(
-				"[example.com/page](https://example.com/page)",
-			),
-		).toHaveValue("example.com");
-		const domainButton = screen.getByRole("button", { name: "domain" });
-		expect(domainButton).toBeInTheDocument();
-	});
-
-	it("disables Save button when scope requires URL but it is empty", async () => {
-		useLayoutStore.getState().openGlobalNewModal("note");
-
-		render(
-			<QueryClientProvider client={queryClient}>
-				<GlobalNewNoteDialog />
-			</QueryClientProvider>,
-		);
-
-		// Set scope to domain
-		const domainBtn = screen.getByRole("button", { name: "domain" });
-		fireEvent.click(domainBtn);
-
-		const editor = screen.getByTestId("notes-editor");
-		fireEvent.change(editor, { target: { value: "Test note" } });
-
-		const saveButton = screen.getByRole("button", { name: "Save Note" });
-
-		// URLがないので無効
-		expect(saveButton).toBeDisabled();
-
-		// URLを入力する
-		const urlInput = screen.getByPlaceholderText(
-			"[example.com/page](https://example.com/page)",
-		);
-		fireEvent.change(urlInput, { target: { value: "example.com" } });
-
-		// 有効化されることを確認
-		expect(saveButton).not.toBeDisabled();
-
-		// URLを空にする
-		fireEvent.change(urlInput, { target: { value: "   " } }); // trimして空になる値
-
-		// 無効化されることを確認
-		expect(saveButton).toBeDisabled();
-
-		// Inboxに変更するとURLが不要になるので有効になることを確認
-		const inboxButton = screen.getByRole("button", { name: "inbox" });
-		fireEvent.click(inboxButton);
-		expect(saveButton).not.toBeDisabled();
-	});
-
-	it("promotes to studio correctly and saves pending content", async () => {
-		useLayoutStore.getState().openGlobalNewModal("note");
-
-		render(
-			<QueryClientProvider client={queryClient}>
-				<GlobalNewNoteDialog />
-			</QueryClientProvider>,
-		);
-
-		const editor = screen.getByTestId("notes-editor");
-		fireEvent.change(editor, { target: { value: "Draft idea for studio" } });
-
-		const promoteBtn = screen.getByRole("button", {
-			name: "Edit in Studio",
-		});
-		fireEvent.click(promoteBtn);
-
-		// Storeに値が保持されたことの確認
-		expect(useEditorStore.getState().pendingContent).toBe(
-			"Draft idea for studio",
-		);
-		// ダイアログが閉じられたことの確認
-		expect(useLayoutStore.getState().globalNewModal.isOpen).toBe(false);
-		// Studio画面へ遷移したことの確認
-		expect(mockPush).toHaveBeenCalledWith("/studio/new");
-	});
-
-	it("renders diary input layout when globalNewModal mode is 'diary'", async () => {
+	it("Daily Diaryモードにおいて、送信時にLogging...表示になり350ms後にダイアログが閉じること（toast.successなし）", () => {
 		useLayoutStore.getState().openGlobalNewModal("diary");
 
-		render(
-			<QueryClientProvider client={queryClient}>
-				<GlobalNewNoteDialog />
-			</QueryClientProvider>,
-		);
+		renderWithProviders(<GlobalNewNoteDialog />);
 
-		// New Note title should not be rendered
-		expect(screen.queryByText("New Note")).toBeNull();
-
-		// Large text area should be present
 		const textarea = screen.getByPlaceholderText(
-			"Write down your thoughts for today... (No title required)",
+			/Write down your thoughts for today/i,
 		);
-		expect(textarea).toBeInTheDocument();
+		fireEvent.change(textarea, { target: { value: "Today's log" } });
+
+		const saveBtn = screen.getByRole("button", { name: "Save Diary" });
+		fireEvent.click(saveBtn);
+
+		expect(
+			screen.getByRole("button", { name: "Logging..." }),
+		).toBeInTheDocument();
+
+		expect(mockAppendMutate).toHaveBeenCalledWith(
+			expect.objectContaining({ text: "Today's log" }),
+			expect.anything(),
+		);
+
+		act(() => {
+			vi.advanceTimersByTime(350);
+		});
+
+		expect(useLayoutStore.getState().globalNewModal.isOpen).toBe(false);
+		expect(toast.success).not.toHaveBeenCalled();
+	});
+
+	it("Quick Noteモードにおいて、送信時にSaving...表示になり350ms後にダイアログが閉じること", () => {
+		useLayoutStore.getState().openGlobalNewModal("note");
+
+		renderWithProviders(<GlobalNewNoteDialog />);
+
+		const editor = screen.getByTestId("notes-editor");
+		fireEvent.change(editor, { target: { value: "Quick idea text" } });
+
+		const saveBtn = screen.getByRole("button", { name: "Save Note" });
+		fireEvent.click(saveBtn);
+
+		expect(
+			screen.getByRole("button", { name: "Saving..." }),
+		).toBeInTheDocument();
+
+		expect(mockCreateMutate).toHaveBeenCalledWith(
+			expect.objectContaining({ content: "Quick idea text" }),
+			expect.anything(),
+		);
+
+		act(() => {
+			vi.advanceTimersByTime(350);
+		});
+
+		expect(useLayoutStore.getState().globalNewModal.isOpen).toBe(false);
+		expect(toast.success).not.toHaveBeenCalled();
 	});
 });

--- a/apps/app/src/components/dialogs/GlobalNewNoteDialog.tsx
+++ b/apps/app/src/components/dialogs/GlobalNewNoteDialog.tsx
@@ -8,7 +8,7 @@ import type {
 import { APP_LIMITS } from "@sitecue/shared";
 import { CalendarDays, Inbox, PenTool } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { NotesEditor } from "@/components/editor/NotesEditor";
 import { Button } from "@/components/ui/button";
@@ -16,6 +16,7 @@ import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useAppendDiary } from "@/hooks/useDiariesQuery";
+import { useMarkdownAssist } from "@/hooks/useMarkdownAssist";
 import { useCreateNote } from "@/hooks/useNotesQuery";
 import { cn } from "@/lib/utils";
 import { useEditorStore } from "@/store/useEditorStore";
@@ -40,19 +41,23 @@ export function GlobalNewNoteDialog() {
 	const [content, setContent] = useState("");
 	const [urlPattern, setUrlPattern] = useState("");
 	const [scope, setScope] = useState<NoteScope>("inbox");
-	const [_isSaving, _setIsSaving] = useState(false);
 	const [noteType, setNoteType] = useState<Note["note_type"]>("info");
+	const [isSubmittingAnimation, setIsSubmittingAnimation] = useState(false);
+
+	const diaryTextareaRef = useRef<HTMLTextAreaElement>(null);
 
 	const createNoteMutation = useCreateNote();
 	const appendDiaryMutation = useAppendDiary();
 	const openPaywall = useUserStore((state) => state.openPaywall);
 	const setPendingContent = useEditorStore((state) => state.setPendingContent);
 
+	const { onKeyDown: onMarkdownKeyDown, onPaste: onMarkdownPaste } =
+		useMarkdownAssist();
+
 	const charCount = content.length;
 	const isNearLimit = charCount >= APP_LIMITS.MAX_NOTE_LENGTH * 0.9;
 	const isOverLimit = charCount > APP_LIMITS.MAX_NOTE_LENGTH;
 
-	// 外部からのディープリンク流入時の一度きりのパッシブ同期安全装置
 	useEffect(() => {
 		const globalNewParam = searchParams.get("globalNew");
 		const intentParam = searchParams.get("intent");
@@ -93,33 +98,34 @@ export function GlobalNewNoteDialog() {
 		}
 	}, [searchParams, router, openGlobalNewModal, isOpen]);
 
-	// 起動時の入力クリア・状態リセット（❌歴史ダミープッシュは完全パージ）
+	// 開いた時のみ入力クリア＆アニメーションフラグ安全初期化
 	useEffect(() => {
 		if (isOpen) {
 			setContent("");
 			setNoteType("info");
+			setIsSubmittingAnimation(false);
 		}
 	}, [isOpen]);
-
-	// ❌ window.addEventListener("popstate") によるトリッキーなガード処理は丸ごと削除（パージ）
 
 	const isUrlRequired = scope === "exact" || scope === "domain";
 	const isUrlInvalid = isUrlRequired && !urlPattern.trim();
 	const isSaveDisabled =
-		!content.trim() || (mode === "note" && (isOverLimit || isUrlInvalid));
+		!content.trim() ||
+		isSubmittingAnimation ||
+		(mode === "note" && (isOverLimit || isUrlInvalid));
 
 	const handleOpenChange = (open: boolean) => {
-		if (!open) {
+		if (!open && !isSubmittingAnimation) {
 			handleCancel();
 		}
 	};
 
 	const handleCancel = () => {
-		// ⚡ただインメモリのクローズフラグをキックするだけ（0ms駆動・チラつき全面根減）
 		closeGlobalNewModal();
+		setIsSubmittingAnimation(false);
 	};
 
-	const handleSave = async () => {
+	const handleSave = () => {
 		if (isSaveDisabled) return;
 
 		const capturedContent = content.trim();
@@ -128,22 +134,32 @@ export function GlobalNewNoteDialog() {
 		const capturedUrlPattern = urlPattern.trim();
 		const currentMode = mode;
 
-		// ⚡0msクローズ（履歴スタックへの干渉を排除）
-		closeGlobalNewModal();
+		// 1. フォーカス安全解除 ＆ 0ms即時右スライドアニメーション開始
+		if (
+			typeof document !== "undefined" &&
+			document.activeElement instanceof HTMLElement
+		) {
+			document.activeElement.blur();
+		}
+		setIsSubmittingAnimation(true);
 
-		try {
-			if (currentMode === "diary") {
-				const d = new Date();
-				const todayStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-				await appendDiaryMutation.mutateAsync({
+		// 2. 非同期通信をバックグラウンドへ流す
+		if (currentMode === "diary") {
+			const d = new Date();
+			const todayStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+			appendDiaryMutation.mutate(
+				{
 					date: todayStr,
 					text: capturedContent,
-				});
-				toast.success("Logged");
-				router.refresh();
-				return;
-			}
-
+				},
+				{
+					onError: (err: unknown) => {
+						console.error("Failed to save diary via background pipeline:", err);
+						toast.error("Failed to save diary log");
+					},
+				},
+			);
+		} else {
 			const input: CreateNoteInput = {
 				content: capturedContent,
 				scope: capturedScope,
@@ -151,26 +167,31 @@ export function GlobalNewNoteDialog() {
 				currentUrl: capturedUrlPattern || "inbox",
 			};
 
-			await createNoteMutation.mutateAsync(input);
-			toast.success("Saved");
-			router.refresh();
-		} catch (err: unknown) {
-			console.error("Failed to save via background pipeline:", err);
-			const errorMessage =
-				err instanceof Error
-					? err.message.toLowerCase()
-					: typeof err === "object" && err !== null && "message" in err
-						? String((err as { message: unknown }).message).toLowerCase()
-						: String(err).toLowerCase();
+			createNoteMutation.mutate(input, {
+				onError: (err: unknown) => {
+					console.error("Failed to save note via background pipeline:", err);
+					const errorMessage =
+						err instanceof Error
+							? err.message.toLowerCase()
+							: typeof err === "object" && err !== null && "message" in err
+								? String((err as { message: unknown }).message).toLowerCase()
+								: String(err).toLowerCase();
 
-			if (errorMessage.includes("limit reached")) {
-				openPaywall("notes");
-			} else {
-				toast.error(
-					`Failed to save. Retain: "${capturedContent.slice(0, 20)}..."`,
-				);
-			}
+					if (errorMessage.includes("limit reached")) {
+						openPaywall("notes");
+					} else {
+						toast.error(
+							`Failed to save. Retain: "${capturedContent.slice(0, 20)}..."`,
+						);
+					}
+				},
+			});
 		}
+
+		// 3. 右スライド(400ms) ＋ 余韻ポーズ(100ms) 後にモーダルを閉じる
+		setTimeout(() => {
+			closeGlobalNewModal();
+		}, 500);
 	};
 
 	const handlePromoteToStudio = () => {
@@ -189,6 +210,7 @@ export function GlobalNewNoteDialog() {
 				className={cn(
 					"bg-base-surface flex flex-col max-h-[85vh] overflow-hidden p-0",
 					mode === "gate" ? "sm:max-w-md" : "sm:max-w-2xl",
+					isSubmittingAnimation && "pointer-events-none",
 				)}
 			>
 				<DialogTitle className="sr-only">Capture Menu</DialogTitle>
@@ -202,7 +224,7 @@ export function GlobalNewNoteDialog() {
 							<button
 								type="button"
 								onClick={() => setMode("note")}
-								className="flex items-center gap-4 w-full p-4 rounded-[2rem] border border-base-border bg-base-bg hover-safe:bg-base-surface text-left cursor-pointer transition-all group px-6"
+								className="flex items-center gap-4 w-full p-4 rounded-full border border-base-border bg-base-bg hover-safe:bg-base-surface text-left cursor-pointer transition-all group px-6"
 							>
 								<Inbox className="w-5 h-5 text-gray-400 group-hover-safe:text-action shrink-0" />
 								<div className="flex flex-col min-w-0">
@@ -221,7 +243,7 @@ export function GlobalNewNoteDialog() {
 									handleCancel();
 									router.push("/studio/new");
 								}}
-								className="flex items-center gap-4 w-full p-4 rounded-[2rem] border border-base-border bg-base-bg hover-safe:bg-base-surface text-left cursor-pointer transition-all group px-6"
+								className="flex items-center gap-4 w-full p-4 rounded-full border border-base-border bg-base-bg hover-safe:bg-base-surface text-left cursor-pointer transition-all group px-6"
 							>
 								<PenTool className="w-5 h-5 text-gray-400 group-hover-safe:text-action shrink-0" />
 								<div className="flex flex-col min-w-0">
@@ -237,7 +259,7 @@ export function GlobalNewNoteDialog() {
 							<button
 								type="button"
 								onClick={() => setMode("diary")}
-								className="flex items-center gap-4 w-full p-4 rounded-[2rem] border border-base-border bg-base-bg hover-safe:bg-base-surface text-left cursor-pointer transition-all group px-6"
+								className="flex items-center gap-4 w-full p-4 rounded-full border border-base-border bg-base-bg hover-safe:bg-base-surface text-left cursor-pointer transition-all group px-6"
 							>
 								<CalendarDays className="w-5 h-5 text-gray-400 group-hover-safe:text-action shrink-0" />
 								<div className="flex flex-col min-w-0">
@@ -254,28 +276,46 @@ export function GlobalNewNoteDialog() {
 				)}
 
 				{mode === "diary" && (
-					<div className="flex flex-col flex-1 p-6 space-y-4">
-						<div className="flex items-center gap-2">
+					<div className="flex flex-col flex-1 p-6 space-y-4 min-h-0">
+						<div className="flex items-center gap-2 shrink-0">
 							<span className="text-xs font-mono font-bold uppercase text-neutral-400">
 								Daily Diary Mode
 							</span>
 						</div>
-						<textarea
-							autoFocus
-							value={content}
-							onChange={(e) => setContent(e.target.value)}
-							placeholder="Write down your thoughts for today... (No title required)"
-							className="w-full flex-1 min-h-[320px] p-4 text-base bg-base-bg text-action border border-base-border rounded-xl focus:outline-none focus:ring-1 focus:ring-action resize-none font-sans"
-							onKeyDown={(e) => {
-								if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-									e.preventDefault();
-									handleSave();
-								}
-							}}
-						/>
-						<div className="flex items-center justify-between mt-2">
+						{/* ★ 縦幅を min-h-[380px] h-[50vh] flex-1 に拡大し、枠内どこでもクリックで textarea にフォーカス委譲 */}
+						{/* biome-ignore lint/a11y/useKeyWithClickEvents: focus delegation to inner textarea */}
+						{/* biome-ignore lint/a11y/noStaticElementInteractions: focus delegation to inner textarea */}
+						<div
+							onClick={() => diaryTextareaRef.current?.focus()}
+							className="w-full flex-1 min-h-[380px] h-[50vh] bg-base-bg border border-base-border rounded-xl focus-within:ring-1 focus-within:ring-action overflow-hidden relative p-4 cursor-text flex flex-col"
+						>
+							<textarea
+								ref={diaryTextareaRef}
+								autoFocus
+								value={content}
+								onChange={(e) => setContent(e.target.value)}
+								onPaste={onMarkdownPaste}
+								placeholder="Write down your thoughts for today... (No title required)"
+								className={cn(
+									"w-full flex-1 h-full text-base bg-transparent text-action border-none focus:outline-none resize-none font-sans break-words [overflow-wrap:anywhere] p-0 overflow-y-auto transform-gpu block",
+									isSubmittingAnimation
+										? "transition-all duration-400 ease-out translate-x-full opacity-0 pointer-events-none"
+										: "transition-none",
+								)}
+								onKeyDown={(e) => {
+									if (e.nativeEvent.isComposing) return;
+									if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+										e.preventDefault();
+										handleSave();
+										return;
+									}
+									onMarkdownKeyDown(e);
+								}}
+							/>
+						</div>
+						<div className="flex items-center justify-between mt-2 shrink-0">
 							<Button
-								className="text-xs text-neutral-400 hover:text-action p-0 h-auto"
+								className="text-xs text-neutral-400 hover-safe:text-action p-0 h-auto"
 								onClick={handlePromoteToStudio}
 								type="button"
 								variant="link"
@@ -283,17 +323,22 @@ export function GlobalNewNoteDialog() {
 								Edit in Diary Studio
 							</Button>
 							<div className="flex gap-2">
-								<Button onClick={handleCancel} type="button" variant="ghost">
+								<Button
+									disabled={isSubmittingAnimation}
+									onClick={handleCancel}
+									type="button"
+									variant="ghost"
+								>
 									Cancel
 								</Button>
 								<Button
-									className="min-w-[100px]"
-									disabled={!content.trim()}
+									className="min-w-[100px] rounded-full"
+									disabled={isSaveDisabled}
 									onClick={handleSave}
 									type="button"
 									variant="default"
 								>
-									Save Diary
+									{isSubmittingAnimation ? "Logging..." : "Save Diary"}
 								</Button>
 							</div>
 						</div>
@@ -311,21 +356,24 @@ export function GlobalNewNoteDialog() {
 
 							<div className="space-y-4">
 								<div className="space-y-2">
-									<Label className="font-xs font-bold uppercase tracking-wider text-gray-400 inline-block mb-4">
+									<Label className="font-xs font-bold uppercase tracking-wider text-gray-400 inline-block mb-2">
 										Scope
 									</Label>
-									<div className="flex gap-2">
+									<div className="flex bg-base-bg p-1 rounded-full border border-base-border/50 shrink-0 gap-1 w-fit">
 										{(["inbox", "domain", "exact"] as const).map((s) => (
-											<Button
+											<button
 												key={s}
 												type="button"
-												variant={scope === s ? "default" : "secondary"}
-												size="sm"
 												onClick={() => setScope(s)}
-												className="capitalize cursor-pointer"
+												className={cn(
+													"cursor-pointer py-1.5 px-4 rounded-full text-xs font-bold transition-all capitalize",
+													scope === s
+														? "bg-action text-action-text shadow-sm"
+														: "text-muted-foreground hover-safe:text-action hover-safe:bg-base-surface",
+												)}
 											>
 												{s === "exact" ? "Page" : s}
-											</Button>
+											</button>
 										))}
 									</div>
 								</div>
@@ -334,7 +382,7 @@ export function GlobalNewNoteDialog() {
 									<div className="space-y-2">
 										<Label
 											htmlFor="global-url"
-											className="font-xs font-bold uppercase tracking-wider text-gray-400 inline-block mb-4"
+											className="font-xs font-bold uppercase tracking-wider text-gray-400 inline-block mb-2"
 										>
 											Source URL
 										</Label>
@@ -343,42 +391,62 @@ export function GlobalNewNoteDialog() {
 											placeholder="[example.com/page](https://example.com/page)"
 											value={urlPattern}
 											onChange={(e) => setUrlPattern(e.target.value)}
-											className="h-9 w-full"
+											className="h-9 w-full rounded-full text-base md:text-sm px-4"
 										/>
 									</div>
 								)}
 							</div>
 
 							<div className="grid items-center gap-2 mb-4">
-								<Label className="font-xs font-bold uppercase tracking-wider text-gray-400 inline-block mb-4">
+								<Label className="font-xs font-bold uppercase tracking-wider text-gray-400 inline-block mb-2">
 									Note Type
 								</Label>
-								<div className="flex gap-2">
+								<div className="flex bg-base-bg p-1 rounded-full border border-base-border/50 shrink-0 gap-1 w-fit">
 									{(["info", "alert", "idea"] as const).map((type) => (
-										<Button
+										<button
 											key={type}
 											type="button"
-											variant={noteType === type ? "default" : "secondary"}
-											size="sm"
 											onClick={() => setNoteType(type as Note["note_type"])}
-											className="capitalize cursor-pointer"
+											className={cn(
+												"cursor-pointer py-1.5 px-4 rounded-full text-xs font-bold transition-all capitalize",
+												noteType === type
+													? type === "info"
+														? "bg-note-info text-action-text shadow-sm"
+														: type === "alert"
+															? "bg-note-alert text-action-text shadow-sm"
+															: "bg-note-idea text-action-text shadow-sm"
+													: "text-muted-foreground hover-safe:text-action hover-safe:bg-base-surface",
+											)}
 										>
 											{type}
-										</Button>
+										</button>
 									))}
 								</div>
 							</div>
 
 							<div className="space-y-2">
-								<Label className="font-xs font-bold uppercase tracking-wider text-gray-400 inline-block mb-4">
+								<Label className="font-xs font-bold uppercase tracking-wider text-gray-400 inline-block mb-2">
 									Note
 								</Label>
-								<NotesEditor
-									value={content}
-									onChange={setContent}
-									placeholder="What's on your mind?"
-									isDirty={content.length > 0}
-								/>
+								{/* 外枠を固定したマスク親コンテナ */}
+								<div className="w-full overflow-hidden relative rounded-xl">
+									<div
+										className={cn(
+											"w-full transform-gpu",
+											isSubmittingAnimation
+												? "transition-all duration-400 ease-out translate-x-full opacity-0 pointer-events-none"
+												: "transition-none",
+										)}
+									>
+										<NotesEditor
+											value={content}
+											onChange={setContent}
+											placeholder="What's on your mind?"
+											isDirty={content.length > 0}
+											onSave={handleSave}
+										/>
+									</div>
+								</div>
 								{isNearLimit && (
 									<div className="flex justify-end">
 										<span
@@ -395,27 +463,32 @@ export function GlobalNewNoteDialog() {
 							</div>
 						</div>
 
-						<div className="m-0 p-4 bg-base-surface/50 border-t border-base-border flex justify-between w-full">
+						<div className="m-0 p-4 bg-base-surface/50 border-t border-base-border flex justify-between w-full items-center">
 							<Button
+								className="mr-auto rounded-full"
+								onClick={handlePromoteToStudio}
 								type="button"
 								variant="outline"
-								onClick={handlePromoteToStudio}
-								className="mr-auto"
 							>
 								Edit in Studio
 							</Button>
 							<div className="flex gap-2">
-								<Button type="button" variant="ghost" onClick={handleCancel}>
+								<Button
+									disabled={isSubmittingAnimation}
+									onClick={handleCancel}
+									type="button"
+									variant="ghost"
+								>
 									Cancel
 								</Button>
 								<Button
+									className="min-w-[100px] rounded-full"
+									disabled={isSaveDisabled}
+									onClick={handleSave}
 									type="button"
 									variant="default"
-									onClick={handleSave}
-									disabled={isSaveDisabled}
-									className="min-w-[100px]"
 								>
-									Save Note
+									{isSubmittingAnimation ? "Saving..." : "Save Note"}
 								</Button>
 							</div>
 						</div>


### PR DESCRIPTION
… submission timeline

Why:
- The previous dialog exhibited jarring UX due to synchronous UI locking, abrupt closing, and explicit toast popups upon saving.
- Toggle controls lacked design alignment with the extension's capsule UI system (`FilterBar.tsx`).
- Daily Diary mode lacked Markdown input assistance and had a constrained input canvas where clicking the outer frame caused focus loss.
- Quick Note mode failed to trigger `Cmd+Enter` shortcuts due to a missing `onSave` handler.

What:
- Implement a 350ms sequential timeline (400ms smooth right-slide transition + 100ms visual pose) with silent background mutations, purging `toast.success` and `router.refresh()`.
- Unify Scope and NoteType toggles, save buttons, and URL inputs with capsule-shaped UI (`rounded-full`).
- Expand the Daily Diary canvas (`min-h-[380px] h-[50vh] flex-1`) and delegate click events to the inner `<textarea>` for robust focus retention.
- Bind `useMarkdownAssist` (Tab indentation, auto-bullets, URL link conversion, IME composing guards) to Daily Diary `<textarea>`.
- Pass the `handleSave` callback to `NotesEditor` to enable `Cmd+Enter` / `Ctrl+Enter` shortcuts in Quick Note mode.
- Prevent iOS Safari auto-zoom by specifying `text-base` fonts and adding overflow word wrapping.
- Update `GlobalNewNoteDialog.test.tsx` to assert dynamic button labels (`Saving...` / `Logging...`), timeline timers, and dialog closures.