### PR TITLE
feat(app): resolve new note scope/type persistence and aggregate doma…

### DIFF
--- a/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneHeader.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneHeader.tsx
@@ -190,9 +190,10 @@ export function MiddlePaneHeader({
 		(currentView === "diaries" && (currentYear || currentMonth));
 
 	const isDiariesView = currentView === "diaries";
+	const typeParam = filterType !== "all" ? `&type=${filterType}` : "";
 	const plusHref = isDiariesView
 		? "/notes?view=diaries&globalNew=note&intent=diary"
-		: `/notes?domain=${currentDomain || "inbox"}${currentExact ? `&exact=${encodeURIComponent(currentExact)}` : ""}&new=note`;
+		: `/notes?domain=${currentDomain || "inbox"}${currentExact ? `&exact=${encodeURIComponent(currentExact)}` : ""}&new=note${typeParam}`;
 	const plusTitle = isDiariesView ? "New Diary Log" : "New Note here";
 
 	return (

--- a/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
 import { useSearchParams } from "next/navigation";
 import { describe, expect, it, vi } from "vitest";
 import { useFetchNotes } from "@/hooks/useNotesQuery";
@@ -236,7 +236,9 @@ describe("NotesContainer - Skeleton & Cache Strategy", () => {
 
 	it("入力パラメータのDeferred化によりヘッダーUIが0msで正常レンダリングされること", async () => {
 		vi.mocked(useSearchParams).mockReturnValue(
-			new URLSearchParams("view=domains") as unknown as ReturnType<typeof useSearchParams>,
+			new URLSearchParams("view=domains") as unknown as ReturnType<
+				typeof useSearchParams
+			>,
 		);
 
 		vi.mocked(useFetchNotes).mockReturnValue({
@@ -259,6 +261,60 @@ describe("NotesContainer - Skeleton & Cache Strategy", () => {
 				screen.getByTestId("middle-pane") ||
 					screen.getByRole("navigation", { name: "ビュー切り替え" }),
 			).toBeInTheDocument();
+		});
+	});
+});
+
+describe("NotesContainer - exact=all All Notes Integration", () => {
+	it("combines domain notes and all page notes sorted correctly when exact=all", async () => {
+		vi.mocked(useSearchParams).mockReturnValue(
+			new URLSearchParams(
+				"?view=domains&domain=example.com&exact=all",
+			) as unknown as ReturnType<typeof useSearchParams>,
+		);
+
+		const notesData = [
+			{
+				id: "domain-note-1",
+				content: "Domain Note 1",
+				url_pattern: "example.com",
+				scope: "domain",
+				is_pinned: false,
+				sort_order: 2.0,
+				created_at: "2026-08-01T00:00:00.000Z",
+			},
+			{
+				id: "page-note-pinned",
+				content: "Pinned Page Note",
+				url_pattern: "example.com/page-1",
+				scope: "exact",
+				is_pinned: true,
+				sort_order: 5.0,
+				created_at: "2026-08-01T00:00:00.000Z",
+			},
+			{
+				id: "page-note-2",
+				content: "Page Note 2",
+				url_pattern: "example.com/page-2",
+				scope: "exact",
+				is_pinned: false,
+				sort_order: 1.0,
+				created_at: "2026-08-02T00:00:00.000Z",
+			},
+		];
+
+		vi.mocked(useFetchNotes).mockReturnValue({
+			data: notesData,
+			isLoading: false,
+		} as unknown as ReturnType<typeof useFetchNotes>);
+
+		render(<NotesContainer />);
+
+		await waitFor(() => {
+			const middlePane = screen.getByTestId("middle-pane");
+			expect(middlePane).toBeInTheDocument();
+			// 3件すべてが統合されて表示対象になること
+			expect(middlePane).toHaveTextContent("3 items");
 		});
 	});
 });

--- a/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.tsx
@@ -124,9 +124,31 @@ export function NotesContainer() {
 		} else if (!groupedNotes) {
 			items = [];
 		} else if (deferredExact === "all") {
-			items = groupedNotes.domains[deferredDomain || ""]?.domainNotes || [];
+			const domainData = groupedNotes.domains[deferredDomain || ""];
+			if (domainData) {
+				items = [
+					...domainData.domainNotes,
+					...Object.values(domainData.pages).flat(),
+				];
+				items.sort((a, b) => {
+					const noteA = a as Note;
+					const noteB = b as Note;
+					if (noteA.is_pinned !== noteB.is_pinned)
+						return noteA.is_pinned ? -1 : 1;
+					if (noteA.sort_order !== noteB.sort_order) {
+						return (noteA.sort_order ?? 0) - (noteB.sort_order ?? 0);
+					}
+					return (
+						new Date(noteB.created_at).getTime() -
+						new Date(noteA.created_at).getTime()
+					);
+				});
+			} else {
+				items = [];
+			}
 		} else if (deferredExact) {
-			items = groupedNotes.domains[deferredDomain || ""]?.pages[deferredExact] || [];
+			items =
+				groupedNotes.domains[deferredDomain || ""]?.pages[deferredExact] || [];
 		} else if (deferredView === "inbox" || deferredDomain === "inbox") {
 			items = groupedNotes.inbox;
 		} else if (deferredDomain) {

--- a/apps/app/src/app/(dashboard)/notes/_components/RightPaneDetail.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/RightPaneDetail.test.tsx
@@ -1,21 +1,29 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { Note } from "../types";
 import { RightPaneDetail } from "./RightPaneDetail";
 
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+let mockSearchParams = new URLSearchParams();
+
 vi.mock("next/navigation", () => ({
-	useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
-	useSearchParams: () => new URLSearchParams(),
+	useRouter: () => ({ push: mockPush, replace: mockReplace }),
+	useSearchParams: () => mockSearchParams,
 }));
 
 vi.mock("@/hooks/useDiariesQuery", () => ({
 	useFetchDiaries: () => ({ data: [] }),
 }));
 
+const mockCreateNoteMutateAsync = vi.fn();
+const mockUpdateNoteMutateAsync = vi.fn();
+const mockDeleteNoteMutateAsync = vi.fn();
+
 vi.mock("@/hooks/useNotesQuery", () => ({
-	useCreateNote: () => ({ mutateAsync: vi.fn() }),
-	useUpdateNote: () => ({ mutateAsync: vi.fn() }),
-	useDeleteNote: () => ({ mutateAsync: vi.fn() }),
+	useCreateNote: () => ({ mutateAsync: mockCreateNoteMutateAsync }),
+	useUpdateNote: () => ({ mutateAsync: mockUpdateNoteMutateAsync }),
+	useDeleteNote: () => ({ mutateAsync: mockDeleteNoteMutateAsync }),
 }));
 
 describe("RightPaneDetail - SWRBoundary Key Isolation", () => {
@@ -90,5 +98,93 @@ describe("RightPaneDetail - SWRBoundary with isDataReady", () => {
 
 		expect(screen.queryByTestId("detail-skeleton")).not.toBeInTheDocument();
 		expect(screen.getByText("Instant Cached Body")).toBeInTheDocument();
+	});
+});
+
+describe("RightPaneDetail - New Note Scope & NoteType Integration", () => {
+	it("saves note with exact scope and user-entered URL when user changes scope to Page", async () => {
+		mockSearchParams = new URLSearchParams("?domain=example.com&new=note");
+		mockCreateNoteMutateAsync.mockResolvedValueOnce({
+			id: "new-note-123",
+			scope: "exact",
+			url_pattern: "example.com/sub-page",
+			note_type: "info",
+			content: "Page note content",
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			is_pinned: false,
+			is_resolved: false,
+			is_favorite: false,
+			sort_order: 0,
+		});
+
+		render(<RightPaneDetail isNewNote={true} />);
+
+		// Scope を Page に切り替え
+		const pageButton = screen.getByRole("button", { name: "Page" });
+		fireEvent.click(pageButton);
+
+		// URL 入力欄に exact URL を入力
+		const urlInput = screen.getByPlaceholderText("https://...");
+		fireEvent.change(urlInput, {
+			target: { value: "https://example.com/sub-page" },
+		});
+
+		// 本文を入力（CodeMirror の onChange 相当）
+		const textarea = screen.getByPlaceholderText("What's on your mind?");
+		fireEvent.change(textarea, { target: { value: "Page note content" } });
+
+		// Save ボタンをクリック
+		const saveButton = screen.getByRole("button", { name: "Save" });
+		fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(mockCreateNoteMutateAsync).toHaveBeenCalledWith({
+				content: "Page note content",
+				scope: "exact",
+				note_type: "info",
+				currentUrl: "example.com/sub-page",
+			});
+			expect(mockReplace).toHaveBeenCalledWith(
+				`/notes?domain=example.com&view=domains&exact=${encodeURIComponent("example.com/sub-page")}&noteId=new-note-123`,
+			);
+		});
+	});
+
+	it("initializes editNoteType from URL searchParams 'type'", async () => {
+		mockSearchParams = new URLSearchParams(
+			"?domain=example.com&new=note&type=alert",
+		);
+		mockCreateNoteMutateAsync.mockResolvedValueOnce({
+			id: "alert-note-456",
+			scope: "domain",
+			url_pattern: "example.com",
+			note_type: "alert",
+			content: "Alert note content",
+			created_at: new Date().toISOString(),
+			updated_at: new Date().toISOString(),
+			is_pinned: false,
+			is_resolved: false,
+			is_favorite: false,
+			sort_order: 0,
+		});
+
+		render(<RightPaneDetail isNewNote={true} />);
+
+		// 本文入力
+		const textarea = screen.getByPlaceholderText("What's on your mind?");
+		fireEvent.change(textarea, { target: { value: "Alert note content" } });
+
+		// Save 実行
+		const saveButton = screen.getByRole("button", { name: "Save" });
+		fireEvent.click(saveButton);
+
+		await waitFor(() => {
+			expect(mockCreateNoteMutateAsync).toHaveBeenCalledWith(
+				expect.objectContaining({
+					note_type: "alert",
+				}),
+			);
+		});
 	});
 });

--- a/apps/app/src/app/(dashboard)/notes/_components/RightPaneDetail.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/RightPaneDetail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+	buildNoteContextHref,
 	type NoteType,
 	normalizeUrlForGrouping,
 	SHARED_LIMITS,
@@ -16,7 +17,7 @@ import {
 	Star,
 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useDeferredValue, useEffect, useState } from "react";
+import { useDeferredValue, useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { NotesEditor } from "@/components/editor/NotesEditor";
 import MarkdownRenderer from "@/components/MarkdownRenderer";
@@ -83,6 +84,7 @@ export function RightPaneDetail({
 	const { data: diaries = [] } = useFetchDiaries();
 	const diary = diaries.find((d) => d.date === selectedDate);
 	const [isEditing, setIsEditing] = useState(false);
+	const editorContainerRef = useRef<HTMLDivElement>(null);
 
 	const [editContent, setEditContent] = useState("");
 	const [isSaving, setIsSaving] = useState(false);
@@ -136,6 +138,18 @@ export function RightPaneDetail({
 		if (isNewNote) {
 			setIsEditing(true);
 			setEditContent("");
+
+			// Note Type 連動
+			const typeParam = searchParams.get("type");
+			if (
+				typeParam === "info" ||
+				typeParam === "alert" ||
+				typeParam === "idea"
+			) {
+				setEditNoteType(typeParam as Note["note_type"]);
+			} else {
+				setEditNoteType("info");
+			}
 
 			let currentExact = searchParams.get("exact");
 			let currentDomain = searchParams.get("domain");
@@ -291,6 +305,12 @@ export function RightPaneDetail({
 	const handleEdit = () => {
 		setEditContent(note?.content || "");
 		setIsEditing(true);
+		requestAnimationFrame(() => {
+			editorContainerRef.current?.scrollIntoView({
+				behavior: "smooth",
+				block: "nearest",
+			});
+		});
 	};
 
 	const handleCancel = () => {
@@ -327,33 +347,30 @@ export function RightPaneDetail({
 
 		try {
 			if (isNewNote) {
-				const exactParam = searchParams.get("exact");
-				const domainParam = searchParams.get("domain");
-
-				let targetScope: Note["scope"] = "inbox";
-				let targetUrlPattern = "";
-
-				// 🚨 exactParam が "all" の場合は弾き、domain へフォールバックさせる
-				if (exactParam && exactParam !== "all") {
-					targetScope = "exact";
-					targetUrlPattern = exactParam;
-				} else if (domainParam && domainParam !== "inbox") {
-					targetScope = "domain";
-					targetUrlPattern = domainParam;
+				let finalUrl = editUrl.trim();
+				if (editScope === "inbox") {
+					finalUrl = "inbox";
+				} else if (finalUrl) {
+					const normalizedFullUrl = normalizeUrlForGrouping(finalUrl);
+					if (editScope === "domain") {
+						finalUrl = normalizedFullUrl.split("/")[0];
+					} else if (editScope === "exact") {
+						finalUrl = normalizedFullUrl;
+					}
+				} else {
+					finalUrl = "inbox";
 				}
 
 				const data = await createNoteMutation.mutateAsync({
 					content: newContent,
-					scope: targetScope,
-					note_type: editNoteType as NoteType, // Cast if needed but should match now
-					currentUrl: targetUrlPattern || "inbox",
+					scope: editScope,
+					note_type: editNoteType as NoteType,
+					currentUrl: finalUrl,
 				});
 
 				setOptimisticContent(newContent);
-				const params = new URLSearchParams(searchParams.toString());
-				params.delete("new");
-				params.set("noteId", data.id);
-				router.replace(`/notes?${params.toString()}`);
+				const targetHref = buildNoteContextHref(data);
+				router.replace(targetHref);
 			} else if (note) {
 				let finalUrl = editUrl.trim();
 				if (editScope === "inbox") {
@@ -784,7 +801,7 @@ export function RightPaneDetail({
 							</div>
 
 							{/* Content Editing Area */}
-							<div className="relative">
+							<div ref={editorContainerRef} className="relative">
 								{(() => {
 									const baseContent =
 										optimisticContent !== null

--- a/apps/app/vitest.setup.ts
+++ b/apps/app/vitest.setup.ts
@@ -95,6 +95,7 @@ vi.mock("@uiw/react-codemirror", () => {
 			return React.createElement("textarea", {
 				"data-testid": "codemirror-mock",
 				value: props.value,
+				placeholder: props.placeholder,
 				onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
 					props.onChange?.(e.target.value),
 			});


### PR DESCRIPTION
…in notes

Why:
- Selecting `exact=all` under a domain only rendered domain-scoped notes, omitting page-specific notes within that domain.
- Creating a note and changing the scope to "Page" mistakenly persisted as "Domain" because `handleSave` prioritized `searchParams` over local form inputs.
- Creating a note while a NoteType filter was active always defaulted to "info", causing immediate disappearance from the filtered list after saving.
- Switching from view to edit mode pushed the editor down due to the metadata panel insertion, causing disorientation.

What:
- Aggregate `domainNotes` and all `pages` notes sorted by pinned/sort_order/created_at when `exact=all` in `NotesContainer.tsx`.
- Prioritize `editScope` and `editUrl` over `searchParams` in `RightPaneDetail.tsx` when saving new notes, resolving destination via `buildNoteContextHref`.
- Propagate active `filterType` via `&type=` query parameter in `MiddlePaneHeader.tsx` and initialize `editNoteType` in `RightPaneDetail.tsx`.
- Add `requestAnimationFrame` smooth scroll targeting the editor container on edit transition.
- Expand test coverage in `NotesContainer.test.tsx` and `RightPaneDetail.test.tsx`, and forward `placeholder` in `vitest.setup.ts`. Please enter the commit message for your changes. Lines starting with '#' will be ignored, and an empty message aborts the commit.

 On branch fix/notes-scope-type-and-all-notes-view