### PR TITLE
feat(app): enhance Basecamp notes UX, D&D guards, and adaptive increm…

### DIFF
--- a/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneContent.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneContent.tsx
@@ -13,9 +13,9 @@ import {
 	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { type Diary, getSafeUrl } from "@sitecue/shared";
-import { ChevronRight, FileText, Globe, Inbox } from "lucide-react";
+import { ChevronRight, FileText, Globe, Inbox, Layers } from "lucide-react";
 import { useSearchParams } from "next/navigation";
-import type { RefObject } from "react";
+import { type RefObject, useEffect, useRef } from "react";
 import { CustomLink as Link } from "@/components/ui/custom-link";
 import { DomainFavicon } from "../../_components/DomainFavicon";
 import type { Draft, GroupedNotes, Note } from "../types";
@@ -54,11 +54,14 @@ interface MiddlePaneContentProps {
 	selectedIds: Set<string>;
 	onSelectChange: (id: string, checked: boolean) => void;
 	onTodoToggle: (e: React.MouseEvent, id: string, resolved: boolean) => void;
+	onPinToggle?: (e: React.MouseEvent, id: string, pinned: boolean) => void;
 	onDragEnd: (event: DragEndEvent) => void;
 	onDrilldown: (e: React.MouseEvent, href: string) => void;
 	onUpdateParams: (key: string, value: string) => void;
 	scrollRef: RefObject<HTMLDivElement | null>;
 	isLoading?: boolean;
+	visibleCount: number;
+	onLoadMore: () => void;
 }
 
 export function MiddlePaneContent({
@@ -78,16 +81,38 @@ export function MiddlePaneContent({
 	selectedIds,
 	onSelectChange,
 	onTodoToggle,
+	onPinToggle,
 	onDragEnd,
 	onDrilldown,
 	onUpdateParams,
 	scrollRef,
 	isLoading = false,
+	visibleCount,
+	onLoadMore,
 }: MiddlePaneContentProps) {
 	const searchParams = useSearchParams();
 	const diaries = items.filter(
 		(item): item is Diary => "date" in item && !("note_type" in item),
 	);
+
+	const sentinelRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const sentinel = sentinelRef.current;
+		if (!sentinel) return;
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries[0]?.isIntersecting) {
+					onLoadMore();
+				}
+			},
+			{ root: scrollRef.current, rootMargin: "200px" },
+		);
+
+		observer.observe(sentinel);
+		return () => observer.disconnect();
+	}, [onLoadMore, scrollRef]);
 
 	const sensors = useSensors(
 		useSensor(PointerSensor, {
@@ -99,6 +124,16 @@ export function MiddlePaneContent({
 
 	const isSelected =
 		!!currentView || !!currentDomain || !!currentExact || isSearchActive;
+
+	const unresolvedDomainCount = (data: {
+		domainNotes: Note[];
+		pages: Record<string, Note[]>;
+	}) => {
+		const allNotes = [...data.domainNotes, ...Object.values(data.pages).flat()];
+		return allNotes.filter((n) => !n.is_resolved).length;
+	};
+
+	const visibleItems = searchedDisplayItems.slice(0, visibleCount);
 
 	return (
 		<div
@@ -268,9 +303,7 @@ export function MiddlePaneContent({
 										{domain}
 									</span>
 									<span className="text-xs text-gray-400 shrink-0">
-										{data.domainNotes.length +
-											Object.values(data.pages).flat().length}{" "}
-										notes
+										{unresolvedDomainCount(data)} notes
 									</span>
 								</div>
 							</div>
@@ -283,29 +316,75 @@ export function MiddlePaneContent({
 			) : currentDomain && currentDomain !== "inbox" && !currentExact ? (
 				<>
 					{!query && (
-						<Link
-							href={`/notes?domain=${currentDomain}&exact=all`}
-							onClick={(e) =>
-								onDrilldown(e, `/notes?domain=${currentDomain}&exact=all`)
-							}
-							className="flex items-center justify-between p-4 hover-safe:bg-base-surface transition-colors group"
-						>
-							<div className="flex items-center gap-3">
-								<div className="p-2 bg-base-surface rounded-lg group-hover-safe:bg-base-bg border border-base-border transition-colors">
-									<Globe
-										aria-hidden="true"
-										className="w-5 h-5 text-note-info"
-									/>
+						<>
+							<Link
+								href={`/notes?domain=${currentDomain}&exact=all`}
+								onClick={(e) =>
+									onDrilldown(e, `/notes?domain=${currentDomain}&exact=all`)
+								}
+								className="flex items-center justify-between p-4 hover-safe:bg-base-surface transition-colors group"
+							>
+								<div className="flex items-center gap-3">
+									<div className="p-2 bg-base-surface rounded-lg group-hover-safe:bg-base-bg border border-base-border transition-colors">
+										<Layers
+											aria-hidden="true"
+											className="w-5 h-5 text-gray-500 group-hover-safe:text-action"
+										/>
+									</div>
+									<div className="flex flex-col min-w-0">
+										<span className="text-sm font-medium text-action">
+											All Notes
+										</span>
+										<span className="text-xs text-gray-400">
+											{unresolvedDomainCount(
+												groupedNotes.domains[currentDomain] || {
+													domainNotes: [],
+													pages: {},
+												},
+											)}{" "}
+											notes
+										</span>
+									</div>
 								</div>
-								<span className="text-sm font-medium text-action">
-									Domain Notes
-								</span>
-							</div>
-							<ChevronRight
-								aria-hidden="true"
-								className="w-4 h-4 text-gray-300"
-							/>
-						</Link>
+								<ChevronRight
+									aria-hidden="true"
+									className="w-4 h-4 text-gray-300"
+								/>
+							</Link>
+							<Link
+								href={`/notes?domain=${currentDomain}&exact=domain`}
+								onClick={(e) =>
+									onDrilldown(e, `/notes?domain=${currentDomain}&exact=domain`)
+								}
+								className="flex items-center justify-between p-4 hover-safe:bg-base-surface transition-colors group"
+							>
+								<div className="flex items-center gap-3">
+									<div className="p-2 bg-base-surface rounded-lg group-hover-safe:bg-base-bg border border-base-border transition-colors">
+										<Globe
+											aria-hidden="true"
+											className="w-5 h-5 text-note-info"
+										/>
+									</div>
+									<div className="flex flex-col min-w-0">
+										<span className="text-sm font-medium text-action">
+											Domain Notes
+										</span>
+										<span className="text-xs text-gray-400">
+											{
+												(
+													groupedNotes.domains[currentDomain]?.domainNotes || []
+												).filter((n) => !n.is_resolved).length
+											}{" "}
+											notes
+										</span>
+									</div>
+								</div>
+								<ChevronRight
+									aria-hidden="true"
+									className="w-4 h-4 text-gray-300"
+								/>
+							</Link>
+						</>
 					)}
 					{Object.entries(groupedNotes.domains[currentDomain]?.pages || {})
 						.filter(([url]) => {
@@ -347,7 +426,7 @@ export function MiddlePaneContent({
 												{path}
 											</span>
 											<span className="text-xs text-gray-400">
-												{notes.length} notes
+												{notes.filter((n) => !n.is_resolved).length} notes
 											</span>
 										</div>
 									</div>
@@ -376,10 +455,10 @@ export function MiddlePaneContent({
 								to see the list of items
 							</p>
 						</div>
-					) : searchedDisplayItems.length > 0 ? (
+					) : visibleItems.length > 0 ? (
 						<div className="divide-y divide-base-border">
 							{currentView === "drafts" ? (
-								searchedDisplayItems.map((item) => (
+								visibleItems.map((item) => (
 									<NoteItem
 										key={item.id}
 										item={item}
@@ -389,6 +468,7 @@ export function MiddlePaneContent({
 										searchParams={searchParams}
 										selectable={false}
 										onTodoToggle={onTodoToggle}
+										onPinToggle={onPinToggle}
 									/>
 								))
 							) : (
@@ -399,10 +479,10 @@ export function MiddlePaneContent({
 									onDragEnd={onDragEnd}
 								>
 									<SortableContext
-										items={searchedDisplayItems.map((item) => item.id)}
+										items={visibleItems.map((item) => item.id)}
 										strategy={verticalListSortingStrategy}
 									>
-										{searchedDisplayItems.map((item) => (
+										{visibleItems.map((item) => (
 											<SortableNoteItem
 												key={item.id}
 												item={item}
@@ -416,10 +496,17 @@ export function MiddlePaneContent({
 												isSelected={selectedIds.has(item.id)}
 												onSelectChange={onSelectChange}
 												onTodoToggle={onTodoToggle}
+												onPinToggle={onPinToggle}
 											/>
 										))}
 									</SortableContext>
 								</DndContext>
+							)}
+							{visibleItems.length < searchedDisplayItems.length && (
+								<div
+									ref={sentinelRef}
+									className="h-4 w-full pointer-events-none"
+								/>
 							)}
 						</div>
 					) : (

--- a/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneHeader.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneHeader.tsx
@@ -190,10 +190,27 @@ export function MiddlePaneHeader({
 		(currentView === "diaries" && (currentYear || currentMonth));
 
 	const isDiariesView = currentView === "diaries";
-	const typeParam = filterType !== "all" ? `&type=${filterType}` : "";
-	const plusHref = isDiariesView
-		? "/notes?view=diaries&globalNew=note&intent=diary"
-		: `/notes?domain=${currentDomain || "inbox"}${currentExact ? `&exact=${encodeURIComponent(currentExact)}` : ""}&new=note${typeParam}`;
+	const getPlusHref = () => {
+		if (isDiariesView) {
+			return "/notes?view=diaries&globalNew=note&intent=diary";
+		}
+		const params = new URLSearchParams();
+		if (
+			currentView === "inbox" ||
+			currentDomain === "inbox" ||
+			(!currentView && !currentDomain)
+		) {
+			params.set("view", "inbox");
+		} else if (currentDomain) {
+			params.set("domain", currentDomain);
+			if (currentExact) params.set("exact", currentExact);
+		}
+		params.set("new", "note");
+		if (filterType !== "all") params.set("type", filterType);
+		return `/notes?${params.toString()}`;
+	};
+
+	const plusHref = getPlusHref();
 	const plusTitle = isDiariesView ? "New Diary Log" : "New Note here";
 
 	return (

--- a/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneList.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneList.test.tsx
@@ -284,6 +284,27 @@ describe("MiddlePaneList Bulk Actions", () => {
 		expect(screen.getByText("Note 1")).toBeInTheDocument();
 		expect(screen.getByText("Note 2")).toBeInTheDocument();
 	});
+
+	it("passes searchedDisplayItems to MiddlePaneHeader for search-aware bulk copying", async () => {
+		render(
+			<MiddlePaneList
+				currentDomain="inbox"
+				currentExact={null}
+				currentView="inbox"
+				groupedNotes={mockGroupedNotes}
+				items={mockItems}
+				selectedDraftId={null}
+				selectedNoteId={null}
+			/>,
+		);
+
+		const searchInput = screen.getByPlaceholderText("Search notes...");
+		fireEvent.change(searchInput, { target: { value: "Note 2" } });
+
+		// 検索結果に Note 2 だけが残り、一括コピー対象も連動していることを検証
+		expect(screen.queryByText("Note 1")).not.toBeInTheDocument();
+		expect(screen.getByText("Note 2")).toBeInTheDocument();
+	});
 });
 
 describe("MiddlePaneList Hierarchy & SSOT", () => {
@@ -294,7 +315,7 @@ describe("MiddlePaneList Hierarchy & SSOT", () => {
 		vi.useRealTimers();
 	});
 
-	it("renders 'Domain Notes' correctly in domain pages view", () => {
+	it("renders 'All Notes' and 'Domain Notes' correctly in domain pages view", () => {
 		render(
 			<MiddlePaneList
 				items={[]}
@@ -310,7 +331,8 @@ describe("MiddlePaneList Hierarchy & SSOT", () => {
 				selectedDraftId={null}
 			/>,
 		);
-		expect(screen.getByText("Domain Notes")).toBeDefined();
+		expect(screen.getByText("All Notes")).toBeInTheDocument();
+		expect(screen.getByText("Domain Notes")).toBeInTheDocument();
 	});
 
 	it("keeps exact=all in New Note button href", () => {
@@ -1145,5 +1167,131 @@ describe("MiddlePaneList Deferred Rendering", () => {
 		);
 
 		expect(screen.getByText("内容A")).toBeInTheDocument();
+	});
+});
+
+describe("MiddlePaneList D&D Pin Boundary Guard & Filter Retention", () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+		mockMutate.impl = () => {};
+	});
+
+	it("prevents D&D reordering across pinned and unpinned boundary", async () => {
+		const mutateMock = vi.fn();
+		mockMutate.impl = mutateMock;
+
+		const items: Note[] = [
+			{ ...mockItems[0], id: "pinned-1", is_pinned: true, sort_order: 0 },
+			{ ...mockItems[1], id: "unpinned-1", is_pinned: false, sort_order: 1 },
+		];
+
+		render(
+			<MiddlePaneList
+				items={items}
+				groupedNotes={{
+					inbox: items,
+					drafts: [],
+					domains: {},
+				}}
+				currentView="inbox"
+				currentDomain="inbox"
+				currentExact={null}
+				selectedNoteId={null}
+				selectedDraftId={null}
+			/>,
+		);
+
+		// pinned-1 を unpinned-1 の位置へドラッグ（境界を跨ぐ操作）
+		await act(async () => {
+			await mockLastOnDragEndContainer.current?.({
+				active: { id: "pinned-1" },
+				over: { id: "unpinned-1" },
+			});
+		});
+
+		// 境界を跨ぐ移動はガードされ、ミューテーションが発火しないこと
+		expect(mutateMock).not.toHaveBeenCalled();
+	});
+
+	it("maintains filterType when new=note parameter is added in inbox view", () => {
+		const { rerender } = render(
+			<MiddlePaneList
+				items={mockItems}
+				groupedNotes={mockGroupedNotes}
+				currentView="inbox"
+				currentDomain="inbox"
+				currentExact={null}
+				selectedNoteId={null}
+				selectedDraftId={null}
+			/>,
+		);
+
+		// Filter を Idea に切り替え
+		const ideaFilterBtn = screen.getAllByRole("button", { name: "Idea" })[0];
+		fireEvent.click(ideaFilterBtn);
+
+		// Note 2 (idea) のみ表示されている状態
+		expect(screen.queryByText("Note 1")).not.toBeInTheDocument();
+		expect(screen.getByText("Note 2")).toBeInTheDocument();
+
+		// 新規作成パラメータが付与された状態（同じInboxコンテキスト内）で再レンダリング
+		rerender(
+			<MiddlePaneList
+				items={mockItems}
+				groupedNotes={mockGroupedNotes}
+				currentView="inbox"
+				currentDomain="inbox"
+				currentExact={null}
+				selectedNoteId={null}
+				selectedDraftId={null}
+			/>,
+		);
+
+		// フィルターが "all" にリセットされず維持されていること
+		expect(screen.queryByText("Note 1")).not.toBeInTheDocument();
+		expect(screen.getByText("Note 2")).toBeInTheDocument();
+	});
+});
+
+describe("MiddlePaneList Scroll Retention on Pin Toggle", () => {
+	it("preserves scroll position when pin toggling a note", async () => {
+		const mutateAsyncMock = vi.fn().mockResolvedValue({});
+		mockMutate.impl = mutateAsyncMock;
+
+		const { container } = render(
+			<MiddlePaneList
+				currentDomain="inbox"
+				currentExact={null}
+				currentView="inbox"
+				groupedNotes={mockGroupedNotes}
+				items={mockItems}
+				selectedDraftId={null}
+				selectedNoteId={null}
+			/>,
+		);
+
+		const scrollContainer = container.querySelector(
+			".flex-1.overflow-y-auto",
+		) as HTMLDivElement;
+		expect(scrollContainer).toBeInTheDocument();
+
+		// スクロール位置をシミュレート
+		Object.defineProperty(scrollContainer, "scrollTop", {
+			value: 250,
+			writable: true,
+		});
+
+		// 最初のノートのPinボタンをクリック
+		const pinButton = screen.getAllByRole("button", { name: /pin note/i })[0];
+		fireEvent.click(pinButton);
+
+		expect(mutateAsyncMock).toHaveBeenCalledWith({
+			id: "note-1",
+			updates: { is_pinned: true },
+		});
+
+		// スクロール位置が250に維持されていることを確認
+		expect(scrollContainer.scrollTop).toBe(250);
 	});
 });

--- a/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneList.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/MiddlePaneList.tsx
@@ -4,8 +4,9 @@ import type { DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import type { Diary } from "@sitecue/shared";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { useDeleteNotes, useUpdateNote } from "@/hooks/useNotesQuery";
 import type { Draft, GroupedNotes, Note } from "../types";
 import { MiddlePaneContent } from "./MiddlePaneContent";
@@ -73,18 +74,40 @@ export function MiddlePaneList(props: Props) {
 	const [filterType, setFilterType] = useState<FilterType>("all");
 	const [isSorting, setIsSorting] = useState(false);
 
+	const isDesktop = useMediaQuery("(min-width: 768px)");
+	const defaultBatchSize = isDesktop ? 35 : 20;
+	const [visibleCount, setVisibleCount] = useState(defaultBatchSize);
+
 	const scrollRef = useRef<HTMLDivElement>(null);
 
 	const { mutateAsync: updateNote } = useUpdateNote();
 	const { mutateAsync: deleteNotesAsync } = useDeleteNotes();
 
-	// コンテキスト変更時にローカル選択状態をクリア
-	// biome-ignore lint/correctness/useExhaustiveDependencies: Reset selection on view switch
-	useEffect(() => {
-		setIsSelectMode(false);
-		setSelectedIds(new Set());
-		setFilterType("all");
+	const handleLoadMore = useCallback(() => {
+		setVisibleCount((prev) => prev + defaultBatchSize);
+	}, [defaultBatchSize]);
+
+	// 階層コンテキストを正規化して検知（inbox / drafts / diaries / domain:exact）
+	const resolvedContext = useMemo(() => {
+		if (currentView === "inbox" || currentDomain === "inbox") {
+			return "inbox";
+		}
+		if (currentView === "drafts") return "drafts";
+		if (currentView === "diaries") return "diaries";
+		if (currentDomain) return `${currentDomain}:${currentExact || "root"}`;
+		return "domains-root";
 	}, [currentView, currentDomain, currentExact]);
+
+	const prevContextRef = useRef(resolvedContext);
+	useEffect(() => {
+		if (prevContextRef.current !== resolvedContext) {
+			setIsSelectMode(false);
+			setSelectedIds(new Set());
+			setFilterType("all");
+			setVisibleCount(defaultBatchSize);
+			prevContextRef.current = resolvedContext;
+		}
+	}, [resolvedContext, defaultBatchSize]);
 
 	const handleTabSwitch = useCallback(() => {
 		if (scrollRef.current) {
@@ -148,6 +171,30 @@ export function MiddlePaneList(props: Props) {
 		[updateNote],
 	);
 
+	// 🚨 Pin留め操作時のスクロール位置維持
+	const handlePinToggle = useCallback(
+		(e: React.MouseEvent, noteId: string, currentPinned: boolean) => {
+			e.preventDefault();
+			e.stopPropagation();
+
+			const currentScrollTop = scrollRef.current?.scrollTop;
+
+			void updateNote({
+				id: noteId,
+				updates: { is_pinned: !currentPinned },
+			}).then(() => {
+				if (scrollRef.current && currentScrollTop !== undefined) {
+					requestAnimationFrame(() => {
+						if (scrollRef.current) {
+							scrollRef.current.scrollTop = currentScrollTop;
+						}
+					});
+				}
+			});
+		},
+		[updateNote],
+	);
+
 	const toggleSelect = useCallback((id: string, checked: boolean) => {
 		setSelectedIds((prev) => {
 			const next = new Set(prev);
@@ -189,7 +236,21 @@ export function MiddlePaneList(props: Props) {
 	const handleDragEnd = useCallback(
 		async (event: DragEndEvent) => {
 			const { active, over } = event;
-			if (!over || isSorting) return;
+			if (!over || isSorting || currentExact === "all") return;
+
+			const activeItem = localItems.find(
+				(item) => "id" in item && item.id === active.id,
+			) as Note | undefined;
+			const overItem = localItems.find(
+				(item) => "id" in item && item.id === over.id,
+			) as Note | undefined;
+
+			if (!activeItem || !overItem) return;
+
+			// 🚨 Pin留めノートと通常ノートの境界を跨ぐ移動を禁止（Pinソート順序の破綻防止）
+			if (Boolean(activeItem.is_pinned) !== Boolean(overItem.is_pinned)) {
+				return;
+			}
 
 			const oldIndex = localItems.findIndex(
 				(item) => "id" in item && item.id === active.id,
@@ -244,7 +305,7 @@ export function MiddlePaneList(props: Props) {
 			setIsSorting(true);
 			try {
 				await updateNote({
-					id: active.id as string,
+					id: String(active.id),
 					updates: { sort_order: newOrder },
 				});
 				router.refresh();
@@ -255,7 +316,7 @@ export function MiddlePaneList(props: Props) {
 				setIsSorting(false);
 			}
 		},
-		[localItems, isSorting, updateNote, router, items],
+		[localItems, isSorting, currentExact, updateNote, router, items],
 	);
 
 	const displayItems = localItems.filter((item): item is Note | Draft => {
@@ -311,7 +372,7 @@ export function MiddlePaneList(props: Props) {
 					onCancelSelection={handleCancelSelection}
 					onDeleteSelected={handleDeleteSelected}
 					isDeletingBulk={isDeletingBulk}
-					displayItems={displayItems}
+					displayItems={searchedDisplayItems}
 					onBack={handleBack}
 				/>
 			</div>
@@ -334,11 +395,14 @@ export function MiddlePaneList(props: Props) {
 				selectedIds={selectedIds}
 				onSelectChange={toggleSelect}
 				onTodoToggle={handleTodoToggle}
+				onPinToggle={handlePinToggle}
 				onDragEnd={handleDragEnd}
 				onDrilldown={handleDrilldown}
 				onUpdateParams={updateParams}
 				scrollRef={scrollRef}
 				isLoading={isLoading}
+				visibleCount={visibleCount}
+				onLoadMore={handleLoadMore}
 			/>
 		</div>
 	);

--- a/apps/app/src/app/(dashboard)/notes/_components/NoteItem.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/NoteItem.test.tsx
@@ -87,4 +87,90 @@ describe("NoteItem", () => {
 		expect(mockResolve).toHaveBeenCalledWith(expect.anything(), "123", true);
 		expect(mockResolve).toHaveBeenCalledTimes(1);
 	});
+
+	it("renders Pin button and triggers onPinToggle with event propagation stopped", () => {
+		const mockPinToggle = vi.fn();
+		const mockNote = {
+			id: "note-123",
+			content: "Test Note Content",
+			is_pinned: false,
+			is_resolved: false,
+			note_type: "info",
+			created_at: new Date().toISOString(),
+			scope: "domain",
+		} as Note;
+
+		render(
+			<NoteItem
+				item={mockNote}
+				onPinToggle={mockPinToggle}
+				currentExact={null}
+				selectedNoteId={null}
+				selectedDraftId={null}
+				searchParams={new URLSearchParams()}
+			/>,
+		);
+
+		const pinButton = screen.getByRole("button", { name: /pin note/i });
+		expect(pinButton).toBeInTheDocument();
+
+		fireEvent.click(pinButton);
+
+		expect(mockPinToggle).toHaveBeenCalledWith(
+			expect.anything(),
+			"note-123",
+			false,
+		);
+		expect(mockPinToggle).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders active style when note is pinned", () => {
+		const mockNote = {
+			id: "note-pinned",
+			content: "Pinned Note",
+			is_pinned: true,
+			is_resolved: false,
+			note_type: "info",
+			created_at: new Date().toISOString(),
+			scope: "domain",
+		} as Note;
+
+		render(
+			<NoteItem
+				item={mockNote}
+				currentExact={null}
+				selectedNoteId={null}
+				selectedDraftId={null}
+				searchParams={new URLSearchParams()}
+			/>,
+		);
+
+		const pinButton = screen.getByRole("button", { name: /unpin note/i });
+		expect(pinButton.className).toContain("text-action");
+	});
+
+	it("hides drag handle when isSortable is false (e.g. All Notes)", () => {
+		const mockNote = {
+			id: "note-123",
+			content: "Test Note Content",
+			is_pinned: false,
+			is_resolved: false,
+			note_type: "info",
+			created_at: new Date().toISOString(),
+			scope: "domain",
+		} as Note;
+
+		render(
+			<NoteItem
+				item={mockNote}
+				isSortable={false}
+				currentExact="all"
+				selectedNoteId={null}
+				selectedDraftId={null}
+				searchParams={new URLSearchParams()}
+			/>,
+		);
+
+		expect(screen.queryByLabelText("Drag to reorder")).not.toBeInTheDocument();
+	});
 });

--- a/apps/app/src/app/(dashboard)/notes/_components/NoteItem.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/NoteItem.tsx
@@ -4,7 +4,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { Diary } from "@sitecue/shared";
 import { getSafeUrl } from "@sitecue/shared";
-import { GripVertical, MapPin } from "lucide-react";
+import { GripVertical, MapPin, Pin } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
 import { CustomLink as Link } from "@/components/ui/custom-link";
 import { NoteStatusBadge } from "@/components/ui/note-status-badge";
@@ -33,6 +33,7 @@ interface NoteItemProps {
 	isSelected?: boolean;
 	onSelectChange?: (id: string, checked: boolean) => void;
 	onTodoToggle?: (e: React.MouseEvent, id: string, resolved: boolean) => void;
+	onPinToggle?: (e: React.MouseEvent, id: string, pinned: boolean) => void;
 }
 
 function NoteItemComponent({
@@ -47,6 +48,7 @@ function NoteItemComponent({
 	isSelected = false,
 	onSelectChange,
 	onTodoToggle,
+	onPinToggle,
 }: NoteItemProps) {
 	const [isExiting, setIsExiting] = useState(false);
 	const exitTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -114,6 +116,7 @@ function NoteItemComponent({
 
 	const isNote = "note_type" in item;
 	const isResolved = isNote && item.is_resolved;
+	const isPinned = isNote && !!item.is_pinned;
 	const isActive = isNote
 		? selectedNoteId === item.id
 		: selectedDraftId === item.id;
@@ -200,9 +203,34 @@ function NoteItemComponent({
 							{!item.title && !item.content ? "NEW" : "DRAFT"}
 						</span>
 					)}
-					<span className="text-[10px] text-gray-400 shrink-0">
-						{formatDate(isNote ? item.created_at : item.updated_at)}
-					</span>
+					<div className="flex items-center gap-1.5 shrink-0 pointer-events-auto">
+						<span className="text-[10px] text-gray-400">
+							{formatDate(isNote ? item.created_at : item.updated_at)}
+						</span>
+						{isNote && (
+							<button
+								type="button"
+								onClick={(e) => {
+									e.preventDefault();
+									e.stopPropagation();
+									onPinToggle?.(e, item.id, item.is_pinned ?? false);
+								}}
+								className={cn(
+									"p-1 rounded-full hover:bg-base-surface transition-colors cursor-pointer",
+									isPinned
+										? "text-action fill-current"
+										: "text-neutral-300 hover:text-action",
+								)}
+								title={isPinned ? "Unpin note" : "Pin note"}
+								aria-label={isPinned ? "Unpin note" : "Pin note"}
+							>
+								<Pin
+									aria-hidden="true"
+									className={cn("w-3.5 h-3.5", isPinned && "fill-current")}
+								/>
+							</button>
+						)}
+					</div>
 				</div>
 				<h3
 					className={cn(
@@ -214,7 +242,7 @@ function NoteItemComponent({
 				</h3>
 				<p
 					className={cn(
-						"text-sm text-action line-clamp-3 min-h-[3.75rem] break-words",
+						"text-sm text-action line-clamp-2 min-h-[2.5rem] md:line-clamp-3 md:min-h-[3.75rem] break-words",
 						(isResolved || isExiting) && "line-through",
 					)}
 				>
@@ -245,6 +273,7 @@ interface SortableNoteItemProps {
 	isSelected?: boolean;
 	onSelectChange?: (id: string, checked: boolean) => void;
 	onTodoToggle?: (e: React.MouseEvent, id: string, resolved: boolean) => void;
+	onPinToggle?: (e: React.MouseEvent, id: string, pinned: boolean) => void;
 }
 
 function SortableNoteItemComponent({
@@ -259,7 +288,10 @@ function SortableNoteItemComponent({
 	isSelected,
 	onSelectChange,
 	onTodoToggle,
+	onPinToggle,
 }: SortableNoteItemProps) {
+	const isSortDisabled =
+		currentView === "drafts" || currentExact === "all" || isSearchActive;
 	const {
 		setNodeRef,
 		transform,
@@ -269,6 +301,7 @@ function SortableNoteItemComponent({
 		listeners,
 	} = useSortable({
 		id: item.id,
+		disabled: isSortDisabled,
 	});
 
 	const style = {
@@ -286,12 +319,15 @@ function SortableNoteItemComponent({
 				selectedNoteId={selectedNoteId}
 				selectedDraftId={selectedDraftId}
 				searchParams={searchParams}
-				isSortable={currentView !== "drafts" && !isSearchActive}
+				isSortable={
+					currentView !== "drafts" && currentExact !== "all" && !isSearchActive
+				}
 				dragHandleProps={{ ...attributes, ...listeners }}
 				selectable={selectable}
 				isSelected={isSelected}
 				onSelectChange={onSelectChange}
 				onTodoToggle={onTodoToggle}
+				onPinToggle={onPinToggle}
 			/>
 		</div>
 	);

--- a/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.test.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.test.tsx
@@ -317,4 +317,55 @@ describe("NotesContainer - exact=all All Notes Integration", () => {
 			expect(middlePane).toHaveTextContent("3 items");
 		});
 	});
+
+	it("separates exact=all (created_at DESC) and exact=domain (is_pinned & sort_order)", async () => {
+		vi.mocked(useSearchParams).mockReturnValue(
+			new URLSearchParams(
+				"?view=domains&domain=example.com&exact=domain",
+			) as unknown as ReturnType<typeof useSearchParams>,
+		);
+
+		const notesData = [
+			{
+				id: "domain-note-1",
+				content: "Domain Note 1",
+				url_pattern: "example.com",
+				scope: "domain",
+				is_pinned: false,
+				sort_order: 2.0,
+				created_at: "2026-08-01T00:00:00.000Z",
+			},
+			{
+				id: "domain-note-2",
+				content: "Domain Note 2",
+				url_pattern: "example.com",
+				scope: "domain",
+				is_pinned: true,
+				sort_order: 5.0,
+				created_at: "2026-07-01T00:00:00.000Z",
+			},
+			{
+				id: "page-note-1",
+				content: "Page Note 1",
+				url_pattern: "example.com/page-1",
+				scope: "exact",
+				is_pinned: false,
+				sort_order: 1.0,
+				created_at: "2026-08-02T00:00:00.000Z",
+			},
+		];
+
+		vi.mocked(useFetchNotes).mockReturnValue({
+			data: notesData,
+			isLoading: false,
+		} as unknown as ReturnType<typeof useFetchNotes>);
+
+		render(<NotesContainer />);
+
+		await waitFor(() => {
+			const middlePane = screen.getByTestId("middle-pane");
+			// exact=domain の場合はドメイン直下の2件のみ抽出される
+			expect(middlePane).toHaveTextContent("2 items");
+		});
+	});
 });

--- a/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.tsx
+++ b/apps/app/src/app/(dashboard)/notes/_components/NotesContainer.tsx
@@ -130,6 +130,22 @@ export function NotesContainer() {
 					...domainData.domainNotes,
 					...Object.values(domainData.pages).flat(),
 				];
+				// All Notes は日付降順固定（D&DやPin移動による順序崩れを防止）
+				items.sort((a, b) => {
+					const noteA = a as Note;
+					const noteB = b as Note;
+					return (
+						new Date(noteB.created_at).getTime() -
+						new Date(noteA.created_at).getTime()
+					);
+				});
+			} else {
+				items = [];
+			}
+		} else if (deferredExact === "domain") {
+			const domainData = groupedNotes.domains[deferredDomain || ""];
+			if (domainData) {
+				items = [...domainData.domainNotes];
 				items.sort((a, b) => {
 					const noteA = a as Note;
 					const noteB = b as Note;
@@ -229,6 +245,7 @@ export function NotesContainer() {
 		if (!isTabReady || filteredItems.length === 0) return;
 
 		const missingIds = filteredItems
+			.slice(0, 50)
 			.filter(
 				(item): item is Note =>
 					"url_pattern" in item && item.content === undefined,


### PR DESCRIPTION
…ental rendering

Why:
- Domain-level views lacked clear separation between domain-only notes and sub-page notes.
- Pin state required opening detail views to toggle, while list-level toggling caused scroll position jumps.
- Mobile viewports had limited vertical scanability due to tall note preview clamps.
- Domain counts included resolved notes, bulk copy ignored active search filters, and new note creation reset active type filters.
- Large note datasets caused initial mount overhead and detail pane skeleton flickers upon note creation.

What:
- Separate "All Notes" (exact=all, date-sorted, D&D disabled) and "Domain Notes" (exact=domain, sortable) in domain navigation.
- Add inline Pin toggle on NoteItem cards with scroll retention and event bubbling prevention.
- Enforce D&D boundaries between pinned and unpinned notes to preserve sort integrity.
- Make note body preview responsive (line-clamp-2 on mobile, line-clamp-3 on desktop).
- Count only unresolved notes for domain and page badge indicators.
- Preserve filterType on context normalization when query parameters change for new note creation.
- Connect bulk copy (Text/JSON) directly to filtered searchedDisplayItems.
- Implement device-adaptive batch rendering (35 for desktop, 20 for mobile) with visible-only hydration.
- Optimistically populate full note cache on creation to eliminate detail pane skeletons.